### PR TITLE
将 `.workpad` 加入 `.gitignore` 并在 `AGENTS.md` 中添加工作笔记说明

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .worktrees/
 .mantic/
+.workpad/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ This file is for coding agents working in this repository.
 - `.worktrees/` must stay Git-ignored. The helper fails fast if the ignore rule is missing.
 - Each worktree should stay focused on one task so review and cleanup remain straightforward.
 
+## Working Notes
+
+- Unless the user explicitly asks otherwise, place temporary task documents (such as specs, plans, and research notes) under `.workpad/`.
+- `.workpad/` is git-ignored on purpose and should be used for task artifacts that should not be committed.
+
 ## Project Index Workflow
 
 - Update the index with `just agents-index`


### PR DESCRIPTION
### Motivation
- 避免临时任务产物（如 spec、plan、research 等）被误提交，并为 agents 提供默认的工作笔记存放位置。 

### Description
- 在 ` .gitignore` 中添加了 `.workpad/`，并在 `AGENTS.md` 增加了 `## Working Notes`，说明除非用户明确要求，否则将任务过程产生的临时文档放入被忽略的 `.workpad/` 目录。 

### Testing
- 运行了 `cargo fmt --check`，该检查通过；尝试运行 `just agents-index-check` 和 `cargo clippy` 时因无法访问 `crates.io`（HTTP 403）导致依赖解析失败，因而这两项检查未能完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c736aba9948323a69c0d208cd260e4)