### PR TITLE
Add selvedge-client HTTP package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ This file is for coding agents working in this repository.
 |.github/workflows:{ci.yml}
 |crates:{client/,config-model/,config/,logging/}
 |crates/client:{src/,tests/,Cargo.toml,README.md}
-|crates/client/src:{config_resolution.rs,lib.rs,redaction.rs,request_prep.rs,runtime.rs}
+|crates/client/src:{config_resolution.rs,lib.rs,redaction.rs,redirect_runtime.rs,request_prep.rs,runtime.rs,single_hop.rs}
 |crates/client/tests:{support/,http_integration.rs}
 |crates/client/tests/support:{mod.rs}
 |crates/config:{examples/,src/,tests/,Cargo.toml,README.md}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,11 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{config-model/,config/,logging/}
+|crates:{client/,config-model/,config/,logging/}
+|crates/client:{src/,tests/,Cargo.toml,README.md}
+|crates/client/src:{lib.rs}
+|crates/client/tests:{support/,http_integration.rs}
+|crates/client/tests/support:{mod.rs}
 |crates/config:{examples/,src/,tests/,Cargo.toml,README.md}
 |crates/config-model:{src/,tests/,Cargo.toml,README.md}
 |crates/config-model/src:{lib.rs}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ This file is for coding agents working in this repository.
 |.github/workflows:{ci.yml}
 |crates:{client/,config-model/,config/,logging/}
 |crates/client:{src/,tests/,Cargo.toml,README.md}
-|crates/client/src:{lib.rs}
+|crates/client/src:{config_resolution.rs,lib.rs,redaction.rs,request_prep.rs,runtime.rs}
 |crates/client/tests:{support/,http_integration.rs}
 |crates/client/tests/support:{mod.rs}
 |crates/config:{examples/,src/,tests/,Cargo.toml,README.md}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,254 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "equivalent"
@@ -33,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -43,10 +281,146 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "getrandom"
@@ -56,7 +430,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -83,10 +457,219 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -101,10 +684,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -125,10 +752,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -137,10 +782,138 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -162,6 +935,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,9 +1000,128 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -186,8 +1133,67 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "selvedge"
@@ -197,6 +1203,29 @@ dependencies = [
  "selvedge-config-model",
  "selvedge-logging",
  "tempfile",
+]
+
+[[package]]
+name = "selvedge-client"
+version = "0.0.0"
+dependencies = [
+ "async-stream",
+ "axum",
+ "bytes",
+ "futures",
+ "http",
+ "rcgen",
+ "reqwest",
+ "rustls-pemfile",
+ "selvedge-config",
+ "selvedge-logging",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "zstd",
 ]
 
 [[package]]
@@ -278,6 +1307,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +1325,58 @@ checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -298,16 +1390,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -328,6 +1440,111 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -372,6 +1589,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +1671,45 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -399,6 +1727,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -424,6 +1807,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,10 +1832,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -449,6 +1892,135 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -548,6 +2120,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "xtask"
 version = "0.0.0"
 dependencies = [
@@ -555,7 +2151,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,6 @@ dependencies = [
  "serde",
  "thiserror",
  "toml",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,9 +1243,11 @@ dependencies = [
 name = "selvedge-config-model"
 version = "0.0.0"
 dependencies = [
+ "http",
  "serde",
  "thiserror",
  "toml",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = ["crates/config", "crates/config-model", "crates/logging", "xtask"]
+members = [
+    "crates/client",
+    "crates/config",
+    "crates/config-model",
+    "crates/logging",
+    "xtask",
+]
 resolver = "2"
 
 [package]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "selvedge-client"
+edition = "2024"
+publish = false
+
+[dependencies]
+async-stream = "0.3.6"
+bytes = "1.10.1"
+futures = "0.3.31"
+http = "1.3.1"
+reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls", "stream"] }
+rustls-pemfile = "2.2.0"
+selvedge-config = { path = "../config" }
+selvedge-logging = { path = "../logging" }
+serde_json = "1.0.145"
+thiserror = "2.0.17"
+tokio = { version = "1.48.0", features = ["time"] }
+url = "2.5.7"
+zstd = "0.13.3"
+
+[dev-dependencies]
+axum = "0.8.6"
+rcgen = "0.14.5"
+tempfile = "3.23.0"
+tokio = { version = "1.48.0", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-rustls = "0.26.4"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -57,7 +57,9 @@ assert!(response.status.is_success());
 - every call reads `network.*` config immediately through `selvedge_config::read`
 - `request.timeout` overrides `network.request_timeout_ms` only for that call
 - `network.request_timeout_ms` is optional; when it is unset and no per-call timeout is supplied, this crate does not install a request timeout and leaves timeout behavior to the underlying HTTP client
+- when `request.timeout` or `network.request_timeout_ms` is set, the timeout budget applies to transport wait phases such as sending the request, waiting for response headers, and waiting for response body chunks; it does not count caller-side processing time between stream polls
 - `network.connect_timeout_ms` and `network.stream_idle_timeout_ms` follow the same rule: unset means this crate does not synthesize a fallback value
+- `network.stream_idle_timeout_ms` applies per wait window while the stream is waiting for the next body bytes; it is reset only when non-empty bytes arrive
 
 ## Response semantics
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -60,7 +60,9 @@ assert!(response.status.is_success());
 - `network.request_timeout_ms` is optional; when it is unset and no per-call timeout is supplied, this crate does not install a request timeout and leaves timeout behavior to the underlying HTTP client
 - when `request.timeout` or `network.request_timeout_ms` is set, the timeout budget applies to transport wait phases such as sending the request, waiting for response headers, and waiting for response body chunks; it does not count caller-side processing time between stream polls
 - `network.connect_timeout_ms` and `network.stream_idle_timeout_ms` follow the same rule: unset means this crate does not synthesize a fallback value
-- `network.stream_idle_timeout_ms` applies per wait window while the stream is waiting for the next body bytes; it is reset only when non-empty bytes arrive
+- `network.stream_idle_timeout_ms` applies only to the successful body stream returned by `stream(...)` after a `2xx` response head has been received
+- `network.stream_idle_timeout_ms` does not apply to `execute(...)` body buffering and does not apply while `stream(...)` buffers a non-`2xx` response body before returning `HttpError::Status`
+- for the successful `stream(...)` body stream, the idle timeout applies per wait window while waiting for the next body bytes and is reset only when non-empty bytes arrive
 
 ## Response semantics
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -1,0 +1,65 @@
+# client
+
+## This crate is for
+
+This crate is the project HTTP client entrypoint.
+
+Use it to:
+
+- execute one-shot HTTP requests through `execute(...)`
+- execute streaming HTTP requests through `stream(...)`
+- read `network.*` config fresh for every call
+- emit structured transport logs through `selvedge_logging`
+
+## This crate is not for
+
+This crate is not for:
+
+- exposing a reusable client object
+- caching config, transport builders, or per-request derived state
+- retrying requests implicitly
+- parsing response bodies into JSON, SSE, or auth-specific models
+
+## Call model
+
+Callers build an `HttpRequest` value and pass it to one of two functions:
+
+- `execute(...)` for full-body responses
+- `stream(...)` for raw byte streams
+
+```no_run
+use http::HeaderMap;
+use selvedge_client::{
+    HttpMethod, HttpRequest, HttpRequestBody, RequestCompression, execute,
+};
+
+# #[tokio::main(flavor = "current_thread")]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+let response = execute(HttpRequest {
+    method: HttpMethod::Post,
+    url: "https://example.com/endpoint".to_owned(),
+    headers: HeaderMap::new(),
+    body: HttpRequestBody::Json(serde_json::json!({ "x": 1 })),
+    timeout: None,
+    compression: RequestCompression::None,
+})
+.await?;
+
+assert!(response.status.is_success());
+# Ok(())
+# }
+```
+
+## Runtime and config
+
+- callers must initialize `selvedge_config` before using this crate
+- callers must run these async functions inside a Tokio runtime
+- every call reads `network.*` config immediately through `selvedge_config::read`
+- `request.timeout` overrides `network.request_timeout_ms` only for that call
+
+## Response semantics
+
+- `execute(...)` returns a full `HttpResponse` only for `2xx`
+- `stream(...)` returns a raw `ByteStream` only for `2xx`
+- non-`2xx` responses are returned as `HttpError::Status`
+- response bodies stay raw; this crate does not auto-decompress or parse them

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -67,7 +67,7 @@ assert!(response.status.is_success());
 ## Response semantics
 
 - `GET` requests follow standard redirect statuses inside this crate, with a fixed hop limit
-- redirect hops are rebuilt inside the crate; cross-origin hops drop origin-bound request headers such as `Authorization` and `Cookie`
+- redirect hops are rebuilt inside the crate; cross-origin hops keep only a small safe request-header allowlist and do not forward other caller-supplied headers
 - `execute(...)` returns a full `HttpResponse` only for `2xx`
 - `stream(...)` returns a raw `ByteStream` only for `2xx`
 - non-`2xx` responses are returned as `HttpError::Status`

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -63,6 +63,8 @@ assert!(response.status.is_success());
 
 ## Response semantics
 
+- `GET` requests follow standard redirect statuses inside this crate, with a fixed hop limit
+- redirect hops are rebuilt inside the crate; cross-origin hops drop origin-bound request headers such as `Authorization` and `Cookie`
 - `execute(...)` returns a full `HttpResponse` only for `2xx`
 - `stream(...)` returns a raw `ByteStream` only for `2xx`
 - non-`2xx` responses are returned as `HttpError::Status`

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -55,6 +55,7 @@ assert!(response.status.is_success());
 - callers must initialize `selvedge_config` before using this crate
 - callers must run these async functions inside a Tokio runtime
 - every call reads `network.*` config immediately through `selvedge_config::read`
+- this crate does not support outbound proxies and intentionally ignores environment proxy settings such as `HTTP_PROXY` and `HTTPS_PROXY`
 - `request.timeout` overrides `network.request_timeout_ms` only for that call
 - `network.request_timeout_ms` is optional; when it is unset and no per-call timeout is supplied, this crate does not install a request timeout and leaves timeout behavior to the underlying HTTP client
 - when `request.timeout` or `network.request_timeout_ms` is set, the timeout budget applies to transport wait phases such as sending the request, waiting for response headers, and waiting for response body chunks; it does not count caller-side processing time between stream polls

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -56,6 +56,8 @@ assert!(response.status.is_success());
 - callers must run these async functions inside a Tokio runtime
 - every call reads `network.*` config immediately through `selvedge_config::read`
 - `request.timeout` overrides `network.request_timeout_ms` only for that call
+- `network.request_timeout_ms` is optional; when it is unset and no per-call timeout is supplied, this crate does not install a request timeout and leaves timeout behavior to the underlying HTTP client
+- `network.connect_timeout_ms` and `network.stream_idle_timeout_ms` follow the same rule: unset means this crate does not synthesize a fallback value
 
 ## Response semantics
 

--- a/crates/client/src/config_resolution.rs
+++ b/crates/client/src/config_resolution.rs
@@ -1,0 +1,61 @@
+use std::{path::PathBuf, time::Duration};
+
+use crate::{HttpError, build_error, duration_millis_or_zero};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedCallConfig {
+    pub(crate) connect_timeout: Option<Duration>,
+    pub(crate) request_timeout: Option<Duration>,
+    pub(crate) stream_idle_timeout: Option<Duration>,
+    pub(crate) ca_bundle_path: Option<PathBuf>,
+    pub(crate) user_agent: Option<String>,
+}
+
+pub(crate) fn resolve_call_config(
+    timeout_override: Option<Duration>,
+) -> Result<ResolvedCallConfig, HttpError> {
+    if timeout_override.is_some_and(|timeout| timeout.is_zero()) {
+        return Err(build_error("request.timeout must be greater than zero"));
+    }
+
+    let (
+        connect_timeout_ms,
+        request_timeout_ms,
+        stream_idle_timeout_ms,
+        ca_bundle_path,
+        user_agent,
+    ) = selvedge_config::read(|config| {
+        (
+            config.network.connect_timeout_ms,
+            config.network.request_timeout_ms,
+            config.network.stream_idle_timeout_ms,
+            config.network.ca_bundle_path.clone(),
+            config.network.user_agent.clone(),
+        )
+    })?;
+
+    let ca_bundle_path = match ca_bundle_path {
+        Some(path) if path.is_relative() => Some(selvedge_config::selvedge_home()?.join(path)),
+        other => other,
+    };
+
+    let config = ResolvedCallConfig {
+        connect_timeout: connect_timeout_ms.map(Duration::from_millis),
+        request_timeout: timeout_override.or_else(|| request_timeout_ms.map(Duration::from_millis)),
+        stream_idle_timeout: stream_idle_timeout_ms.map(Duration::from_millis),
+        ca_bundle_path,
+        user_agent,
+    };
+
+    crate::log_event!(
+        selvedge_logging::LogLevel::Debug,
+        "http config resolved";
+        connect_timeout_ms = duration_millis_or_zero(config.connect_timeout),
+        request_timeout_ms = duration_millis_or_zero(config.request_timeout),
+        stream_idle_timeout_ms = duration_millis_or_zero(config.stream_idle_timeout),
+        has_ca_bundle = config.ca_bundle_path.is_some(),
+        has_user_agent = config.user_agent.is_some()
+    );
+
+    Ok(config)
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -722,7 +722,7 @@ fn compress_bytes_with_deadline(
 
 fn sanitize_url_for_output(raw_url: &str) -> String {
     let Ok(mut parsed) = Url::parse(raw_url) else {
-        return raw_url.to_owned();
+        return "<invalid-url>".to_owned();
     };
 
     if !parsed.username().is_empty() {
@@ -802,7 +802,13 @@ fn wrap_stream(
 }
 
 fn map_transport_error(error: reqwest::Error, request_url: &str) -> HttpError {
-    let reason = format!("{request_url}: {}", render_error_chain(&error));
+    let mut rendered = render_error_chain(&error);
+
+    if let Some(url) = error.url() {
+        rendered = rendered.replace(url.as_str(), &sanitize_url_for_output(url.as_str()));
+    }
+
+    let reason = format!("{request_url}: {rendered}");
 
     if error.is_timeout() {
         HttpError::Timeout
@@ -1307,5 +1313,12 @@ mod tests {
         );
 
         assert_eq!(sanitized, "https://example.com/path");
+    }
+
+    #[test]
+    fn sanitized_invalid_url_does_not_echo_raw_input() {
+        let sanitized = sanitize_url_for_output("://user:pass@example.com/?token=secret");
+
+        assert_eq!(sanitized, "<invalid-url>");
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -644,7 +644,13 @@ async fn build_client(
     }
 
     if let Some(path) = &call_config.ca_bundle_path {
-        let bundle = tokio_fs::read(path).await.map_err(|error| {
+        let bundle = match request_deadline {
+            Some(deadline) => timeout_at(deadline, tokio_fs::read(path))
+                .await
+                .map_err(|_| HttpError::Timeout)?,
+            None => tokio_fs::read(path).await,
+        }
+        .map_err(|error| {
             build_error(format!(
                 "failed to read network.ca_bundle_path {}: {error}",
                 path.display()

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -7,7 +7,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
     HeaderMap, HeaderValue, StatusCode,
-    header::{CONTENT_ENCODING, CONTENT_TYPE, USER_AGENT},
+    header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
 use tokio::time::{Instant, timeout_at};
@@ -266,7 +266,7 @@ async fn execute_inner(
     .await?;
 
     if !response.status().is_success() {
-        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await);
+        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await?);
     }
 
     let status = response.status();
@@ -295,7 +295,7 @@ async fn stream_inner(
     .await?;
 
     if !response.status().is_success() {
-        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await);
+        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await?);
     }
 
     let status = response.status();
@@ -344,7 +344,7 @@ async fn collect_status_error(
     response: reqwest::Response,
     deadline: Option<Instant>,
     request_url: &str,
-) -> HttpError {
+) -> Result<HttpError, HttpError> {
     let url = response.url().to_string();
     let status = response.status();
     let headers = response.headers().clone();
@@ -362,7 +362,7 @@ async fn collect_status_error(
                         url = url.as_str(),
                         status = status.as_u16()
                     );
-                    break;
+                    return Err(HttpError::Timeout);
                 }
             },
             None => stream.next().await,
@@ -385,12 +385,12 @@ async fn collect_status_error(
         }
     }
 
-    HttpError::Status(HttpStatusError {
+    Ok(HttpError::Status(HttpStatusError {
         url,
         status,
         headers,
         body: body.freeze(),
-    })
+    }))
 }
 
 async fn collect_success_body(
@@ -485,6 +485,7 @@ fn prepare_request(
     body = maybe_compress_body(body, request.compression, &mut headers)?;
 
     let body_len = body.len();
+    reconcile_content_length(&body, &mut headers)?;
     let mut reqwest_request = reqwest::Request::new(request.method.clone().into(), url);
     *reqwest_request.headers_mut() = headers;
 
@@ -498,6 +499,17 @@ fn prepare_request(
         request_url: request.url,
         body_len,
     })
+}
+
+fn reconcile_content_length(body: &PreparedBody, headers: &mut HeaderMap) -> Result<(), HttpError> {
+    if headers.contains_key(CONTENT_LENGTH) {
+        let content_length = HeaderValue::from_str(&body.len().to_string()).map_err(|error| {
+            build_error(format!("invalid computed Content-Length header: {error}"))
+        })?;
+        headers.insert(CONTENT_LENGTH, content_length);
+    }
+
+    Ok(())
 }
 
 fn parse_absolute_http_url(url: &str) -> Result<Url, HttpError> {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -664,35 +664,24 @@ async fn build_client(
         builder = builder.no_proxy();
     }
 
-    if should_load_ca_bundle(call_config, uses_tls, method)
-        && let Some(path) = &call_config.ca_bundle_path
-    {
-        let bundle = match request_deadline {
-            Some(deadline) => timeout_at(deadline, tokio_fs::read(path))
-                .await
-                .map_err(|_| HttpError::Timeout)?,
-            None => tokio_fs::read(path).await,
-        }
-        .map_err(|error| {
-            build_error(format!(
-                "failed to read network.ca_bundle_path {}: {error}",
-                path.display()
-            ))
-        })?;
-        check_request_deadline(request_deadline)?;
-        let path = path.clone();
-        let certificates = run_blocking(move || {
-            parse_certificates(&bundle).map_err(|error| {
-                build_error(format!(
-                    "failed to parse network.ca_bundle_path {}: {error}",
-                    path.display()
-                ))
-            })
-        })
-        .await?;
+    if let Some(path) = &call_config.ca_bundle_path {
+        let tls_proxy = call_config
+            .proxy_url
+            .as_deref()
+            .and_then(|proxy_url| Url::parse(proxy_url).ok())
+            .is_some_and(|proxy_url| proxy_url.scheme() == "https");
+        let ca_load_is_optional = !uses_tls && !tls_proxy && matches!(method, HttpMethod::Get);
 
-        for certificate in certificates {
-            builder = builder.add_root_certificate(certificate);
+        let certificates = match load_ca_bundle(path, request_deadline).await {
+            Ok(certificates) => Some(certificates),
+            Err(_) if ca_load_is_optional => None,
+            Err(error) => return Err(error),
+        };
+
+        if let Some(certificates) = certificates {
+            for certificate in certificates {
+                builder = builder.add_root_certificate(certificate);
+            }
         }
     }
 
@@ -701,20 +690,34 @@ async fn build_client(
         .map_err(|error| build_error(format!("failed to build http client: {error}")))
 }
 
-fn should_load_ca_bundle(
-    call_config: &ResolvedCallConfig,
-    uses_tls: bool,
-    method: &HttpMethod,
-) -> bool {
-    if uses_tls || matches!(method, HttpMethod::Get) {
-        return true;
+async fn load_ca_bundle(
+    path: &std::path::Path,
+    request_deadline: Option<Instant>,
+) -> Result<Vec<Certificate>, HttpError> {
+    let bundle = match request_deadline {
+        Some(deadline) => timeout_at(deadline, tokio_fs::read(path))
+            .await
+            .map_err(|_| HttpError::Timeout)?,
+        None => tokio_fs::read(path).await,
     }
+    .map_err(|error| {
+        build_error(format!(
+            "failed to read network.ca_bundle_path {}: {error}",
+            path.display()
+        ))
+    })?;
+    check_request_deadline(request_deadline)?;
+    let path = path.to_path_buf();
 
-    call_config
-        .proxy_url
-        .as_deref()
-        .and_then(|proxy_url| Url::parse(proxy_url).ok())
-        .is_some_and(|proxy_url| proxy_url.scheme() == "https")
+    run_blocking(move || {
+        parse_certificates(&bundle).map_err(|error| {
+            build_error(format!(
+                "failed to parse network.ca_bundle_path {}: {error}",
+                path.display()
+            ))
+        })
+    })
+    .await
 }
 
 fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -120,11 +120,11 @@ enum PreparedBody {
 #[derive(Debug, Clone, Copy)]
 enum StreamTimeoutState {
     AwaitingFirstByte {
-        request_timeout_remaining: Option<Duration>,
+        request_deadline: Option<Instant>,
         idle_timeout: Option<Duration>,
     },
     Streaming {
-        request_timeout_remaining: Option<Duration>,
+        request_deadline: Option<Instant>,
         idle_timeout: Option<Duration>,
     },
 }
@@ -293,7 +293,7 @@ async fn execute_inner(
 async fn stream_inner(
     call_config: &ResolvedCallConfig,
     prepared: PreparedRequest,
-    request_timeout: Option<Duration>,
+    _request_timeout: Option<Duration>,
     request_deadline: Option<Instant>,
     idle_timeout: Option<Duration>,
 ) -> Result<HttpStreamResponse, HttpError> {
@@ -308,7 +308,7 @@ async fn stream_inner(
     let headers = response.headers().clone();
     let body = wrap_stream(
         request_url,
-        request_timeout.and_then(|_| remaining_duration_until(request_deadline)),
+        request_deadline,
         idle_timeout,
         response.bytes_stream(),
     );
@@ -506,6 +506,11 @@ fn resolve_call_config(
             config.network.user_agent.clone(),
         )
     })?;
+
+    let ca_bundle_path = match ca_bundle_path {
+        Some(path) if path.is_relative() => Some(selvedge_config::selvedge_home()?.join(path)),
+        other => other,
+    };
 
     let config = ResolvedCallConfig {
         connect_timeout: connect_timeout_ms.map(Duration::from_millis),
@@ -830,19 +835,18 @@ fn sanitize_url_for_output(raw_url: &str) -> String {
 
 fn wrap_stream(
     request_url: String,
-    request_timeout: Option<Duration>,
+    request_deadline: Option<Instant>,
     idle_timeout: Option<Duration>,
     stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 ) -> ByteStream {
     let stream = async_stream::stream! {
         let mut stream = Box::pin(stream);
         let mut timeout_state = StreamTimeoutState::AwaitingFirstByte {
-            request_timeout_remaining: request_timeout,
+            request_deadline,
             idle_timeout,
         };
 
         loop {
-            let wait_started_at = Instant::now();
             let next_item = match timeout_state.deadline() {
                 Some(deadline) => match timeout_at(deadline, stream.next()).await {
                     Ok(item) => item,
@@ -859,8 +863,6 @@ fn wrap_stream(
                 },
                 None => stream.next().await,
             };
-            let waited = wait_started_at.elapsed();
-            timeout_state = timeout_state.after_wait(waited);
 
             match next_item {
                 Some(Ok(bytes)) => {
@@ -968,14 +970,6 @@ fn duration_millis_or_zero(duration: Option<Duration>) -> u64 {
 
 fn relative_deadline(timeout: Option<Duration>) -> Option<Instant> {
     timeout.map(|timeout| Instant::now() + timeout)
-}
-
-fn remaining_duration_until(deadline: Option<Instant>) -> Option<Duration> {
-    deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()))
-}
-
-fn subtract_duration(duration: Option<Duration>, waited: Duration) -> Option<Duration> {
-    duration.map(|duration| duration.saturating_sub(waited))
 }
 
 fn min_deadline(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
@@ -1139,34 +1133,31 @@ impl StreamTimeoutState {
     fn deadline(self) -> Option<Instant> {
         match self {
             Self::AwaitingFirstByte {
-                request_timeout_remaining,
+                request_deadline,
                 idle_timeout,
-            } => min_deadline(
-                relative_deadline(request_timeout_remaining),
-                relative_deadline(idle_timeout),
-            ),
-            Self::Streaming {
-                request_timeout_remaining,
+            }
+            | Self::Streaming {
+                request_deadline,
                 idle_timeout,
-            } => min_deadline(
-                relative_deadline(request_timeout_remaining),
-                relative_deadline(idle_timeout),
-            ),
+            } => min_deadline(request_deadline, relative_deadline(idle_timeout)),
         }
     }
 
     fn timeout_message(self) -> &'static str {
         match self {
             Self::AwaitingFirstByte {
-                request_timeout_remaining,
+                request_deadline,
                 idle_timeout,
             }
             | Self::Streaming {
-                request_timeout_remaining,
+                request_deadline,
                 idle_timeout,
-            } => match (request_timeout_remaining, idle_timeout) {
-                (Some(request_timeout), Some(idle_timeout)) => {
-                    if idle_timeout <= request_timeout {
+            } => match (request_deadline, idle_timeout) {
+                (Some(request_deadline), Some(idle_timeout)) => {
+                    let request_remaining =
+                        request_deadline.saturating_duration_since(Instant::now());
+
+                    if idle_timeout <= request_remaining {
                         "http stream idle timeout"
                     } else {
                         "http stream request timeout"
@@ -1179,48 +1170,29 @@ impl StreamTimeoutState {
         }
     }
 
-    fn after_wait(self, waited: Duration) -> Self {
-        match self {
-            Self::AwaitingFirstByte {
-                request_timeout_remaining,
-                idle_timeout,
-            } => Self::AwaitingFirstByte {
-                request_timeout_remaining: subtract_duration(request_timeout_remaining, waited),
-                idle_timeout,
-            },
-            Self::Streaming {
-                request_timeout_remaining,
-                idle_timeout,
-            } => Self::Streaming {
-                request_timeout_remaining: subtract_duration(request_timeout_remaining, waited),
-                idle_timeout,
-            },
-        }
-    }
-
     fn on_chunk(self, chunk: &Bytes) -> Self {
         match self {
             Self::AwaitingFirstByte {
-                request_timeout_remaining,
+                request_deadline,
                 idle_timeout,
             } => {
                 if chunk.is_empty() {
                     Self::AwaitingFirstByte {
-                        request_timeout_remaining,
+                        request_deadline,
                         idle_timeout,
                     }
                 } else {
                     Self::Streaming {
-                        request_timeout_remaining,
+                        request_deadline,
                         idle_timeout,
                     }
                 }
             }
             Self::Streaming {
-                request_timeout_remaining,
+                request_deadline,
                 idle_timeout,
             } => Self::Streaming {
-                request_timeout_remaining,
+                request_deadline,
                 idle_timeout,
             },
         }
@@ -1230,7 +1202,7 @@ impl StreamTimeoutState {
 #[cfg(test)]
 mod tests {
     use super::{
-        HeaderMap, HeaderValue, HttpMethod, HttpRequest, HttpRequestBody, PreparedBody,
+        HeaderMap, HeaderValue, HttpError, HttpMethod, HttpRequest, HttpRequestBody, PreparedBody,
         RequestCompression, ResolvedCallConfig, build_client, build_error, encode_body,
         maybe_compress_body, parse_absolute_http_url, prepare_request, sanitize_url_for_output,
         wrap_stream,
@@ -1239,7 +1211,7 @@ mod tests {
 
     use bytes::Bytes;
     use futures::{StreamExt, stream};
-    use tokio::time::sleep;
+    use tokio::time::{Instant, sleep};
 
     #[test]
     fn absolute_http_url_is_required() {
@@ -1372,7 +1344,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn first_chunk_timeout_starts_on_first_poll() {
+    async fn first_chunk_timeout_uses_absolute_deadline() {
         let inner = stream::unfold(0_u8, |state| async move {
             match state {
                 0 => {
@@ -1385,7 +1357,7 @@ mod tests {
 
         let mut wrapped = wrap_stream(
             "http://example.test/stream".to_owned(),
-            Some(Duration::from_millis(50)),
+            Some(Instant::now() + Duration::from_millis(50)),
             None,
             inner,
         );
@@ -1393,7 +1365,7 @@ mod tests {
         sleep(Duration::from_millis(120)).await;
 
         let first = wrapped.next().await.expect("first item");
-        assert_eq!(first.expect("first chunk"), Bytes::from_static(b"first"));
+        assert!(matches!(first, Err(HttpError::Timeout)));
     }
 
     #[test]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -338,11 +338,11 @@ async fn send_with_redirects(
 ) -> Result<reqwest::Response, HttpError> {
     let mut request = prepared.request;
     let method = prepared.method;
-    let request_url = prepared.request_url;
     let mut redirect_count = 0_usize;
 
     loop {
         check_request_deadline(request_deadline)?;
+        let current_request_url = sanitize_url_for_output(request.url().as_str());
         let client = build_client(
             call_config,
             request_deadline,
@@ -358,7 +358,8 @@ async fn send_with_redirects(
         } else {
             None
         };
-        let response = send_with_deadline(client, request, &request_url, request_deadline).await?;
+        let response =
+            send_with_deadline(client, request, &current_request_url, request_deadline).await?;
 
         if matches!(method, HttpMethod::Get) && response.status().is_redirection() {
             if redirect_count >= 10 {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -476,4 +476,19 @@ mod tests {
         assert!(!sanitized.contains("user:pass"));
         assert!(!sanitized.contains("token=secret"));
     }
+
+    #[test]
+    fn sanitize_error_text_scrubs_earliest_https_url_before_later_http_url() {
+        let raw = concat!(
+            "tls failed for https://user:pass@example.com/path?token=secret ",
+            "before redirecting to http://other.example.test/path?x=1"
+        );
+        let sanitized = sanitize_error_text(raw, &[]);
+
+        assert!(sanitized.contains("https://example.com/path"));
+        assert!(sanitized.contains("http://other.example.test/path"));
+        assert!(!sanitized.contains("user:pass"));
+        assert!(!sanitized.contains("token=secret"));
+        assert!(!sanitized.contains("?x=1"));
+    }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -3,8 +3,10 @@
 
 mod config_resolution;
 mod redaction;
+mod redirect_runtime;
 mod request_prep;
 mod runtime;
+mod single_hop;
 
 use std::{error::Error as StdError, fmt, pin::Pin, time::Duration};
 
@@ -16,8 +18,9 @@ use tokio::task;
 use crate::{
     config_resolution::resolve_call_config,
     redaction::sanitize_url,
+    redirect_runtime::{execute_inner, stream_inner},
     request_prep::prepare_request,
-    runtime::{RequestBudget, execute_inner, log_result, log_stream_result, stream_inner},
+    runtime::{RequestBudget, log_result, log_stream_result},
 };
 
 macro_rules! log_event {
@@ -163,7 +166,7 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
     );
 
     let call_config = resolve_call_config(request.timeout)?;
-    let prepared = prepare_request(request, &call_config).await?;
+    let prepared = prepare_request(request.clone(), &call_config).await?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -179,6 +182,7 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
     let body_len = prepared.body_len;
     let result = execute_inner(
         &call_config,
+        request,
         prepared,
         RequestBudget::new(call_config.request_timeout),
     )
@@ -200,7 +204,7 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     );
 
     let call_config = resolve_call_config(request.timeout)?;
-    let prepared = prepare_request(request, &call_config).await?;
+    let prepared = prepare_request(request.clone(), &call_config).await?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -216,6 +220,7 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     let body_len = prepared.body_len;
     let result = stream_inner(
         &call_config,
+        request,
         prepared,
         RequestBudget::new(call_config.request_timeout),
         call_config.stream_idle_timeout,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::result_large_err)]
 
-use std::{error::Error as StdError, fmt, fs, path::PathBuf, pin::Pin, time::Duration};
+use std::{error::Error as StdError, fmt, io::Write, path::PathBuf, pin::Pin, time::Duration};
 
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
@@ -10,8 +10,8 @@ use http::{
     header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
-use tokio::task;
 use tokio::time::{Instant, timeout_at};
+use tokio::{fs as tokio_fs, task};
 use url::form_urlencoded;
 
 macro_rules! log_event {
@@ -184,12 +184,13 @@ impl From<selvedge_config::ConfigError> for HttpError {
 }
 
 pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
+    let sanitized_request_url = sanitize_url_for_output(&request.url);
     log_event!(
         selvedge_logging::LogLevel::Debug,
         "http request started";
         mode = "execute",
         method = request.method.as_str(),
-        url = request.url.as_str()
+        url = sanitized_request_url.as_str()
     );
 
     let call_config = resolve_call_config(request.timeout)?;
@@ -220,12 +221,13 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
 }
 
 pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpError> {
+    let sanitized_request_url = sanitize_url_for_output(&request.url);
     log_event!(
         selvedge_logging::LogLevel::Debug,
         "http request started";
         mode = "stream",
         method = request.method.as_str(),
-        url = request.url.as_str()
+        url = sanitized_request_url.as_str()
     );
 
     let call_config = resolve_call_config(request.timeout)?;
@@ -358,7 +360,7 @@ async fn collect_status_error(
     deadline: Option<Instant>,
     request_url: &str,
 ) -> Result<HttpError, HttpError> {
-    let url = response.url().to_string();
+    let url = sanitize_url_for_output(response.url().as_str());
     let status = response.status();
     let headers = response.headers().clone();
     let mut body = BytesMut::new();
@@ -510,7 +512,7 @@ async fn prepare_request(
     Ok(PreparedRequest {
         request: reqwest_request,
         method: request.method,
-        request_url: request.url,
+        request_url: sanitize_url_for_output(&request.url),
         body_len,
     })
 }
@@ -611,12 +613,8 @@ async fn maybe_compress_body(
                 ));
             }
 
-            let compressed = run_blocking_with_deadline(request_deadline, move || {
-                zstd::stream::encode_all(bytes.as_ref(), 0)
-                    .map(Bytes::from)
-                    .map_err(|error| build_error(format!("failed to encode zstd body: {error}")))
-            })
-            .await?;
+            let compressed =
+                run_blocking(move || compress_bytes_with_deadline(bytes, request_deadline)).await?;
             headers.insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
 
             Ok(PreparedBody::Buffered {
@@ -646,14 +644,15 @@ async fn build_client(
     }
 
     if let Some(path) = &call_config.ca_bundle_path {
+        let bundle = tokio_fs::read(path).await.map_err(|error| {
+            build_error(format!(
+                "failed to read network.ca_bundle_path {}: {error}",
+                path.display()
+            ))
+        })?;
+        check_request_deadline(request_deadline)?;
         let path = path.clone();
-        let certificates = run_blocking_with_deadline(request_deadline, move || {
-            let bundle = fs::read(&path).map_err(|error| {
-                build_error(format!(
-                    "failed to read network.ca_bundle_path {}: {error}",
-                    path.display()
-                ))
-            })?;
+        let certificates = run_blocking(move || {
             parse_certificates(&bundle).map_err(|error| {
                 build_error(format!(
                     "failed to parse network.ca_bundle_path {}: {error}",
@@ -690,6 +689,45 @@ fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
     }
 
     Ok(certificates)
+}
+
+fn compress_bytes_with_deadline(
+    bytes: Bytes,
+    deadline: Option<Instant>,
+) -> Result<Bytes, HttpError> {
+    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0)
+        .map_err(|error| build_error(format!("failed to start zstd encoder: {error}")))?;
+
+    for chunk in bytes.chunks(64 * 1024) {
+        check_request_deadline(deadline)?;
+        encoder
+            .write_all(chunk)
+            .map_err(|error| build_error(format!("failed to encode zstd body: {error}")))?;
+    }
+
+    check_request_deadline(deadline)?;
+
+    let compressed = encoder
+        .finish()
+        .map_err(|error| build_error(format!("failed to finish zstd body: {error}")))?;
+
+    Ok(Bytes::from(compressed))
+}
+
+fn sanitize_url_for_output(raw_url: &str) -> String {
+    let Ok(mut parsed) = Url::parse(raw_url) else {
+        return raw_url.to_owned();
+    };
+
+    if !parsed.username().is_empty() {
+        let _ = parsed.set_username("");
+    }
+
+    if parsed.password().is_some() {
+        let _ = parsed.set_password(None);
+    }
+
+    parsed.to_string()
 }
 
 fn wrap_stream(
@@ -853,23 +891,14 @@ fn check_request_deadline(deadline: Option<Instant>) -> Result<(), HttpError> {
     Ok(())
 }
 
-async fn run_blocking_with_deadline<T, F>(
-    deadline: Option<Instant>,
-    operation: F,
-) -> Result<T, HttpError>
+async fn run_blocking<T, F>(operation: F) -> Result<T, HttpError>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T, HttpError> + Send + 'static,
 {
     let task = task::spawn_blocking(operation);
 
-    match deadline {
-        Some(deadline) => timeout_at(deadline, task)
-            .await
-            .map_err(|_| HttpError::Timeout)?
-            .expect("blocking task must not panic"),
-        None => task.await.expect("blocking task must not panic"),
-    }
+    task.await.expect("blocking task must not panic")
 }
 
 fn log_result<T>(

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,22 +1,16 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::result_large_err)]
 
-use std::{
-    error::Error as StdError,
-    fmt, fs,
-    path::PathBuf,
-    pin::Pin,
-    time::{Duration, Instant},
-};
+use std::{error::Error as StdError, fmt, fs, path::PathBuf, pin::Pin, time::Duration};
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
     HeaderMap, HeaderValue, StatusCode,
     header::{CONTENT_ENCODING, CONTENT_TYPE, USER_AGENT},
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
-use tokio::time::{timeout, timeout_at};
+use tokio::time::{Instant, timeout, timeout_at};
 use url::form_urlencoded;
 
 macro_rules! log_event {
@@ -116,6 +110,18 @@ enum PreparedBody {
     Buffered {
         bytes: Bytes,
         content_type_if_missing: Option<HeaderValue>,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StreamTimeoutState {
+    AwaitingFirstByte {
+        request_deadline: Option<Instant>,
+        idle_timeout: Option<Duration>,
+    },
+    Streaming {
+        idle_timeout: Option<Duration>,
+        idle_deadline: Option<Instant>,
     },
 }
 
@@ -241,10 +247,8 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
 
-    let result = run_with_timeout(request_timeout, async move {
-        stream_inner(client, prepared, idle_timeout).await
-    })
-    .await;
+    let request_deadline = request_timeout.map(|duration| Instant::now() + duration);
+    let result = stream_inner(client, prepared, request_deadline, idle_timeout).await;
 
     log_result("stream", &method, &request_url, body_len, &result);
 
@@ -258,7 +262,7 @@ async fn execute_inner(
     let response = send(client, prepared.request, &prepared.request_url).await?;
 
     if !response.status().is_success() {
-        return Err(read_status_error(response, &prepared.request_url).await?);
+        return Err(collect_status_error(response, None, &prepared.request_url).await);
     }
 
     let status = response.status();
@@ -278,18 +282,26 @@ async fn execute_inner(
 async fn stream_inner(
     client: Client,
     prepared: PreparedRequest,
+    request_deadline: Option<Instant>,
     idle_timeout: Option<Duration>,
 ) -> Result<HttpStreamResponse, HttpError> {
-    let response = send(client, prepared.request, &prepared.request_url).await?;
+    let response = send_with_deadline(
+        client,
+        prepared.request,
+        &prepared.request_url,
+        request_deadline,
+    )
+    .await?;
 
     if !response.status().is_success() {
-        return Err(read_status_error(response, &prepared.request_url).await?);
+        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await);
     }
 
     let status = response.status();
     let headers = response.headers().clone();
     let body = wrap_stream(
         prepared.request_url.clone(),
+        request_deadline,
         idle_timeout,
         response.bytes_stream(),
     );
@@ -312,24 +324,72 @@ async fn send(
         .map_err(|error| map_transport_error(error, request_url))
 }
 
-async fn read_status_error(
-    response: reqwest::Response,
+async fn send_with_deadline(
+    client: Client,
+    request: reqwest::Request,
     request_url: &str,
-) -> Result<HttpError, HttpError> {
+    deadline: Option<Instant>,
+) -> Result<reqwest::Response, HttpError> {
+    match deadline {
+        Some(deadline) => timeout_at(deadline, client.execute(request))
+            .await
+            .map_err(|_| HttpError::Timeout)?
+            .map_err(|error| map_transport_error(error, request_url)),
+        None => send(client, request, request_url).await,
+    }
+}
+
+async fn collect_status_error(
+    response: reqwest::Response,
+    deadline: Option<Instant>,
+    request_url: &str,
+) -> HttpError {
     let url = response.url().to_string();
     let status = response.status();
     let headers = response.headers().clone();
-    let body = response
-        .bytes()
-        .await
-        .map_err(|error| map_transport_error(error, request_url))?;
+    let mut body = BytesMut::new();
+    let mut stream = Box::pin(response.bytes_stream());
 
-    Ok(HttpError::Status(HttpStatusError {
+    loop {
+        let next_chunk = match deadline {
+            Some(deadline) => match timeout_at(deadline, stream.next()).await {
+                Ok(next_chunk) => next_chunk,
+                Err(_) => {
+                    log_event!(
+                        selvedge_logging::LogLevel::Warn,
+                        "http non-success response body timed out";
+                        url = url.as_str(),
+                        status = status.as_u16()
+                    );
+                    break;
+                }
+            },
+            None => stream.next().await,
+        };
+
+        match next_chunk {
+            Some(Ok(chunk)) => body.extend_from_slice(&chunk),
+            Some(Err(error)) => {
+                let mapped = map_transport_error(error, request_url);
+                log_event!(
+                    selvedge_logging::LogLevel::Warn,
+                    "http non-success response body truncated";
+                    url = url.as_str(),
+                    status = status.as_u16(),
+                    error = mapped.to_string()
+                );
+                break;
+            }
+            None => break,
+        }
+    }
+
+    HttpError::Status(HttpStatusError {
         url,
         status,
         headers,
-        body,
-    }))
+        body: body.freeze(),
+    })
 }
 
 fn resolve_call_config(
@@ -574,21 +634,25 @@ fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
 
 fn wrap_stream(
     request_url: String,
+    request_deadline: Option<Instant>,
     idle_timeout: Option<Duration>,
     stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 ) -> ByteStream {
     let stream = async_stream::stream! {
         let mut stream = Box::pin(stream);
-        let mut deadline = idle_timeout.map(|timeout| Instant::now() + timeout);
+        let mut timeout_state = StreamTimeoutState::AwaitingFirstByte {
+            request_deadline,
+            idle_timeout,
+        };
 
         loop {
-            let next_item = match deadline {
-                Some(deadline) => match timeout_at(deadline.into(), stream.next()).await {
+            let next_item = match timeout_state.deadline() {
+                Some(deadline) => match timeout_at(deadline, stream.next()).await {
                     Ok(item) => item,
                     Err(_) => {
                         log_event!(
                             selvedge_logging::LogLevel::Warn,
-                            "http stream idle timeout";
+                            timeout_state.timeout_message();
                             mode = "stream",
                             url = request_url.as_str()
                         );
@@ -601,10 +665,7 @@ fn wrap_stream(
 
             match next_item {
                 Some(Ok(bytes)) => {
-                    if !bytes.is_empty() {
-                        deadline = idle_timeout.map(|timeout| Instant::now() + timeout);
-                    }
-
+                    timeout_state = timeout_state.on_chunk(&bytes);
                     yield Ok(bytes);
                 }
                 Some(Err(error)) => {
@@ -798,6 +859,61 @@ impl PreparedBody {
         match self {
             Self::Empty => 0,
             Self::Buffered { bytes, .. } => bytes.len(),
+        }
+    }
+}
+
+impl StreamTimeoutState {
+    fn deadline(self) -> Option<Instant> {
+        match self {
+            Self::AwaitingFirstByte {
+                request_deadline, ..
+            } => request_deadline,
+            Self::Streaming { idle_deadline, .. } => idle_deadline,
+        }
+    }
+
+    fn timeout_message(self) -> &'static str {
+        match self {
+            Self::AwaitingFirstByte { .. } => "http stream request timeout",
+            Self::Streaming { .. } => "http stream idle timeout",
+        }
+    }
+
+    fn on_chunk(self, chunk: &Bytes) -> Self {
+        match self {
+            Self::AwaitingFirstByte {
+                request_deadline,
+                idle_timeout,
+            } => {
+                if chunk.is_empty() {
+                    Self::AwaitingFirstByte {
+                        request_deadline,
+                        idle_timeout,
+                    }
+                } else {
+                    Self::Streaming {
+                        idle_timeout,
+                        idle_deadline: idle_timeout.map(|timeout| Instant::now() + timeout),
+                    }
+                }
+            }
+            Self::Streaming {
+                idle_timeout,
+                idle_deadline,
+            } => {
+                if chunk.is_empty() {
+                    Self::Streaming {
+                        idle_timeout,
+                        idle_deadline,
+                    }
+                } else {
+                    Self::Streaming {
+                        idle_timeout,
+                        idle_deadline: idle_timeout.map(|timeout| Instant::now() + timeout),
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -191,7 +191,12 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
     );
 
     let call_config = resolve_call_config(request.timeout)?;
+    let request_deadline = call_config
+        .request_timeout
+        .map(|duration| Instant::now() + duration);
+    check_request_deadline(request_deadline)?;
     let prepared = prepare_request(request, &call_config)?;
+    check_request_deadline(request_deadline)?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -203,11 +208,10 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
     );
 
     let client = build_client(&call_config)?;
-    let request_timeout = call_config.request_timeout;
+    check_request_deadline(request_deadline)?;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
-    let request_deadline = request_timeout.map(|duration| Instant::now() + duration);
     let result = execute_inner(client, prepared, request_deadline).await;
 
     log_result("execute", &method, &request_url, body_len, &result);
@@ -225,7 +229,12 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     );
 
     let call_config = resolve_call_config(request.timeout)?;
+    let request_deadline = call_config
+        .request_timeout
+        .map(|duration| Instant::now() + duration);
+    check_request_deadline(request_deadline)?;
     let prepared = prepare_request(request, &call_config)?;
+    check_request_deadline(request_deadline)?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -237,13 +246,12 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     );
 
     let client = build_client(&call_config)?;
-    let request_timeout = call_config.request_timeout;
+    check_request_deadline(request_deadline)?;
     let idle_timeout = call_config.stream_idle_timeout;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
 
-    let request_deadline = request_timeout.map(|duration| Instant::now() + duration);
     let result = stream_inner(client, prepared, request_deadline, idle_timeout).await;
 
     log_stream_result(&method, &request_url, body_len, &result);
@@ -793,6 +801,27 @@ fn duration_millis_or_zero(duration: Option<Duration>) -> u64 {
         .unwrap_or(0)
 }
 
+fn relative_deadline(timeout: Option<Duration>) -> Option<Instant> {
+    timeout.map(|timeout| Instant::now() + timeout)
+}
+
+fn min_deadline(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn check_request_deadline(deadline: Option<Instant>) -> Result<(), HttpError> {
+    if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+        return Err(HttpError::Timeout);
+    }
+
+    Ok(())
+}
+
 fn log_result<T>(
     mode: &str,
     method: &HttpMethod,
@@ -927,8 +956,9 @@ impl StreamTimeoutState {
     fn deadline(self) -> Option<Instant> {
         match self {
             Self::AwaitingFirstByte {
-                request_deadline, ..
-            } => request_deadline,
+                request_deadline,
+                idle_timeout,
+            } => min_deadline(request_deadline, relative_deadline(idle_timeout)),
             Self::Streaming { idle_timeout } => {
                 idle_timeout.map(|timeout| Instant::now() + timeout)
             }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -209,7 +209,12 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
         body_len = prepared.body_len
     );
 
-    let client = build_client(&call_config, request_deadline).await?;
+    let client = build_client(
+        &call_config,
+        request_deadline,
+        prepared.request.url().scheme() == "https",
+    )
+    .await?;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
@@ -246,7 +251,12 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
         body_len = prepared.body_len
     );
 
-    let client = build_client(&call_config, request_deadline).await?;
+    let client = build_client(
+        &call_config,
+        request_deadline,
+        prepared.request.url().scheme() == "https",
+    )
+    .await?;
     let idle_timeout = call_config.stream_idle_timeout;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
@@ -628,6 +638,7 @@ async fn maybe_compress_body(
 async fn build_client(
     call_config: &ResolvedCallConfig,
     request_deadline: Option<Instant>,
+    uses_tls: bool,
 ) -> Result<Client, HttpError> {
     let mut builder = Client::builder().retry(reqwest::retry::never());
 
@@ -643,7 +654,7 @@ async fn build_client(
         builder = builder.no_proxy();
     }
 
-    if let Some(path) = &call_config.ca_bundle_path {
+    if uses_tls && let Some(path) = &call_config.ca_bundle_path {
         let bundle = match request_deadline {
             Some(deadline) => timeout_at(deadline, tokio_fs::read(path))
                 .await
@@ -1220,6 +1231,7 @@ mod tests {
                 user_agent: None,
             },
             None,
+            true,
         )
         .await
         .expect_err("invalid proxy must fail");

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -727,6 +727,9 @@ fn sanitize_url_for_output(raw_url: &str) -> String {
         let _ = parsed.set_password(None);
     }
 
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+
     parsed.to_string()
 }
 
@@ -1128,7 +1131,8 @@ mod tests {
     use super::{
         HeaderMap, HeaderValue, HttpMethod, HttpRequest, HttpRequestBody, PreparedBody,
         RequestCompression, ResolvedCallConfig, build_client, build_error, encode_body,
-        maybe_compress_body, parse_absolute_http_url, prepare_request, wrap_stream,
+        maybe_compress_body, parse_absolute_http_url, prepare_request, sanitize_url_for_output,
+        wrap_stream,
     };
     use std::time::Duration;
 
@@ -1288,5 +1292,14 @@ mod tests {
 
         let first = wrapped.next().await.expect("first item");
         assert_eq!(first.expect("first chunk"), Bytes::from_static(b"first"));
+    }
+
+    #[test]
+    fn sanitized_url_removes_userinfo_query_and_fragment() {
+        let sanitized = sanitize_url_for_output(
+            "https://user:pass@example.com/path?access_token=secret#fragment",
+        );
+
+        assert_eq!(sanitized, "https://example.com/path");
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,0 +1,904 @@
+#![doc = include_str!("../README.md")]
+#![allow(clippy::result_large_err)]
+
+use std::{
+    error::Error as StdError,
+    fmt, fs,
+    path::PathBuf,
+    pin::Pin,
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use http::{
+    HeaderMap, HeaderValue, StatusCode,
+    header::{CONTENT_ENCODING, CONTENT_TYPE, USER_AGENT},
+};
+use reqwest::{Certificate, Client, Method, Proxy, Url};
+use tokio::time::{timeout, timeout_at};
+use url::form_urlencoded;
+
+macro_rules! log_event {
+    ($level:expr, $message:expr $(; $($key:ident = $value:expr),+ $(,)?)?) => {{
+        let _ = selvedge_logging::selvedge_log!($level, $message $(; $($key = $value),+)?);
+    }};
+}
+
+pub type ByteStream = Pin<Box<dyn Stream<Item = Result<bytes::Bytes, HttpError>> + Send + 'static>>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequestCompression {
+    None,
+    Zstd,
+}
+
+#[derive(Clone, Debug)]
+pub enum HttpRequestBody {
+    Empty,
+    Json(serde_json::Value),
+    FormUrlEncoded(Vec<(String, String)>),
+    Bytes(bytes::Bytes),
+}
+
+#[derive(Clone, Debug)]
+pub struct HttpRequest {
+    pub method: HttpMethod,
+    pub url: String,
+    pub headers: HeaderMap,
+    pub body: HttpRequestBody,
+    pub timeout: Option<Duration>,
+    pub compression: RequestCompression,
+}
+
+#[derive(Clone, Debug)]
+pub struct HttpResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: bytes::Bytes,
+}
+
+pub struct HttpStreamResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: ByteStream,
+}
+
+#[derive(Debug)]
+pub enum HttpError {
+    Config(selvedge_config::ConfigError),
+    Build { reason: String },
+    Timeout,
+    Connect { reason: String },
+    Tls { reason: String },
+    Io { reason: String },
+    Status(HttpStatusError),
+}
+
+#[derive(Debug)]
+pub struct HttpStatusError {
+    pub url: String,
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: bytes::Bytes,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedCallConfig {
+    connect_timeout: Option<Duration>,
+    request_timeout: Option<Duration>,
+    stream_idle_timeout: Option<Duration>,
+    proxy_url: Option<String>,
+    ca_bundle_path: Option<PathBuf>,
+    user_agent: Option<HeaderValue>,
+}
+
+#[derive(Debug)]
+struct PreparedRequest {
+    request: reqwest::Request,
+    method: HttpMethod,
+    request_url: String,
+    body_len: usize,
+}
+
+#[derive(Debug)]
+enum PreparedBody {
+    Empty,
+    Buffered {
+        bytes: Bytes,
+        content_type_if_missing: Option<HeaderValue>,
+    },
+}
+
+impl fmt::Debug for HttpStreamResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HttpStreamResponse")
+            .field("status", &self.status)
+            .field("headers", &self.headers)
+            .field("body", &"<byte-stream>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HttpError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Config(error) => write!(formatter, "config error: {error}"),
+            Self::Build { reason } => write!(formatter, "request build failed: {reason}"),
+            Self::Timeout => formatter.write_str("request timed out"),
+            Self::Connect { reason } => write!(formatter, "connection failed: {reason}"),
+            Self::Tls { reason } => write!(formatter, "tls failed: {reason}"),
+            Self::Io { reason } => write!(formatter, "i/o failed: {reason}"),
+            Self::Status(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl StdError for HttpError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Config(error) => Some(error),
+            Self::Status(error) => Some(error),
+            Self::Build { .. }
+            | Self::Timeout
+            | Self::Connect { .. }
+            | Self::Tls { .. }
+            | Self::Io { .. } => None,
+        }
+    }
+}
+
+impl fmt::Display for HttpStatusError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "received non-success status {} for {}",
+            self.status, self.url
+        )
+    }
+}
+
+impl StdError for HttpStatusError {}
+
+impl From<selvedge_config::ConfigError> for HttpError {
+    fn from(error: selvedge_config::ConfigError) -> Self {
+        Self::Config(error)
+    }
+}
+
+pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
+    log_event!(
+        selvedge_logging::LogLevel::Debug,
+        "http request started";
+        mode = "execute",
+        method = request.method.as_str(),
+        url = request.url.as_str()
+    );
+
+    let call_config = resolve_call_config(request.timeout)?;
+    let prepared = prepare_request(request, &call_config)?;
+
+    log_event!(
+        selvedge_logging::LogLevel::Debug,
+        "http request prepared";
+        mode = "execute",
+        method = prepared.method.as_str(),
+        url = prepared.request_url.as_str(),
+        body_len = prepared.body_len
+    );
+
+    let client = build_client(&call_config)?;
+    let request_timeout = call_config.request_timeout;
+    let request_url = prepared.request_url.clone();
+    let method = prepared.method.clone();
+    let body_len = prepared.body_len;
+
+    let result = run_with_timeout(request_timeout, async move {
+        execute_inner(client, prepared).await
+    })
+    .await;
+
+    log_result("execute", &method, &request_url, body_len, &result);
+
+    result
+}
+
+pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpError> {
+    log_event!(
+        selvedge_logging::LogLevel::Debug,
+        "http request started";
+        mode = "stream",
+        method = request.method.as_str(),
+        url = request.url.as_str()
+    );
+
+    let call_config = resolve_call_config(request.timeout)?;
+    let prepared = prepare_request(request, &call_config)?;
+
+    log_event!(
+        selvedge_logging::LogLevel::Debug,
+        "http request prepared";
+        mode = "stream",
+        method = prepared.method.as_str(),
+        url = prepared.request_url.as_str(),
+        body_len = prepared.body_len
+    );
+
+    let client = build_client(&call_config)?;
+    let request_timeout = call_config.request_timeout;
+    let idle_timeout = call_config.stream_idle_timeout;
+    let request_url = prepared.request_url.clone();
+    let method = prepared.method.clone();
+    let body_len = prepared.body_len;
+
+    let result = run_with_timeout(request_timeout, async move {
+        stream_inner(client, prepared, idle_timeout).await
+    })
+    .await;
+
+    log_result("stream", &method, &request_url, body_len, &result);
+
+    result
+}
+
+async fn execute_inner(
+    client: Client,
+    prepared: PreparedRequest,
+) -> Result<HttpResponse, HttpError> {
+    let response = send(client, prepared.request, &prepared.request_url).await?;
+
+    if !response.status().is_success() {
+        return Err(read_status_error(response, &prepared.request_url).await?);
+    }
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| map_transport_error(error, &prepared.request_url))?;
+
+    Ok(HttpResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+async fn stream_inner(
+    client: Client,
+    prepared: PreparedRequest,
+    idle_timeout: Option<Duration>,
+) -> Result<HttpStreamResponse, HttpError> {
+    let response = send(client, prepared.request, &prepared.request_url).await?;
+
+    if !response.status().is_success() {
+        return Err(read_status_error(response, &prepared.request_url).await?);
+    }
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = wrap_stream(
+        prepared.request_url.clone(),
+        idle_timeout,
+        response.bytes_stream(),
+    );
+
+    Ok(HttpStreamResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+async fn send(
+    client: Client,
+    request: reqwest::Request,
+    request_url: &str,
+) -> Result<reqwest::Response, HttpError> {
+    client
+        .execute(request)
+        .await
+        .map_err(|error| map_transport_error(error, request_url))
+}
+
+async fn read_status_error(
+    response: reqwest::Response,
+    request_url: &str,
+) -> Result<HttpError, HttpError> {
+    let url = response.url().to_string();
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| map_transport_error(error, request_url))?;
+
+    Ok(HttpError::Status(HttpStatusError {
+        url,
+        status,
+        headers,
+        body,
+    }))
+}
+
+fn resolve_call_config(
+    timeout_override: Option<Duration>,
+) -> Result<ResolvedCallConfig, HttpError> {
+    if timeout_override.is_some_and(|timeout| timeout.is_zero()) {
+        return Err(build_error("request.timeout must be greater than zero"));
+    }
+
+    let (
+        connect_timeout_ms,
+        request_timeout_ms,
+        stream_idle_timeout_ms,
+        proxy_url,
+        ca_bundle_path,
+        user_agent,
+    ) = selvedge_config::read(|config| {
+        (
+            config.network.connect_timeout_ms,
+            config.network.request_timeout_ms,
+            config.network.stream_idle_timeout_ms,
+            config.network.proxy_url.clone(),
+            config.network.ca_bundle_path.clone(),
+            config.network.user_agent.clone(),
+        )
+    })?;
+
+    let config = ResolvedCallConfig {
+        connect_timeout: connect_timeout_ms.map(Duration::from_millis),
+        request_timeout: timeout_override.or_else(|| request_timeout_ms.map(Duration::from_millis)),
+        stream_idle_timeout: stream_idle_timeout_ms.map(Duration::from_millis),
+        proxy_url,
+        ca_bundle_path,
+        user_agent: user_agent
+            .as_deref()
+            .map(HeaderValue::from_str)
+            .transpose()
+            .map_err(|error| build_error(format!("invalid network.user_agent header: {error}")))?,
+    };
+
+    log_event!(
+        selvedge_logging::LogLevel::Debug,
+        "http config resolved";
+        connect_timeout_ms = duration_millis_or_zero(config.connect_timeout),
+        request_timeout_ms = duration_millis_or_zero(config.request_timeout),
+        stream_idle_timeout_ms = duration_millis_or_zero(config.stream_idle_timeout),
+        has_proxy = config.proxy_url.is_some(),
+        has_ca_bundle = config.ca_bundle_path.is_some(),
+        has_user_agent = config.user_agent.is_some()
+    );
+
+    Ok(config)
+}
+
+fn prepare_request(
+    request: HttpRequest,
+    call_config: &ResolvedCallConfig,
+) -> Result<PreparedRequest, HttpError> {
+    let url = parse_absolute_http_url(&request.url)?;
+    let mut headers = request.headers;
+    let mut body = encode_body(request.body)?;
+
+    if !headers.contains_key(USER_AGENT)
+        && let Some(user_agent) = &call_config.user_agent
+    {
+        headers.insert(USER_AGENT, user_agent.clone());
+    }
+
+    finalize_headers(&mut headers, &body);
+    body = maybe_compress_body(body, request.compression, &mut headers)?;
+
+    let body_len = body.len();
+    let mut reqwest_request = reqwest::Request::new(request.method.clone().into(), url);
+    *reqwest_request.headers_mut() = headers;
+
+    if let Some(bytes) = body.into_bytes() {
+        *reqwest_request.body_mut() = Some(bytes.into());
+    }
+
+    Ok(PreparedRequest {
+        request: reqwest_request,
+        method: request.method,
+        request_url: request.url,
+        body_len,
+    })
+}
+
+fn parse_absolute_http_url(url: &str) -> Result<Url, HttpError> {
+    let parsed = Url::parse(url)
+        .map_err(|error| build_error(format!("url must be an absolute URL: {error}")))?;
+
+    if !parsed.has_host() || parsed.cannot_be_a_base() {
+        return Err(build_error("url must be an absolute URL"));
+    }
+
+    match parsed.scheme() {
+        "http" | "https" => Ok(parsed),
+        other => Err(build_error(format!(
+            "url scheme must be http or https, got {other}"
+        ))),
+    }
+}
+
+fn encode_body(body: HttpRequestBody) -> Result<PreparedBody, HttpError> {
+    match body {
+        HttpRequestBody::Empty => Ok(PreparedBody::Empty),
+        HttpRequestBody::Json(value) => {
+            let bytes = serde_json::to_vec(&value)
+                .map(Bytes::from)
+                .map_err(|error| build_error(format!("failed to encode json body: {error}")))?;
+
+            Ok(PreparedBody::Buffered {
+                bytes,
+                content_type_if_missing: Some(HeaderValue::from_static("application/json")),
+            })
+        }
+        HttpRequestBody::FormUrlEncoded(pairs) => {
+            let mut encoded = pairs.into_iter().fold(
+                form_urlencoded::Serializer::new(String::new()),
+                |mut serializer, (key, value)| {
+                    serializer.append_pair(&key, &value);
+                    serializer
+                },
+            );
+
+            Ok(PreparedBody::Buffered {
+                bytes: Bytes::from(encoded.finish()),
+                content_type_if_missing: Some(HeaderValue::from_static(
+                    "application/x-www-form-urlencoded",
+                )),
+            })
+        }
+        HttpRequestBody::Bytes(bytes) => Ok(PreparedBody::Buffered {
+            bytes,
+            content_type_if_missing: None,
+        }),
+    }
+}
+
+fn finalize_headers(headers: &mut HeaderMap, body: &PreparedBody) {
+    if let PreparedBody::Buffered {
+        content_type_if_missing: Some(content_type),
+        ..
+    } = body
+        && !headers.contains_key(CONTENT_TYPE)
+    {
+        headers.insert(CONTENT_TYPE, content_type.clone());
+    }
+}
+
+fn maybe_compress_body(
+    body: PreparedBody,
+    compression: RequestCompression,
+    headers: &mut HeaderMap,
+) -> Result<PreparedBody, HttpError> {
+    match (body, compression) {
+        (PreparedBody::Empty, _) => Ok(PreparedBody::Empty),
+        (body, RequestCompression::None) => Ok(body),
+        (
+            PreparedBody::Buffered {
+                bytes,
+                content_type_if_missing,
+            },
+            RequestCompression::Zstd,
+        ) => {
+            if headers.contains_key(CONTENT_ENCODING) {
+                return Err(build_error(
+                    "cannot apply request compression when Content-Encoding is already set",
+                ));
+            }
+
+            let compressed = zstd::stream::encode_all(bytes.as_ref(), 0)
+                .map(Bytes::from)
+                .map_err(|error| build_error(format!("failed to encode zstd body: {error}")))?;
+            headers.insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+
+            Ok(PreparedBody::Buffered {
+                bytes: compressed,
+                content_type_if_missing,
+            })
+        }
+    }
+}
+
+fn build_client(call_config: &ResolvedCallConfig) -> Result<Client, HttpError> {
+    let mut builder = Client::builder().retry(reqwest::retry::never());
+
+    if let Some(connect_timeout) = call_config.connect_timeout {
+        builder = builder.connect_timeout(connect_timeout);
+    }
+
+    if let Some(proxy_url) = &call_config.proxy_url {
+        let proxy = Proxy::all(proxy_url)
+            .map_err(|error| build_error(format!("invalid network.proxy_url: {error}")))?;
+        builder = builder.proxy(proxy);
+    } else {
+        builder = builder.no_proxy();
+    }
+
+    if let Some(path) = &call_config.ca_bundle_path {
+        let bundle = fs::read(path).map_err(|error| {
+            build_error(format!(
+                "failed to read network.ca_bundle_path {}: {error}",
+                path.display()
+            ))
+        })?;
+        let certificates = parse_certificates(&bundle).map_err(|error| {
+            build_error(format!(
+                "failed to parse network.ca_bundle_path {}: {error}",
+                path.display()
+            ))
+        })?;
+
+        for certificate in certificates {
+            builder = builder.add_root_certificate(certificate);
+        }
+    }
+
+    builder
+        .build()
+        .map_err(|error| build_error(format!("failed to build http client: {error}")))
+}
+
+fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
+    let mut reader = bundle;
+    let mut certificates = Vec::new();
+
+    for parsed in rustls_pemfile::certs(&mut reader) {
+        let parsed = parsed
+            .map_err(|error| build_error(format!("failed to parse pem certificate: {error}")))?;
+        let certificate = Certificate::from_der(parsed.as_ref())
+            .map_err(|error| build_error(format!("failed to load pem certificate: {error}")))?;
+        certificates.push(certificate);
+    }
+
+    if certificates.is_empty() {
+        return Err(build_error("ca bundle did not contain any certificates"));
+    }
+
+    Ok(certificates)
+}
+
+fn wrap_stream(
+    request_url: String,
+    idle_timeout: Option<Duration>,
+    stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+) -> ByteStream {
+    let stream = async_stream::stream! {
+        let mut stream = Box::pin(stream);
+        let mut deadline = idle_timeout.map(|timeout| Instant::now() + timeout);
+
+        loop {
+            let next_item = match deadline {
+                Some(deadline) => match timeout_at(deadline.into(), stream.next()).await {
+                    Ok(item) => item,
+                    Err(_) => {
+                        log_event!(
+                            selvedge_logging::LogLevel::Warn,
+                            "http stream idle timeout";
+                            mode = "stream",
+                            url = request_url.as_str()
+                        );
+                        yield Err(HttpError::Timeout);
+                        break;
+                    }
+                },
+                None => stream.next().await,
+            };
+
+            match next_item {
+                Some(Ok(bytes)) => {
+                    if !bytes.is_empty() {
+                        deadline = idle_timeout.map(|timeout| Instant::now() + timeout);
+                    }
+
+                    yield Ok(bytes);
+                }
+                Some(Err(error)) => {
+                    let mapped = map_transport_error(error, &request_url);
+                    log_transport_error("stream", &request_url, &mapped);
+                    yield Err(mapped);
+                    break;
+                }
+                None => break,
+            }
+        }
+    };
+
+    Box::pin(stream)
+}
+
+async fn run_with_timeout<F, T>(
+    timeout_duration: Option<Duration>,
+    future: F,
+) -> Result<T, HttpError>
+where
+    F: std::future::Future<Output = Result<T, HttpError>>,
+{
+    match timeout_duration {
+        Some(timeout_duration) => timeout(timeout_duration, future)
+            .await
+            .map_err(|_| HttpError::Timeout)?,
+        None => future.await,
+    }
+}
+
+fn map_transport_error(error: reqwest::Error, request_url: &str) -> HttpError {
+    let reason = format!("{request_url}: {}", render_error_chain(&error));
+
+    if error.is_timeout() {
+        HttpError::Timeout
+    } else if is_tls_error(&error) {
+        HttpError::Tls { reason }
+    } else if error.is_connect() {
+        HttpError::Connect { reason }
+    } else if error.is_builder() || error.is_redirect() || error.is_request() {
+        HttpError::Build { reason }
+    } else {
+        HttpError::Io { reason }
+    }
+}
+
+fn is_tls_error(error: &reqwest::Error) -> bool {
+    let mut source = error.source();
+
+    while let Some(current) = source {
+        let reason = current.to_string().to_ascii_lowercase();
+
+        if [
+            "tls",
+            "rustls",
+            "certificate",
+            "unknown issuer",
+            "self-signed",
+            "dns name",
+            "handshake",
+            "webpki",
+            "peer sent no certificates",
+            "not valid for name",
+        ]
+        .iter()
+        .any(|needle| reason.contains(needle))
+        {
+            return true;
+        }
+
+        source = current.source();
+    }
+
+    false
+}
+
+fn render_error_chain(error: &dyn StdError) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut source = error.source();
+
+    while let Some(current) = source {
+        parts.push(current.to_string());
+        source = current.source();
+    }
+
+    parts.join(": ")
+}
+
+fn build_error(reason: impl Into<String>) -> HttpError {
+    HttpError::Build {
+        reason: reason.into(),
+    }
+}
+
+fn duration_millis_or_zero(duration: Option<Duration>) -> u64 {
+    duration
+        .map(|timeout| timeout.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn log_result<T>(
+    mode: &str,
+    method: &HttpMethod,
+    request_url: &str,
+    body_len: usize,
+    result: &Result<T, HttpError>,
+) {
+    match result {
+        Ok(_) => {
+            log_event!(
+                selvedge_logging::LogLevel::Debug,
+                "http request finished";
+                mode = mode,
+                method = method.as_str(),
+                url = request_url,
+                body_len = body_len,
+                outcome = "success"
+            );
+        }
+        Err(HttpError::Status(error)) => {
+            log_event!(
+                selvedge_logging::LogLevel::Warn,
+                "http request returned non-success status";
+                mode = mode,
+                method = method.as_str(),
+                url = error.url.as_str(),
+                status = error.status.as_u16(),
+                body_len = error.body.len()
+            );
+        }
+        Err(error) => {
+            log_transport_error(mode, request_url, error);
+        }
+    }
+}
+
+fn log_transport_error(mode: &str, request_url: &str, error: &HttpError) {
+    let message = match error {
+        HttpError::Timeout => "http request timed out",
+        HttpError::Connect { .. } => "http request connect failure",
+        HttpError::Tls { .. } => "http request tls failure",
+        HttpError::Io { .. } => "http request i/o failure",
+        HttpError::Build { .. } => "http request build failure",
+        HttpError::Config { .. } => "http request config failure",
+        HttpError::Status(_) => "http request status failure",
+    };
+
+    log_event!(
+        selvedge_logging::LogLevel::Warn,
+        message;
+        mode = mode,
+        url = request_url,
+        error = error.to_string()
+    );
+}
+
+impl HttpMethod {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+        }
+    }
+}
+
+impl From<HttpMethod> for Method {
+    fn from(value: HttpMethod) -> Self {
+        match value {
+            HttpMethod::Get => Method::GET,
+            HttpMethod::Post => Method::POST,
+            HttpMethod::Put => Method::PUT,
+            HttpMethod::Patch => Method::PATCH,
+            HttpMethod::Delete => Method::DELETE,
+        }
+    }
+}
+
+impl PreparedBody {
+    fn into_bytes(self) -> Option<Bytes> {
+        match self {
+            Self::Empty => None,
+            Self::Buffered { bytes, .. } => Some(bytes),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::Buffered { bytes, .. } => bytes.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        HeaderMap, HeaderValue, HttpMethod, HttpRequest, HttpRequestBody, PreparedBody,
+        RequestCompression, ResolvedCallConfig, build_client, build_error, encode_body,
+        maybe_compress_body, parse_absolute_http_url, prepare_request,
+    };
+
+    #[test]
+    fn absolute_http_url_is_required() {
+        let error = parse_absolute_http_url("/relative").expect_err("relative url must fail");
+
+        assert!(matches!(error, super::HttpError::Build { .. }));
+    }
+
+    #[test]
+    fn request_compression_conflicts_with_existing_content_encoding() {
+        let mut headers = HeaderMap::new();
+        headers.insert(super::CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+
+        let body = PreparedBody::Buffered {
+            bytes: bytes::Bytes::from_static(b"payload"),
+            content_type_if_missing: None,
+        };
+
+        let error = maybe_compress_body(body, RequestCompression::Zstd, &mut headers)
+            .expect_err("content-encoding conflict must fail");
+
+        assert!(matches!(error, super::HttpError::Build { .. }));
+    }
+
+    #[test]
+    fn json_body_sets_default_content_type() {
+        let request = HttpRequest {
+            method: HttpMethod::Post,
+            url: "https://example.com".to_owned(),
+            headers: HeaderMap::new(),
+            body: HttpRequestBody::Json(serde_json::json!({ "x": 1 })),
+            timeout: None,
+            compression: RequestCompression::None,
+        };
+
+        let prepared = prepare_request(
+            request,
+            &ResolvedCallConfig {
+                connect_timeout: None,
+                request_timeout: None,
+                stream_idle_timeout: None,
+                proxy_url: None,
+                ca_bundle_path: None,
+                user_agent: None,
+            },
+        )
+        .expect("prepare request");
+
+        assert_eq!(
+            prepared.request.headers().get(super::CONTENT_TYPE),
+            Some(&HeaderValue::from_static("application/json"))
+        );
+    }
+
+    #[test]
+    fn invalid_proxy_url_fails_client_build() {
+        let error = build_client(&ResolvedCallConfig {
+            connect_timeout: None,
+            request_timeout: None,
+            stream_idle_timeout: None,
+            proxy_url: Some("://bad-proxy".to_owned()),
+            ca_bundle_path: None,
+            user_agent: None,
+        })
+        .expect_err("invalid proxy must fail");
+
+        assert!(matches!(error, super::HttpError::Build { .. }));
+    }
+
+    #[test]
+    fn zstd_compression_changes_request_body() {
+        let body = encode_body(HttpRequestBody::Bytes(bytes::Bytes::from_static(
+            b"payload",
+        )))
+        .expect("encode body");
+        let mut headers = HeaderMap::new();
+        let compressed = maybe_compress_body(body, RequestCompression::Zstd, &mut headers)
+            .expect("compress body");
+
+        assert_eq!(
+            headers.get(super::CONTENT_ENCODING),
+            Some(&HeaderValue::from_static("zstd"))
+        );
+        assert!(compressed.len() > 0);
+    }
+
+    #[test]
+    fn build_error_has_stable_shape() {
+        let error = build_error("reason");
+
+        assert!(matches!(error, super::HttpError::Build { reason } if reason == "reason"));
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -10,6 +10,7 @@ use http::{
     header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
+use tokio::task;
 use tokio::time::{Instant, timeout_at};
 use url::form_urlencoded;
 
@@ -116,7 +117,7 @@ enum PreparedBody {
 #[derive(Debug, Clone, Copy)]
 enum StreamTimeoutState {
     AwaitingFirstByte {
-        request_deadline: Option<Instant>,
+        request_timeout: Option<Duration>,
         idle_timeout: Option<Duration>,
     },
     Streaming {
@@ -195,8 +196,7 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
         .request_timeout
         .map(|duration| Instant::now() + duration);
     check_request_deadline(request_deadline)?;
-    let prepared = prepare_request(request, &call_config)?;
-    check_request_deadline(request_deadline)?;
+    let prepared = prepare_request(request, &call_config, request_deadline).await?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -207,8 +207,7 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
         body_len = prepared.body_len
     );
 
-    let client = build_client(&call_config)?;
-    check_request_deadline(request_deadline)?;
+    let client = build_client(&call_config, request_deadline).await?;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
@@ -233,8 +232,7 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
         .request_timeout
         .map(|duration| Instant::now() + duration);
     check_request_deadline(request_deadline)?;
-    let prepared = prepare_request(request, &call_config)?;
-    check_request_deadline(request_deadline)?;
+    let prepared = prepare_request(request, &call_config, request_deadline).await?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -245,14 +243,20 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
         body_len = prepared.body_len
     );
 
-    let client = build_client(&call_config)?;
-    check_request_deadline(request_deadline)?;
+    let client = build_client(&call_config, request_deadline).await?;
     let idle_timeout = call_config.stream_idle_timeout;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
 
-    let result = stream_inner(client, prepared, request_deadline, idle_timeout).await;
+    let result = stream_inner(
+        client,
+        prepared,
+        call_config.request_timeout,
+        request_deadline,
+        idle_timeout,
+    )
+    .await;
 
     log_stream_result(&method, &request_url, body_len, &result);
 
@@ -290,6 +294,7 @@ async fn execute_inner(
 async fn stream_inner(
     client: Client,
     prepared: PreparedRequest,
+    request_timeout: Option<Duration>,
     request_deadline: Option<Instant>,
     idle_timeout: Option<Duration>,
 ) -> Result<HttpStreamResponse, HttpError> {
@@ -309,7 +314,7 @@ async fn stream_inner(
     let headers = response.headers().clone();
     let body = wrap_stream(
         prepared.request_url.clone(),
-        request_deadline,
+        request_timeout,
         idle_timeout,
         response.bytes_stream(),
     );
@@ -472,9 +477,10 @@ fn resolve_call_config(
     Ok(config)
 }
 
-fn prepare_request(
+async fn prepare_request(
     request: HttpRequest,
     call_config: &ResolvedCallConfig,
+    request_deadline: Option<Instant>,
 ) -> Result<PreparedRequest, HttpError> {
     let url = parse_absolute_http_url(&request.url)?;
     let mut headers = request.headers;
@@ -489,7 +495,7 @@ fn prepare_request(
     }
 
     finalize_headers(&mut headers, &body);
-    body = maybe_compress_body(body, request.compression, &mut headers)?;
+    body = maybe_compress_body(body, request.compression, &mut headers, request_deadline).await?;
 
     let body_len = body.len();
     reconcile_content_length(&body, &mut headers)?;
@@ -582,10 +588,11 @@ fn finalize_headers(headers: &mut HeaderMap, body: &PreparedBody) {
     }
 }
 
-fn maybe_compress_body(
+async fn maybe_compress_body(
     body: PreparedBody,
     compression: RequestCompression,
     headers: &mut HeaderMap,
+    request_deadline: Option<Instant>,
 ) -> Result<PreparedBody, HttpError> {
     match (body, compression) {
         (PreparedBody::Empty, _) => Ok(PreparedBody::Empty),
@@ -603,9 +610,12 @@ fn maybe_compress_body(
                 ));
             }
 
-            let compressed = zstd::stream::encode_all(bytes.as_ref(), 0)
-                .map(Bytes::from)
-                .map_err(|error| build_error(format!("failed to encode zstd body: {error}")))?;
+            let compressed = run_blocking_with_deadline(request_deadline, move || {
+                zstd::stream::encode_all(bytes.as_ref(), 0)
+                    .map(Bytes::from)
+                    .map_err(|error| build_error(format!("failed to encode zstd body: {error}")))
+            })
+            .await?;
             headers.insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
 
             Ok(PreparedBody::Buffered {
@@ -616,7 +626,10 @@ fn maybe_compress_body(
     }
 }
 
-fn build_client(call_config: &ResolvedCallConfig) -> Result<Client, HttpError> {
+async fn build_client(
+    call_config: &ResolvedCallConfig,
+    request_deadline: Option<Instant>,
+) -> Result<Client, HttpError> {
     let mut builder = Client::builder().retry(reqwest::retry::never());
 
     if let Some(connect_timeout) = call_config.connect_timeout {
@@ -632,18 +645,22 @@ fn build_client(call_config: &ResolvedCallConfig) -> Result<Client, HttpError> {
     }
 
     if let Some(path) = &call_config.ca_bundle_path {
-        let bundle = fs::read(path).map_err(|error| {
-            build_error(format!(
-                "failed to read network.ca_bundle_path {}: {error}",
-                path.display()
-            ))
-        })?;
-        let certificates = parse_certificates(&bundle).map_err(|error| {
-            build_error(format!(
-                "failed to parse network.ca_bundle_path {}: {error}",
-                path.display()
-            ))
-        })?;
+        let path = path.clone();
+        let certificates = run_blocking_with_deadline(request_deadline, move || {
+            let bundle = fs::read(&path).map_err(|error| {
+                build_error(format!(
+                    "failed to read network.ca_bundle_path {}: {error}",
+                    path.display()
+                ))
+            })?;
+            parse_certificates(&bundle).map_err(|error| {
+                build_error(format!(
+                    "failed to parse network.ca_bundle_path {}: {error}",
+                    path.display()
+                ))
+            })
+        })
+        .await?;
 
         for certificate in certificates {
             builder = builder.add_root_certificate(certificate);
@@ -676,14 +693,14 @@ fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
 
 fn wrap_stream(
     request_url: String,
-    request_deadline: Option<Instant>,
+    request_timeout: Option<Duration>,
     idle_timeout: Option<Duration>,
     stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 ) -> ByteStream {
     let stream = async_stream::stream! {
         let mut stream = Box::pin(stream);
         let mut timeout_state = StreamTimeoutState::AwaitingFirstByte {
-            request_deadline,
+            request_timeout,
             idle_timeout,
         };
 
@@ -824,6 +841,25 @@ fn check_request_deadline(deadline: Option<Instant>) -> Result<(), HttpError> {
     Ok(())
 }
 
+async fn run_blocking_with_deadline<T, F>(
+    deadline: Option<Instant>,
+    operation: F,
+) -> Result<T, HttpError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, HttpError> + Send + 'static,
+{
+    let task = task::spawn_blocking(operation);
+
+    match deadline {
+        Some(deadline) => timeout_at(deadline, task)
+            .await
+            .map_err(|_| HttpError::Timeout)?
+            .expect("blocking task must not panic"),
+        None => task.await.expect("blocking task must not panic"),
+    }
+}
+
 fn log_result<T>(
     mode: &str,
     method: &HttpMethod,
@@ -958,9 +994,12 @@ impl StreamTimeoutState {
     fn deadline(self) -> Option<Instant> {
         match self {
             Self::AwaitingFirstByte {
-                request_deadline,
+                request_timeout,
                 idle_timeout,
-            } => min_deadline(request_deadline, relative_deadline(idle_timeout)),
+            } => min_deadline(
+                relative_deadline(request_timeout),
+                relative_deadline(idle_timeout),
+            ),
             Self::Streaming { idle_timeout } => {
                 idle_timeout.map(|timeout| Instant::now() + timeout)
             }
@@ -969,7 +1008,21 @@ impl StreamTimeoutState {
 
     fn timeout_message(self) -> &'static str {
         match self {
-            Self::AwaitingFirstByte { .. } => "http stream request timeout",
+            Self::AwaitingFirstByte {
+                request_timeout,
+                idle_timeout,
+            } => match (request_timeout, idle_timeout) {
+                (Some(request_timeout), Some(idle_timeout)) => {
+                    if idle_timeout <= request_timeout {
+                        "http stream idle timeout"
+                    } else {
+                        "http stream request timeout"
+                    }
+                }
+                (Some(_), None) => "http stream request timeout",
+                (None, Some(_)) => "http stream idle timeout",
+                (None, None) => "http stream request timeout",
+            },
             Self::Streaming { .. } => "http stream idle timeout",
         }
     }
@@ -977,12 +1030,12 @@ impl StreamTimeoutState {
     fn on_chunk(self, chunk: &Bytes) -> Self {
         match self {
             Self::AwaitingFirstByte {
-                request_deadline,
+                request_timeout,
                 idle_timeout,
             } => {
                 if chunk.is_empty() {
                     Self::AwaitingFirstByte {
-                        request_deadline,
+                        request_timeout,
                         idle_timeout,
                     }
                 } else {
@@ -1014,8 +1067,8 @@ mod tests {
         assert!(matches!(error, super::HttpError::Build { .. }));
     }
 
-    #[test]
-    fn request_compression_conflicts_with_existing_content_encoding() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_compression_conflicts_with_existing_content_encoding() {
         let mut headers = HeaderMap::new();
         headers.insert(super::CONTENT_ENCODING, HeaderValue::from_static("gzip"));
 
@@ -1024,14 +1077,15 @@ mod tests {
             content_type_if_missing: None,
         };
 
-        let error = maybe_compress_body(body, RequestCompression::Zstd, &mut headers)
+        let error = maybe_compress_body(body, RequestCompression::Zstd, &mut headers, None)
+            .await
             .expect_err("content-encoding conflict must fail");
 
         assert!(matches!(error, super::HttpError::Build { .. }));
     }
 
-    #[test]
-    fn json_body_sets_default_content_type() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn json_body_sets_default_content_type() {
         let request = HttpRequest {
             method: HttpMethod::Post,
             url: "https://example.com".to_owned(),
@@ -1051,7 +1105,9 @@ mod tests {
                 ca_bundle_path: None,
                 user_agent: None,
             },
+            None,
         )
+        .await
         .expect("prepare request");
 
         assert_eq!(
@@ -1060,29 +1116,34 @@ mod tests {
         );
     }
 
-    #[test]
-    fn invalid_proxy_url_fails_client_build() {
-        let error = build_client(&ResolvedCallConfig {
-            connect_timeout: None,
-            request_timeout: None,
-            stream_idle_timeout: None,
-            proxy_url: Some("://bad-proxy".to_owned()),
-            ca_bundle_path: None,
-            user_agent: None,
-        })
+    #[tokio::test(flavor = "current_thread")]
+    async fn invalid_proxy_url_fails_client_build() {
+        let error = build_client(
+            &ResolvedCallConfig {
+                connect_timeout: None,
+                request_timeout: None,
+                stream_idle_timeout: None,
+                proxy_url: Some("://bad-proxy".to_owned()),
+                ca_bundle_path: None,
+                user_agent: None,
+            },
+            None,
+        )
+        .await
         .expect_err("invalid proxy must fail");
 
         assert!(matches!(error, super::HttpError::Build { .. }));
     }
 
-    #[test]
-    fn zstd_compression_changes_request_body() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn zstd_compression_changes_request_body() {
         let body = encode_body(HttpRequestBody::Bytes(bytes::Bytes::from_static(
             b"payload",
         )))
         .expect("encode body");
         let mut headers = HeaderMap::new();
-        let compressed = maybe_compress_body(body, RequestCompression::Zstd, &mut headers)
+        let compressed = maybe_compress_body(body, RequestCompression::Zstd, &mut headers, None)
+            .await
             .expect("compress body");
 
         assert_eq!(
@@ -1126,5 +1187,30 @@ mod tests {
 
         let second = wrapped.next().await.expect("second item");
         assert_eq!(second.expect("second chunk"), Bytes::from_static(b"second"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn first_chunk_timeout_starts_on_first_poll() {
+        let inner = stream::unfold(0_u8, |state| async move {
+            match state {
+                0 => {
+                    sleep(Duration::from_millis(10)).await;
+                    Some((Ok(Bytes::from_static(b"first")), 1))
+                }
+                _ => None,
+            }
+        });
+
+        let mut wrapped = wrap_stream(
+            "http://example.test/stream".to_owned(),
+            Some(Duration::from_millis(50)),
+            None,
+            inner,
+        );
+
+        sleep(Duration::from_millis(120)).await;
+
+        let first = wrapped.next().await.expect("first item");
+        assert_eq!(first.expect("first chunk"), Bytes::from_static(b"first"));
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -9,7 +9,7 @@ use http::{
     HeaderMap, HeaderValue, StatusCode,
     header::{
         AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HOST, LOCATION,
-        ORIGIN, PROXY_AUTHORIZATION, REFERER, USER_AGENT,
+        ORIGIN, REFERER, USER_AGENT,
     },
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
@@ -758,7 +758,6 @@ fn strip_origin_bound_headers(headers: &mut HeaderMap) {
     headers.remove(COOKIE);
     headers.remove(HOST);
     headers.remove(ORIGIN);
-    headers.remove(PROXY_AUTHORIZATION);
     headers.remove(REFERER);
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -12,7 +12,7 @@ use http::{
         ORIGIN, REFERER, USER_AGENT,
     },
 };
-use reqwest::{Certificate, Client, Method, Proxy, Url};
+use reqwest::{Certificate, Client, Method, Url};
 use tokio::time::{Instant, timeout_at};
 use tokio::{fs as tokio_fs, task};
 use url::form_urlencoded;
@@ -95,7 +95,6 @@ struct ResolvedCallConfig {
     connect_timeout: Option<Duration>,
     request_timeout: Option<Duration>,
     stream_idle_timeout: Option<Duration>,
-    proxy_url: Option<String>,
     ca_bundle_path: Option<PathBuf>,
     user_agent: Option<String>,
 }
@@ -494,7 +493,6 @@ fn resolve_call_config(
         connect_timeout_ms,
         request_timeout_ms,
         stream_idle_timeout_ms,
-        proxy_url,
         ca_bundle_path,
         user_agent,
     ) = selvedge_config::read(|config| {
@@ -502,7 +500,6 @@ fn resolve_call_config(
             config.network.connect_timeout_ms,
             config.network.request_timeout_ms,
             config.network.stream_idle_timeout_ms,
-            config.network.proxy_url.clone(),
             config.network.ca_bundle_path.clone(),
             config.network.user_agent.clone(),
         )
@@ -517,7 +514,6 @@ fn resolve_call_config(
         connect_timeout: connect_timeout_ms.map(Duration::from_millis),
         request_timeout: timeout_override.or_else(|| request_timeout_ms.map(Duration::from_millis)),
         stream_idle_timeout: stream_idle_timeout_ms.map(Duration::from_millis),
-        proxy_url,
         ca_bundle_path,
         user_agent,
     };
@@ -528,7 +524,6 @@ fn resolve_call_config(
         connect_timeout_ms = duration_millis_or_zero(config.connect_timeout),
         request_timeout_ms = duration_millis_or_zero(config.request_timeout),
         stream_idle_timeout_ms = duration_millis_or_zero(config.stream_idle_timeout),
-        has_proxy = config.proxy_url.is_some(),
         has_ca_bundle = config.ca_bundle_path.is_some(),
         has_user_agent = config.user_agent.is_some()
     );
@@ -693,28 +688,15 @@ async fn build_client(
     if let Some(connect_timeout) = call_config.connect_timeout {
         builder = builder.connect_timeout(connect_timeout);
     }
+    builder = builder.no_proxy();
 
-    if let Some(proxy_url) = &call_config.proxy_url {
-        let proxy = Proxy::all(proxy_url)
-            .map_err(|error| build_error(format!("invalid network.proxy_url: {error}")))?;
-        builder = builder.proxy(proxy);
-    } else {
-        builder = builder.no_proxy();
-    }
+    if let Some(path) = &call_config.ca_bundle_path
+        && uses_tls
+    {
+        let certificates = load_ca_bundle(path, request_deadline).await?;
 
-    if let Some(path) = &call_config.ca_bundle_path {
-        let tls_proxy = call_config
-            .proxy_url
-            .as_deref()
-            .and_then(|proxy_url| Url::parse(proxy_url).ok())
-            .is_some_and(|proxy_url| proxy_url.scheme() == "https");
-
-        if uses_tls || tls_proxy {
-            let certificates = load_ca_bundle(path, request_deadline).await?;
-
-            for certificate in certificates {
-                builder = builder.add_root_certificate(certificate);
-            }
+        for certificate in certificates {
+            builder = builder.add_root_certificate(certificate);
         }
     }
 
@@ -1204,9 +1186,8 @@ impl StreamTimeoutState {
 mod tests {
     use super::{
         HeaderMap, HeaderValue, HttpError, HttpMethod, HttpRequest, HttpRequestBody, PreparedBody,
-        RequestCompression, ResolvedCallConfig, build_client, build_error, encode_body,
-        maybe_compress_body, parse_absolute_http_url, prepare_request, sanitize_url_for_output,
-        wrap_stream,
+        RequestCompression, ResolvedCallConfig, build_error, encode_body, maybe_compress_body,
+        parse_absolute_http_url, prepare_request, sanitize_url_for_output, wrap_stream,
     };
     use std::time::Duration;
 
@@ -1255,7 +1236,6 @@ mod tests {
                 connect_timeout: None,
                 request_timeout: None,
                 stream_idle_timeout: None,
-                proxy_url: None,
                 ca_bundle_path: None,
                 user_agent: None,
             },
@@ -1268,26 +1248,6 @@ mod tests {
             prepared.request.headers().get(super::CONTENT_TYPE),
             Some(&HeaderValue::from_static("application/json"))
         );
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn invalid_proxy_url_fails_client_build() {
-        let error = build_client(
-            &ResolvedCallConfig {
-                connect_timeout: None,
-                request_timeout: None,
-                stream_idle_timeout: None,
-                proxy_url: Some("://bad-proxy".to_owned()),
-                ca_bundle_path: None,
-                user_agent: None,
-            },
-            None,
-            true,
-        )
-        .await
-        .expect_err("invalid proxy must fail");
-
-        assert!(matches!(error, super::HttpError::Build { .. }));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,27 +1,32 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::result_large_err)]
 
-use std::{error::Error as StdError, fmt, io::Write, path::PathBuf, pin::Pin, time::Duration};
+mod config_resolution;
+mod redaction;
+mod request_prep;
+mod runtime;
 
-use bytes::{Bytes, BytesMut};
-use futures::{Stream, StreamExt};
-use http::{
-    HeaderMap, HeaderValue, StatusCode,
-    header::{
-        AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HOST, LOCATION,
-        ORIGIN, REFERER, USER_AGENT,
-    },
+use std::{error::Error as StdError, fmt, pin::Pin, time::Duration};
+
+use futures::Stream;
+use http::{HeaderMap, StatusCode};
+use reqwest::Method;
+use tokio::task;
+
+use crate::{
+    config_resolution::resolve_call_config,
+    redaction::sanitize_url,
+    request_prep::prepare_request,
+    runtime::{RequestBudget, execute_inner, log_result, log_stream_result, stream_inner},
 };
-use reqwest::{Certificate, Client, Method, Url};
-use tokio::time::{Instant, timeout_at};
-use tokio::{fs as tokio_fs, task};
-use url::form_urlencoded;
 
 macro_rules! log_event {
     ($level:expr, $message:expr $(; $($key:ident = $value:expr),+ $(,)?)?) => {{
         let _ = selvedge_logging::selvedge_log!($level, $message $(; $($key = $value),+)?);
     }};
 }
+
+pub(crate) use log_event;
 
 pub type ByteStream = Pin<Box<dyn Stream<Item = Result<bytes::Bytes, HttpError>> + Send + 'static>>;
 
@@ -90,44 +95,6 @@ pub struct HttpStatusError {
     pub body: bytes::Bytes,
 }
 
-#[derive(Debug, Clone)]
-struct ResolvedCallConfig {
-    connect_timeout: Option<Duration>,
-    request_timeout: Option<Duration>,
-    stream_idle_timeout: Option<Duration>,
-    ca_bundle_path: Option<PathBuf>,
-    user_agent: Option<String>,
-}
-
-#[derive(Debug)]
-struct PreparedRequest {
-    request: reqwest::Request,
-    method: HttpMethod,
-    request_url: String,
-    body_len: usize,
-}
-
-#[derive(Debug)]
-enum PreparedBody {
-    Empty,
-    Buffered {
-        bytes: Bytes,
-        content_type_if_missing: Option<HeaderValue>,
-    },
-}
-
-#[derive(Debug, Clone, Copy)]
-enum StreamTimeoutState {
-    AwaitingFirstByte {
-        request_deadline: Option<Instant>,
-        idle_timeout: Option<Duration>,
-    },
-    Streaming {
-        request_deadline: Option<Instant>,
-        idle_timeout: Option<Duration>,
-    },
-}
-
 impl fmt::Debug for HttpStreamResponse {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -186,7 +153,7 @@ impl From<selvedge_config::ConfigError> for HttpError {
 }
 
 pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
-    let sanitized_request_url = sanitize_url_for_output(&request.url);
+    let sanitized_request_url = sanitize_url(&request.url);
     log_event!(
         selvedge_logging::LogLevel::Debug,
         "http request started";
@@ -196,11 +163,7 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
     );
 
     let call_config = resolve_call_config(request.timeout)?;
-    let request_deadline = call_config
-        .request_timeout
-        .map(|duration| Instant::now() + duration);
-    check_request_deadline(request_deadline)?;
-    let prepared = prepare_request(request, &call_config, request_deadline).await?;
+    let prepared = prepare_request(request, &call_config).await?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -214,7 +177,12 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
-    let result = execute_inner(&call_config, prepared, request_deadline).await;
+    let result = execute_inner(
+        &call_config,
+        prepared,
+        RequestBudget::new(call_config.request_timeout),
+    )
+    .await;
 
     log_result("execute", &method, &request_url, body_len, &result);
 
@@ -222,7 +190,7 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
 }
 
 pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpError> {
-    let sanitized_request_url = sanitize_url_for_output(&request.url);
+    let sanitized_request_url = sanitize_url(&request.url);
     log_event!(
         selvedge_logging::LogLevel::Debug,
         "http request started";
@@ -232,11 +200,7 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     );
 
     let call_config = resolve_call_config(request.timeout)?;
-    let request_deadline = call_config
-        .request_timeout
-        .map(|duration| Instant::now() + duration);
-    check_request_deadline(request_deadline)?;
-    let prepared = prepare_request(request, &call_config, request_deadline).await?;
+    let prepared = prepare_request(request, &call_config).await?;
 
     log_event!(
         selvedge_logging::LogLevel::Debug,
@@ -247,17 +211,14 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
         body_len = prepared.body_len
     );
 
-    let idle_timeout = call_config.stream_idle_timeout;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
-
     let result = stream_inner(
         &call_config,
         prepared,
-        call_config.request_timeout,
-        request_deadline,
-        idle_timeout,
+        RequestBudget::new(call_config.request_timeout),
+        call_config.stream_idle_timeout,
     )
     .await;
 
@@ -266,713 +227,19 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     result
 }
 
-async fn execute_inner(
-    call_config: &ResolvedCallConfig,
-    prepared: PreparedRequest,
-    request_deadline: Option<Instant>,
-) -> Result<HttpResponse, HttpError> {
-    let request_url = prepared.request_url.clone();
-    let response = send_with_redirects(call_config, prepared, request_deadline).await?;
-
-    if !response.status().is_success() {
-        return Err(collect_status_error(response, request_deadline, &request_url).await?);
-    }
-
-    let status = response.status();
-    let headers = response.headers().clone();
-    let body = collect_success_body(response, request_deadline, &request_url).await?;
-
-    Ok(HttpResponse {
-        status,
-        headers,
-        body,
-    })
-}
-
-async fn stream_inner(
-    call_config: &ResolvedCallConfig,
-    prepared: PreparedRequest,
-    _request_timeout: Option<Duration>,
-    request_deadline: Option<Instant>,
-    idle_timeout: Option<Duration>,
-) -> Result<HttpStreamResponse, HttpError> {
-    let request_url = prepared.request_url.clone();
-    let response = send_with_redirects(call_config, prepared, request_deadline).await?;
-
-    if !response.status().is_success() {
-        return Err(collect_status_error(response, request_deadline, &request_url).await?);
-    }
-
-    let status = response.status();
-    let headers = response.headers().clone();
-    let body = wrap_stream(
-        request_url,
-        request_deadline,
-        idle_timeout,
-        response.bytes_stream(),
-    );
-
-    Ok(HttpStreamResponse {
-        status,
-        headers,
-        body,
-    })
-}
-
-async fn send(
-    client: Client,
-    request: reqwest::Request,
-    request_url: &str,
-) -> Result<reqwest::Response, HttpError> {
-    client
-        .execute(request)
-        .await
-        .map_err(|error| map_transport_error(error, request_url))
-}
-
-async fn send_with_redirects(
-    call_config: &ResolvedCallConfig,
-    prepared: PreparedRequest,
-    request_deadline: Option<Instant>,
-) -> Result<reqwest::Response, HttpError> {
-    let mut request = prepared.request;
-    let method = prepared.method;
-    let mut redirect_count = 0_usize;
-
-    loop {
-        check_request_deadline(request_deadline)?;
-        let current_request_url = sanitize_url_for_output(request.url().as_str());
-        let client = build_client(
-            call_config,
-            request_deadline,
-            request.url().scheme() == "https",
-        )
-        .await?;
-        let redirect_template = if matches!(method, HttpMethod::Get) {
-            Some(
-                request
-                    .try_clone()
-                    .ok_or_else(|| build_error("failed to clone redirectable request"))?,
-            )
-        } else {
-            None
-        };
-        let response =
-            send_with_deadline(client, request, &current_request_url, request_deadline).await?;
-
-        if matches!(method, HttpMethod::Get) && response.status().is_redirection() {
-            if redirect_count >= 10 {
-                return Err(build_error("too many redirects"));
-            }
-
-            let Some(location) = response.headers().get(LOCATION) else {
-                return Ok(response);
-            };
-            let location = location.to_str().map_err(|error| {
-                build_error(format!("invalid redirect location header: {error}"))
-            })?;
-            let next_url = response
-                .url()
-                .join(location)
-                .map_err(|error| build_error(format!("invalid redirect target URL: {error}")))?;
-            let mut next_request = redirect_template
-                .ok_or_else(|| build_error("missing redirect request template"))?;
-            if !same_origin(response.url(), &next_url) {
-                strip_origin_bound_headers(next_request.headers_mut());
-            }
-            *next_request.url_mut() = next_url;
-            request = next_request;
-            redirect_count += 1;
-            continue;
-        }
-
-        return Ok(response);
-    }
-}
-
-async fn send_with_deadline(
-    client: Client,
-    request: reqwest::Request,
-    request_url: &str,
-    deadline: Option<Instant>,
-) -> Result<reqwest::Response, HttpError> {
-    match deadline {
-        Some(deadline) => timeout_at(deadline, client.execute(request))
-            .await
-            .map_err(|_| HttpError::Timeout)?
-            .map_err(|error| map_transport_error(error, request_url)),
-        None => send(client, request, request_url).await,
-    }
-}
-
-async fn collect_status_error(
-    response: reqwest::Response,
-    deadline: Option<Instant>,
-    request_url: &str,
-) -> Result<HttpError, HttpError> {
-    let url = sanitize_url_for_output(response.url().as_str());
-    let status = response.status();
-    let headers = response.headers().clone();
-    let mut body = BytesMut::new();
-    let mut stream = Box::pin(response.bytes_stream());
-
-    loop {
-        let next_chunk = match deadline {
-            Some(deadline) => match timeout_at(deadline, stream.next()).await {
-                Ok(next_chunk) => next_chunk,
-                Err(_) => {
-                    log_event!(
-                        selvedge_logging::LogLevel::Warn,
-                        "http non-success response body timed out";
-                        url = url.as_str(),
-                        status = status.as_u16()
-                    );
-                    return Err(HttpError::Timeout);
-                }
-            },
-            None => stream.next().await,
-        };
-
-        match next_chunk {
-            Some(Ok(chunk)) => body.extend_from_slice(&chunk),
-            Some(Err(error)) => {
-                let mapped = map_transport_error(error, request_url);
-                log_event!(
-                    selvedge_logging::LogLevel::Warn,
-                    "http non-success response body truncated";
-                    url = url.as_str(),
-                    status = status.as_u16(),
-                    error = mapped.to_string()
-                );
-                break;
-            }
-            None => break,
-        }
-    }
-
-    Ok(HttpError::Status(HttpStatusError {
-        url,
-        status,
-        headers,
-        body: body.freeze(),
-    }))
-}
-
-async fn collect_success_body(
-    response: reqwest::Response,
-    deadline: Option<Instant>,
-    request_url: &str,
-) -> Result<Bytes, HttpError> {
-    let mut body = BytesMut::new();
-    let mut stream = Box::pin(response.bytes_stream());
-
-    loop {
-        let next_chunk = match deadline {
-            Some(deadline) => timeout_at(deadline, stream.next())
-                .await
-                .map_err(|_| HttpError::Timeout)?,
-            None => stream.next().await,
-        };
-
-        match next_chunk {
-            Some(Ok(chunk)) => body.extend_from_slice(&chunk),
-            Some(Err(error)) => return Err(map_transport_error(error, request_url)),
-            None => return Ok(body.freeze()),
-        }
-    }
-}
-
-fn resolve_call_config(
-    timeout_override: Option<Duration>,
-) -> Result<ResolvedCallConfig, HttpError> {
-    if timeout_override.is_some_and(|timeout| timeout.is_zero()) {
-        return Err(build_error("request.timeout must be greater than zero"));
-    }
-
-    let (
-        connect_timeout_ms,
-        request_timeout_ms,
-        stream_idle_timeout_ms,
-        ca_bundle_path,
-        user_agent,
-    ) = selvedge_config::read(|config| {
-        (
-            config.network.connect_timeout_ms,
-            config.network.request_timeout_ms,
-            config.network.stream_idle_timeout_ms,
-            config.network.ca_bundle_path.clone(),
-            config.network.user_agent.clone(),
-        )
-    })?;
-
-    let ca_bundle_path = match ca_bundle_path {
-        Some(path) if path.is_relative() => Some(selvedge_config::selvedge_home()?.join(path)),
-        other => other,
-    };
-
-    let config = ResolvedCallConfig {
-        connect_timeout: connect_timeout_ms.map(Duration::from_millis),
-        request_timeout: timeout_override.or_else(|| request_timeout_ms.map(Duration::from_millis)),
-        stream_idle_timeout: stream_idle_timeout_ms.map(Duration::from_millis),
-        ca_bundle_path,
-        user_agent,
-    };
-
-    log_event!(
-        selvedge_logging::LogLevel::Debug,
-        "http config resolved";
-        connect_timeout_ms = duration_millis_or_zero(config.connect_timeout),
-        request_timeout_ms = duration_millis_or_zero(config.request_timeout),
-        stream_idle_timeout_ms = duration_millis_or_zero(config.stream_idle_timeout),
-        has_ca_bundle = config.ca_bundle_path.is_some(),
-        has_user_agent = config.user_agent.is_some()
-    );
-
-    Ok(config)
-}
-
-async fn prepare_request(
-    request: HttpRequest,
-    call_config: &ResolvedCallConfig,
-    request_deadline: Option<Instant>,
-) -> Result<PreparedRequest, HttpError> {
-    let url = parse_absolute_http_url(&request.url)?;
-    let mut headers = request.headers;
-    let mut body = encode_body(request.body)?;
-
-    if !headers.contains_key(USER_AGENT)
-        && let Some(user_agent) = &call_config.user_agent
-    {
-        let user_agent = HeaderValue::from_str(user_agent)
-            .map_err(|error| build_error(format!("invalid network.user_agent header: {error}")))?;
-        headers.insert(USER_AGENT, user_agent);
-    }
-
-    finalize_headers(&mut headers, &body);
-    body = maybe_compress_body(body, request.compression, &mut headers, request_deadline).await?;
-
-    let body_len = body.len();
-    reconcile_content_length(&body, &mut headers)?;
-    let mut reqwest_request = reqwest::Request::new(request.method.clone().into(), url);
-    *reqwest_request.headers_mut() = headers;
-
-    if let Some(bytes) = body.into_bytes() {
-        *reqwest_request.body_mut() = Some(bytes.into());
-    }
-
-    Ok(PreparedRequest {
-        request: reqwest_request,
-        method: request.method,
-        request_url: sanitize_url_for_output(&request.url),
-        body_len,
-    })
-}
-
-fn reconcile_content_length(body: &PreparedBody, headers: &mut HeaderMap) -> Result<(), HttpError> {
-    if headers.contains_key(CONTENT_LENGTH) {
-        let content_length = HeaderValue::from_str(&body.len().to_string()).map_err(|error| {
-            build_error(format!("invalid computed Content-Length header: {error}"))
-        })?;
-        headers.insert(CONTENT_LENGTH, content_length);
-    }
-
-    Ok(())
-}
-
-fn parse_absolute_http_url(url: &str) -> Result<Url, HttpError> {
-    let parsed = Url::parse(url)
-        .map_err(|error| build_error(format!("url must be an absolute URL: {error}")))?;
-
-    if !parsed.has_host() || parsed.cannot_be_a_base() {
-        return Err(build_error("url must be an absolute URL"));
-    }
-
-    match parsed.scheme() {
-        "http" | "https" => Ok(parsed),
-        other => Err(build_error(format!(
-            "url scheme must be http or https, got {other}"
-        ))),
-    }
-}
-
-fn encode_body(body: HttpRequestBody) -> Result<PreparedBody, HttpError> {
-    match body {
-        HttpRequestBody::Empty => Ok(PreparedBody::Empty),
-        HttpRequestBody::Json(value) => {
-            let bytes = serde_json::to_vec(&value)
-                .map(Bytes::from)
-                .map_err(|error| build_error(format!("failed to encode json body: {error}")))?;
-
-            Ok(PreparedBody::Buffered {
-                bytes,
-                content_type_if_missing: Some(HeaderValue::from_static("application/json")),
-            })
-        }
-        HttpRequestBody::FormUrlEncoded(pairs) => {
-            let mut encoded = pairs.into_iter().fold(
-                form_urlencoded::Serializer::new(String::new()),
-                |mut serializer, (key, value)| {
-                    serializer.append_pair(&key, &value);
-                    serializer
-                },
-            );
-
-            Ok(PreparedBody::Buffered {
-                bytes: Bytes::from(encoded.finish()),
-                content_type_if_missing: Some(HeaderValue::from_static(
-                    "application/x-www-form-urlencoded",
-                )),
-            })
-        }
-        HttpRequestBody::Bytes(bytes) => Ok(PreparedBody::Buffered {
-            bytes,
-            content_type_if_missing: None,
-        }),
-    }
-}
-
-fn finalize_headers(headers: &mut HeaderMap, body: &PreparedBody) {
-    if let PreparedBody::Buffered {
-        content_type_if_missing: Some(content_type),
-        ..
-    } = body
-        && !headers.contains_key(CONTENT_TYPE)
-    {
-        headers.insert(CONTENT_TYPE, content_type.clone());
-    }
-}
-
-async fn maybe_compress_body(
-    body: PreparedBody,
-    compression: RequestCompression,
-    headers: &mut HeaderMap,
-    request_deadline: Option<Instant>,
-) -> Result<PreparedBody, HttpError> {
-    match (body, compression) {
-        (PreparedBody::Empty, _) => Ok(PreparedBody::Empty),
-        (body, RequestCompression::None) => Ok(body),
-        (
-            PreparedBody::Buffered {
-                bytes,
-                content_type_if_missing,
-            },
-            RequestCompression::Zstd,
-        ) => {
-            if headers.contains_key(CONTENT_ENCODING) {
-                return Err(build_error(
-                    "cannot apply request compression when Content-Encoding is already set",
-                ));
-            }
-
-            let compressed =
-                run_blocking(move || compress_bytes_with_deadline(bytes, request_deadline)).await?;
-            headers.insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
-
-            Ok(PreparedBody::Buffered {
-                bytes: compressed,
-                content_type_if_missing,
-            })
-        }
-    }
-}
-
-async fn build_client(
-    call_config: &ResolvedCallConfig,
-    request_deadline: Option<Instant>,
-    uses_tls: bool,
-) -> Result<Client, HttpError> {
-    let mut builder = Client::builder()
-        .retry(reqwest::retry::never())
-        .redirect(reqwest::redirect::Policy::none());
-
-    if let Some(connect_timeout) = call_config.connect_timeout {
-        builder = builder.connect_timeout(connect_timeout);
-    }
-    builder = builder.no_proxy();
-
-    if let Some(path) = &call_config.ca_bundle_path
-        && uses_tls
-    {
-        let certificates = load_ca_bundle(path, request_deadline).await?;
-
-        for certificate in certificates {
-            builder = builder.add_root_certificate(certificate);
-        }
-    }
-
-    builder
-        .build()
-        .map_err(|error| build_error(format!("failed to build http client: {error}")))
-}
-
-async fn load_ca_bundle(
-    path: &std::path::Path,
-    request_deadline: Option<Instant>,
-) -> Result<Vec<Certificate>, HttpError> {
-    let bundle = match request_deadline {
-        Some(deadline) => timeout_at(deadline, tokio_fs::read(path))
-            .await
-            .map_err(|_| HttpError::Timeout)?,
-        None => tokio_fs::read(path).await,
-    }
-    .map_err(|error| {
-        build_error(format!(
-            "failed to read network.ca_bundle_path {}: {error}",
-            path.display()
-        ))
-    })?;
-    check_request_deadline(request_deadline)?;
-    let path = path.to_path_buf();
-
-    run_blocking(move || {
-        parse_certificates(&bundle, request_deadline).map_err(|error| {
-            build_error(format!(
-                "failed to parse network.ca_bundle_path {}: {error}",
-                path.display()
-            ))
-        })
-    })
-    .await
-}
-
-fn same_origin(left: &Url, right: &Url) -> bool {
-    left.scheme() == right.scheme()
-        && left.host_str() == right.host_str()
-        && left.port_or_known_default() == right.port_or_known_default()
-}
-
-fn strip_origin_bound_headers(headers: &mut HeaderMap) {
-    headers.remove(AUTHORIZATION);
-    headers.remove(COOKIE);
-    headers.remove(HOST);
-    headers.remove(ORIGIN);
-    headers.remove(REFERER);
-}
-
-fn parse_certificates(
-    bundle: &[u8],
-    request_deadline: Option<Instant>,
-) -> Result<Vec<Certificate>, HttpError> {
-    let mut reader = bundle;
-    let mut certificates = Vec::new();
-
-    for parsed in rustls_pemfile::certs(&mut reader) {
-        check_request_deadline(request_deadline)?;
-        let parsed = parsed
-            .map_err(|error| build_error(format!("failed to parse pem certificate: {error}")))?;
-        let certificate = Certificate::from_der(parsed.as_ref())
-            .map_err(|error| build_error(format!("failed to load pem certificate: {error}")))?;
-        certificates.push(certificate);
-    }
-
-    check_request_deadline(request_deadline)?;
-
-    if certificates.is_empty() {
-        return Err(build_error("ca bundle did not contain any certificates"));
-    }
-
-    Ok(certificates)
-}
-
-fn compress_bytes_with_deadline(
-    bytes: Bytes,
-    deadline: Option<Instant>,
-) -> Result<Bytes, HttpError> {
-    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0)
-        .map_err(|error| build_error(format!("failed to start zstd encoder: {error}")))?;
-
-    for chunk in bytes.chunks(64 * 1024) {
-        check_request_deadline(deadline)?;
-        encoder
-            .write_all(chunk)
-            .map_err(|error| build_error(format!("failed to encode zstd body: {error}")))?;
-    }
-
-    check_request_deadline(deadline)?;
-
-    let compressed = encoder
-        .finish()
-        .map_err(|error| build_error(format!("failed to finish zstd body: {error}")))?;
-
-    Ok(Bytes::from(compressed))
-}
-
-fn sanitize_url_for_output(raw_url: &str) -> String {
-    let Ok(mut parsed) = Url::parse(raw_url) else {
-        return "<invalid-url>".to_owned();
-    };
-
-    if !parsed.username().is_empty() {
-        let _ = parsed.set_username("");
-    }
-
-    if parsed.password().is_some() {
-        let _ = parsed.set_password(None);
-    }
-
-    parsed.set_query(None);
-    parsed.set_fragment(None);
-
-    parsed.to_string()
-}
-
-fn wrap_stream(
-    request_url: String,
-    request_deadline: Option<Instant>,
-    idle_timeout: Option<Duration>,
-    stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
-) -> ByteStream {
-    let stream = async_stream::stream! {
-        let mut stream = Box::pin(stream);
-        let mut timeout_state = StreamTimeoutState::AwaitingFirstByte {
-            request_deadline,
-            idle_timeout,
-        };
-
-        loop {
-            let next_item = match timeout_state.deadline() {
-                Some(deadline) => match timeout_at(deadline, stream.next()).await {
-                    Ok(item) => item,
-                    Err(_) => {
-                        log_event!(
-                            selvedge_logging::LogLevel::Warn,
-                            timeout_state.timeout_message();
-                            mode = "stream",
-                            url = request_url.as_str()
-                        );
-                        yield Err(HttpError::Timeout);
-                        break;
-                    }
-                },
-                None => stream.next().await,
-            };
-
-            match next_item {
-                Some(Ok(bytes)) => {
-                    timeout_state = timeout_state.on_chunk(&bytes);
-                    yield Ok(bytes);
-                }
-                Some(Err(error)) => {
-                    let mapped = map_transport_error(error, &request_url);
-                    log_transport_error("stream", &request_url, &mapped);
-                    yield Err(mapped);
-                    break;
-                }
-                None => {
-                    log_event!(
-                        selvedge_logging::LogLevel::Debug,
-                        "http stream finished";
-                        mode = "stream",
-                        url = request_url.as_str(),
-                        outcome = "success"
-                    );
-                    break;
-                }
-            }
-        }
-    };
-
-    Box::pin(stream)
-}
-
-fn map_transport_error(error: reqwest::Error, request_url: &str) -> HttpError {
-    let mut rendered = render_error_chain(&error);
-
-    if let Some(url) = error.url() {
-        rendered = rendered.replace(url.as_str(), &sanitize_url_for_output(url.as_str()));
-    }
-
-    let reason = format!("{request_url}: {rendered}");
-
-    if error.is_timeout() {
-        HttpError::Timeout
-    } else if is_tls_error(&error) {
-        HttpError::Tls { reason }
-    } else if error.is_connect() {
-        HttpError::Connect { reason }
-    } else if error.is_builder() || error.is_redirect() || error.is_request() {
-        HttpError::Build { reason }
-    } else {
-        HttpError::Io { reason }
-    }
-}
-
-fn is_tls_error(error: &reqwest::Error) -> bool {
-    let mut source = error.source();
-
-    while let Some(current) = source {
-        let reason = current.to_string().to_ascii_lowercase();
-
-        if [
-            "tls",
-            "rustls",
-            "certificate",
-            "unknown issuer",
-            "self-signed",
-            "dns name",
-            "handshake",
-            "webpki",
-            "peer sent no certificates",
-            "not valid for name",
-        ]
-        .iter()
-        .any(|needle| reason.contains(needle))
-        {
-            return true;
-        }
-
-        source = current.source();
-    }
-
-    false
-}
-
-fn render_error_chain(error: &dyn StdError) -> String {
-    let mut parts = vec![error.to_string()];
-    let mut source = error.source();
-
-    while let Some(current) = source {
-        parts.push(current.to_string());
-        source = current.source();
-    }
-
-    parts.join(": ")
-}
-
-fn build_error(reason: impl Into<String>) -> HttpError {
+pub(crate) fn build_error(reason: impl Into<String>) -> HttpError {
     HttpError::Build {
         reason: reason.into(),
     }
 }
 
-fn duration_millis_or_zero(duration: Option<Duration>) -> u64 {
+pub(crate) fn duration_millis_or_zero(duration: Option<Duration>) -> u64 {
     duration
         .map(|timeout| timeout.as_millis() as u64)
         .unwrap_or(0)
 }
 
-fn relative_deadline(timeout: Option<Duration>) -> Option<Instant> {
-    timeout.map(|timeout| Instant::now() + timeout)
-}
-
-fn min_deadline(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
-    match (left, right) {
-        (Some(left), Some(right)) => Some(left.min(right)),
-        (Some(left), None) => Some(left),
-        (None, Some(right)) => Some(right),
-        (None, None) => None,
-    }
-}
-
-fn check_request_deadline(deadline: Option<Instant>) -> Result<(), HttpError> {
-    if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
-        return Err(HttpError::Timeout);
-    }
-
-    Ok(())
-}
-
-async fn run_blocking<T, F>(operation: F) -> Result<T, HttpError>
+pub(crate) async fn run_blocking<T, F>(operation: F) -> Result<T, HttpError>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T, HttpError> + Send + 'static,
@@ -980,96 +247,6 @@ where
     let task = task::spawn_blocking(operation);
 
     task.await.expect("blocking task must not panic")
-}
-
-fn log_result<T>(
-    mode: &str,
-    method: &HttpMethod,
-    request_url: &str,
-    body_len: usize,
-    result: &Result<T, HttpError>,
-) {
-    match result {
-        Ok(_) => {
-            log_event!(
-                selvedge_logging::LogLevel::Debug,
-                "http request finished";
-                mode = mode,
-                method = method.as_str(),
-                url = request_url,
-                body_len = body_len,
-                outcome = "success"
-            );
-        }
-        Err(HttpError::Status(error)) => {
-            log_event!(
-                selvedge_logging::LogLevel::Warn,
-                "http request returned non-success status";
-                mode = mode,
-                method = method.as_str(),
-                url = error.url.as_str(),
-                status = error.status.as_u16(),
-                body_len = error.body.len()
-            );
-        }
-        Err(error) => {
-            log_transport_error(mode, request_url, error);
-        }
-    }
-}
-
-fn log_stream_result(
-    method: &HttpMethod,
-    request_url: &str,
-    body_len: usize,
-    result: &Result<HttpStreamResponse, HttpError>,
-) {
-    match result {
-        Ok(_) => {
-            log_event!(
-                selvedge_logging::LogLevel::Debug,
-                "http stream established";
-                mode = "stream",
-                method = method.as_str(),
-                url = request_url,
-                body_len = body_len
-            );
-        }
-        Err(HttpError::Status(error)) => {
-            log_event!(
-                selvedge_logging::LogLevel::Warn,
-                "http request returned non-success status";
-                mode = "stream",
-                method = method.as_str(),
-                url = error.url.as_str(),
-                status = error.status.as_u16(),
-                body_len = error.body.len()
-            );
-        }
-        Err(error) => {
-            log_transport_error("stream", request_url, error);
-        }
-    }
-}
-
-fn log_transport_error(mode: &str, request_url: &str, error: &HttpError) {
-    let message = match error {
-        HttpError::Timeout => "http request timed out",
-        HttpError::Connect { .. } => "http request connect failure",
-        HttpError::Tls { .. } => "http request tls failure",
-        HttpError::Io { .. } => "http request i/o failure",
-        HttpError::Build { .. } => "http request build failure",
-        HttpError::Config { .. } => "http request config failure",
-        HttpError::Status(_) => "http request status failure",
-    };
-
-    log_event!(
-        selvedge_logging::LogLevel::Warn,
-        message;
-        mode = mode,
-        url = request_url,
-        error = error.to_string()
-    );
 }
 
 impl HttpMethod {
@@ -1096,127 +273,52 @@ impl From<HttpMethod> for Method {
     }
 }
 
-impl PreparedBody {
-    fn into_bytes(self) -> Option<Bytes> {
-        match self {
-            Self::Empty => None,
-            Self::Buffered { bytes, .. } => Some(bytes),
-        }
-    }
-
-    fn len(&self) -> usize {
-        match self {
-            Self::Empty => 0,
-            Self::Buffered { bytes, .. } => bytes.len(),
-        }
-    }
-}
-
-impl StreamTimeoutState {
-    fn deadline(self) -> Option<Instant> {
-        match self {
-            Self::AwaitingFirstByte {
-                request_deadline,
-                idle_timeout,
-            }
-            | Self::Streaming {
-                request_deadline,
-                idle_timeout,
-            } => min_deadline(request_deadline, relative_deadline(idle_timeout)),
-        }
-    }
-
-    fn timeout_message(self) -> &'static str {
-        match self {
-            Self::AwaitingFirstByte {
-                request_deadline,
-                idle_timeout,
-            }
-            | Self::Streaming {
-                request_deadline,
-                idle_timeout,
-            } => match (request_deadline, idle_timeout) {
-                (Some(request_deadline), Some(idle_timeout)) => {
-                    let request_remaining =
-                        request_deadline.saturating_duration_since(Instant::now());
-
-                    if idle_timeout <= request_remaining {
-                        "http stream idle timeout"
-                    } else {
-                        "http stream request timeout"
-                    }
-                }
-                (Some(_), None) => "http stream request timeout",
-                (None, Some(_)) => "http stream idle timeout",
-                (None, None) => "http stream request timeout",
-            },
-        }
-    }
-
-    fn on_chunk(self, chunk: &Bytes) -> Self {
-        match self {
-            Self::AwaitingFirstByte {
-                request_deadline,
-                idle_timeout,
-            } => {
-                if chunk.is_empty() {
-                    Self::AwaitingFirstByte {
-                        request_deadline,
-                        idle_timeout,
-                    }
-                } else {
-                    Self::Streaming {
-                        request_deadline,
-                        idle_timeout,
-                    }
-                }
-            }
-            Self::Streaming {
-                request_deadline,
-                idle_timeout,
-            } => Self::Streaming {
-                request_deadline,
-                idle_timeout,
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        HeaderMap, HeaderValue, HttpError, HttpMethod, HttpRequest, HttpRequestBody, PreparedBody,
-        RequestCompression, ResolvedCallConfig, build_error, encode_body, maybe_compress_body,
-        parse_absolute_http_url, prepare_request, sanitize_url_for_output, wrap_stream,
-    };
     use std::time::Duration;
 
     use bytes::Bytes;
     use futures::{StreamExt, stream};
-    use tokio::time::{Instant, sleep};
+    use http::{HeaderMap, HeaderValue};
+    use tokio::time::sleep;
+    use url::Url;
+
+    use crate::{
+        HttpError, HttpMethod, HttpRequest, HttpRequestBody, RequestCompression, build_error,
+        config_resolution::ResolvedCallConfig,
+        redaction::{sanitize_error_text, sanitize_url},
+        request_prep::{
+            PreparedBody, encode_body, maybe_compress_body, parse_absolute_http_url,
+            prepare_request,
+        },
+        runtime::{RequestBudget, wrap_stream},
+    };
 
     #[test]
     fn absolute_http_url_is_required() {
         let error = parse_absolute_http_url("/relative").expect_err("relative url must fail");
 
-        assert!(matches!(error, super::HttpError::Build { .. }));
+        assert!(matches!(error, HttpError::Build { .. }));
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_compression_conflicts_with_existing_content_encoding() {
         let mut headers = HeaderMap::new();
-        headers.insert(super::CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+        headers.insert(
+            http::header::CONTENT_ENCODING,
+            HeaderValue::from_static("gzip"),
+        );
 
         let body = PreparedBody::Buffered {
-            bytes: bytes::Bytes::from_static(b"payload"),
+            bytes: Bytes::from_static(b"payload"),
             content_type_if_missing: None,
         };
 
-        let error = maybe_compress_body(body, RequestCompression::Zstd, &mut headers, None)
+        let error = maybe_compress_body(body, RequestCompression::Zstd, &mut headers)
             .await
             .expect_err("content-encoding conflict must fail");
 
-        assert!(matches!(error, super::HttpError::Build { .. }));
+        assert!(matches!(error, HttpError::Build { .. }));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1239,30 +341,27 @@ mod tests {
                 ca_bundle_path: None,
                 user_agent: None,
             },
-            None,
         )
         .await
         .expect("prepare request");
 
         assert_eq!(
-            prepared.request.headers().get(super::CONTENT_TYPE),
+            prepared.request.headers().get(http::header::CONTENT_TYPE),
             Some(&HeaderValue::from_static("application/json"))
         );
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn zstd_compression_changes_request_body() {
-        let body = encode_body(HttpRequestBody::Bytes(bytes::Bytes::from_static(
-            b"payload",
-        )))
-        .expect("encode body");
+        let body = encode_body(HttpRequestBody::Bytes(Bytes::from_static(b"payload")))
+            .expect("encode body");
         let mut headers = HeaderMap::new();
-        let compressed = maybe_compress_body(body, RequestCompression::Zstd, &mut headers, None)
+        let compressed = maybe_compress_body(body, RequestCompression::Zstd, &mut headers)
             .await
             .expect("compress body");
 
         assert_eq!(
-            headers.get(super::CONTENT_ENCODING),
+            headers.get(http::header::CONTENT_ENCODING),
             Some(&HeaderValue::from_static("zstd"))
         );
         assert!(compressed.len() > 0);
@@ -1272,7 +371,7 @@ mod tests {
     fn build_error_has_stable_shape() {
         let error = build_error("reason");
 
-        assert!(matches!(error, super::HttpError::Build { reason } if reason == "reason"));
+        assert!(matches!(error, HttpError::Build { reason } if reason == "reason"));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1290,7 +389,7 @@ mod tests {
 
         let mut wrapped = wrap_stream(
             "http://example.test/stream".to_owned(),
-            None,
+            RequestBudget::new(None),
             Some(Duration::from_millis(50)),
             inner,
         );
@@ -1305,20 +404,17 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn first_chunk_timeout_uses_absolute_deadline() {
+    async fn request_budget_starts_when_waiting_for_first_chunk() {
         let inner = stream::unfold(0_u8, |state| async move {
             match state {
-                0 => {
-                    sleep(Duration::from_millis(10)).await;
-                    Some((Ok(Bytes::from_static(b"first")), 1))
-                }
+                0 => Some((Ok(Bytes::from_static(b"first")), 1)),
                 _ => None,
             }
         });
 
         let mut wrapped = wrap_stream(
             "http://example.test/stream".to_owned(),
-            Some(Instant::now() + Duration::from_millis(50)),
+            RequestBudget::new(Some(Duration::from_millis(50))),
             None,
             inner,
         );
@@ -1326,22 +422,33 @@ mod tests {
         sleep(Duration::from_millis(120)).await;
 
         let first = wrapped.next().await.expect("first item");
-        assert!(matches!(first, Err(HttpError::Timeout)));
+        assert_eq!(first.expect("first chunk"), Bytes::from_static(b"first"));
     }
 
     #[test]
-    fn sanitized_url_removes_userinfo_query_and_fragment() {
-        let sanitized = sanitize_url_for_output(
-            "https://user:pass@example.com/path?access_token=secret#fragment",
-        );
+    fn sanitize_url_removes_sensitive_parts() {
+        let sanitized =
+            sanitize_url("https://user:pass@example.com:8443/path?token=secret#fragment");
 
-        assert_eq!(sanitized, "https://example.com/path");
+        assert_eq!(sanitized.as_str(), "https://example.com:8443/path");
     }
 
     #[test]
-    fn sanitized_invalid_url_does_not_echo_raw_input() {
-        let sanitized = sanitize_url_for_output("://user:pass@example.com/?token=secret");
+    fn sanitize_url_hides_invalid_input() {
+        let sanitized = sanitize_url("not a valid url\r\nsecret");
 
-        assert_eq!(sanitized, "<invalid-url>");
+        assert_eq!(sanitized.as_str(), "<invalid-url>");
+    }
+
+    #[test]
+    fn sanitize_error_text_replaces_known_urls() {
+        let url =
+            Url::parse("https://user:pass@example.com/path?token=secret").expect("parse known url");
+        let raw = format!("connect error for {}", url.as_str());
+        let sanitized = sanitize_error_text(&raw, &[url.as_str()]);
+
+        assert!(sanitized.contains("https://example.com/path"));
+        assert!(!sanitized.contains("user:pass"));
+        assert!(!sanitized.contains("token=secret"));
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -314,7 +314,7 @@ async fn stream_inner(
     let headers = response.headers().clone();
     let body = wrap_stream(
         prepared.request_url.clone(),
-        request_timeout,
+        request_timeout.and_then(|_| remaining_duration_until(request_deadline)),
         idle_timeout,
         response.bytes_stream(),
     );
@@ -822,6 +822,10 @@ fn duration_millis_or_zero(duration: Option<Duration>) -> u64 {
 
 fn relative_deadline(timeout: Option<Duration>) -> Option<Instant> {
     timeout.map(|timeout| Instant::now() + timeout)
+}
+
+fn remaining_duration_until(deadline: Option<Instant>) -> Option<Duration> {
+    deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()))
 }
 
 fn min_deadline(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -213,6 +213,7 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
         &call_config,
         request_deadline,
         prepared.request.url().scheme() == "https",
+        &prepared.method,
     )
     .await?;
     let request_url = prepared.request_url.clone();
@@ -255,6 +256,7 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
         &call_config,
         request_deadline,
         prepared.request.url().scheme() == "https",
+        &prepared.method,
     )
     .await?;
     let idle_timeout = call_config.stream_idle_timeout;
@@ -639,8 +641,16 @@ async fn build_client(
     call_config: &ResolvedCallConfig,
     request_deadline: Option<Instant>,
     uses_tls: bool,
+    method: &HttpMethod,
 ) -> Result<Client, HttpError> {
-    let mut builder = Client::builder().retry(reqwest::retry::never());
+    let redirect_policy = if matches!(method, HttpMethod::Get) {
+        reqwest::redirect::Policy::limited(10)
+    } else {
+        reqwest::redirect::Policy::none()
+    };
+    let mut builder = Client::builder()
+        .retry(reqwest::retry::never())
+        .redirect(redirect_policy);
 
     if let Some(connect_timeout) = call_config.connect_timeout {
         builder = builder.connect_timeout(connect_timeout);
@@ -654,7 +664,9 @@ async fn build_client(
         builder = builder.no_proxy();
     }
 
-    if uses_tls && let Some(path) = &call_config.ca_bundle_path {
+    if should_load_ca_bundle(call_config, uses_tls, method)
+        && let Some(path) = &call_config.ca_bundle_path
+    {
         let bundle = match request_deadline {
             Some(deadline) => timeout_at(deadline, tokio_fs::read(path))
                 .await
@@ -687,6 +699,22 @@ async fn build_client(
     builder
         .build()
         .map_err(|error| build_error(format!("failed to build http client: {error}")))
+}
+
+fn should_load_ca_bundle(
+    call_config: &ResolvedCallConfig,
+    uses_tls: bool,
+    method: &HttpMethod,
+) -> bool {
+    if uses_tls || matches!(method, HttpMethod::Get) {
+        return true;
+    }
+
+    call_config
+        .proxy_url
+        .as_deref()
+        .and_then(|proxy_url| Url::parse(proxy_url).ok())
+        .is_some_and(|proxy_url| proxy_url.scheme() == "https")
 }
 
 fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
@@ -1232,6 +1260,7 @@ mod tests {
             },
             None,
             true,
+            &HttpMethod::Get,
         )
         .await
         .expect_err("invalid proxy must fail");

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -627,6 +627,8 @@ fn build_client(call_config: &ResolvedCallConfig) -> Result<Client, HttpError> {
         let proxy = Proxy::all(proxy_url)
             .map_err(|error| build_error(format!("invalid network.proxy_url: {error}")))?;
         builder = builder.proxy(proxy);
+    } else {
+        builder = builder.no_proxy();
     }
 
     if let Some(path) = &call_config.ca_bundle_path {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -620,8 +620,6 @@ fn build_client(call_config: &ResolvedCallConfig) -> Result<Client, HttpError> {
         let proxy = Proxy::all(proxy_url)
             .map_err(|error| build_error(format!("invalid network.proxy_url: {error}")))?;
         builder = builder.proxy(proxy);
-    } else {
-        builder = builder.no_proxy();
     }
 
     if let Some(path) = &call_config.ca_bundle_path {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -7,7 +7,10 @@ use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
     HeaderMap, HeaderValue, StatusCode,
-    header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, USER_AGENT},
+    header::{
+        AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HOST, LOCATION,
+        ORIGIN, PROXY_AUTHORIZATION, REFERER, USER_AGENT,
+    },
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
 use tokio::time::{Instant, timeout_at};
@@ -374,6 +377,9 @@ async fn send_with_redirects(
                 .map_err(|error| build_error(format!("invalid redirect target URL: {error}")))?;
             let mut next_request = redirect_template
                 .ok_or_else(|| build_error("missing redirect request template"))?;
+            if !same_origin(response.url(), &next_url) {
+                strip_origin_bound_headers(next_request.headers_mut());
+            }
             *next_request.url_mut() = next_url;
             request = next_request;
             redirect_count += 1;
@@ -731,7 +737,7 @@ async fn load_ca_bundle(
     let path = path.to_path_buf();
 
     run_blocking(move || {
-        parse_certificates(&bundle).map_err(|error| {
+        parse_certificates(&bundle, request_deadline).map_err(|error| {
             build_error(format!(
                 "failed to parse network.ca_bundle_path {}: {error}",
                 path.display()
@@ -741,17 +747,38 @@ async fn load_ca_bundle(
     .await
 }
 
-fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
+fn same_origin(left: &Url, right: &Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
+}
+
+fn strip_origin_bound_headers(headers: &mut HeaderMap) {
+    headers.remove(AUTHORIZATION);
+    headers.remove(COOKIE);
+    headers.remove(HOST);
+    headers.remove(ORIGIN);
+    headers.remove(PROXY_AUTHORIZATION);
+    headers.remove(REFERER);
+}
+
+fn parse_certificates(
+    bundle: &[u8],
+    request_deadline: Option<Instant>,
+) -> Result<Vec<Certificate>, HttpError> {
     let mut reader = bundle;
     let mut certificates = Vec::new();
 
     for parsed in rustls_pemfile::certs(&mut reader) {
+        check_request_deadline(request_deadline)?;
         let parsed = parsed
             .map_err(|error| build_error(format!("failed to parse pem certificate: {error}")))?;
         let certificate = Certificate::from_der(parsed.as_ref())
             .map_err(|error| build_error(format!("failed to load pem certificate: {error}")))?;
         certificates.push(certificate);
     }
+
+    check_request_deadline(request_deadline)?;
 
     if certificates.is_empty() {
         return Err(build_error("ca bundle did not contain any certificates"));

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -93,7 +93,7 @@ struct ResolvedCallConfig {
     stream_idle_timeout: Option<Duration>,
     proxy_url: Option<String>,
     ca_bundle_path: Option<PathBuf>,
-    user_agent: Option<HeaderValue>,
+    user_agent: Option<String>,
 }
 
 #[derive(Debug)]
@@ -448,11 +448,7 @@ fn resolve_call_config(
         stream_idle_timeout: stream_idle_timeout_ms.map(Duration::from_millis),
         proxy_url,
         ca_bundle_path,
-        user_agent: user_agent
-            .as_deref()
-            .map(HeaderValue::from_str)
-            .transpose()
-            .map_err(|error| build_error(format!("invalid network.user_agent header: {error}")))?,
+        user_agent,
     };
 
     log_event!(
@@ -480,7 +476,9 @@ fn prepare_request(
     if !headers.contains_key(USER_AGENT)
         && let Some(user_agent) = &call_config.user_agent
     {
-        headers.insert(USER_AGENT, user_agent.clone());
+        let user_agent = HeaderValue::from_str(user_agent)
+            .map_err(|error| build_error(format!("invalid network.user_agent header: {error}")))?;
+        headers.insert(USER_AGENT, user_agent);
     }
 
     finalize_headers(&mut headers, &body);

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -121,7 +121,6 @@ enum StreamTimeoutState {
     },
     Streaming {
         idle_timeout: Option<Duration>,
-        idle_deadline: Option<Instant>,
     },
 }
 
@@ -930,7 +929,9 @@ impl StreamTimeoutState {
             Self::AwaitingFirstByte {
                 request_deadline, ..
             } => request_deadline,
-            Self::Streaming { idle_deadline, .. } => idle_deadline,
+            Self::Streaming { idle_timeout } => {
+                idle_timeout.map(|timeout| Instant::now() + timeout)
+            }
         }
     }
 
@@ -953,28 +954,10 @@ impl StreamTimeoutState {
                         idle_timeout,
                     }
                 } else {
-                    Self::Streaming {
-                        idle_timeout,
-                        idle_deadline: idle_timeout.map(|timeout| Instant::now() + timeout),
-                    }
+                    Self::Streaming { idle_timeout }
                 }
             }
-            Self::Streaming {
-                idle_timeout,
-                idle_deadline,
-            } => {
-                if chunk.is_empty() {
-                    Self::Streaming {
-                        idle_timeout,
-                        idle_deadline,
-                    }
-                } else {
-                    Self::Streaming {
-                        idle_timeout,
-                        idle_deadline: idle_timeout.map(|timeout| Instant::now() + timeout),
-                    }
-                }
-            }
+            Self::Streaming { idle_timeout } => Self::Streaming { idle_timeout },
         }
     }
 }
@@ -984,8 +967,13 @@ mod tests {
     use super::{
         HeaderMap, HeaderValue, HttpMethod, HttpRequest, HttpRequestBody, PreparedBody,
         RequestCompression, ResolvedCallConfig, build_client, build_error, encode_body,
-        maybe_compress_body, parse_absolute_http_url, prepare_request,
+        maybe_compress_body, parse_absolute_http_url, prepare_request, wrap_stream,
     };
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use futures::{StreamExt, stream};
+    use tokio::time::sleep;
 
     #[test]
     fn absolute_http_url_is_required() {
@@ -1077,5 +1065,34 @@ mod tests {
         let error = build_error("reason");
 
         assert!(matches!(error, super::HttpError::Build { reason } if reason == "reason"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idle_timeout_starts_when_waiting_for_next_chunk() {
+        let inner = stream::unfold(0_u8, |state| async move {
+            match state {
+                0 => Some((Ok(Bytes::from_static(b"first")), 1)),
+                1 => {
+                    sleep(Duration::from_millis(10)).await;
+                    Some((Ok(Bytes::from_static(b"second")), 2))
+                }
+                _ => None,
+            }
+        });
+
+        let mut wrapped = wrap_stream(
+            "http://example.test/stream".to_owned(),
+            None,
+            Some(Duration::from_millis(50)),
+            inner,
+        );
+
+        let first = wrapped.next().await.expect("first item");
+        assert_eq!(first.expect("first chunk"), Bytes::from_static(b"first"));
+
+        sleep(Duration::from_millis(120)).await;
+
+        let second = wrapped.next().await.expect("second item");
+        assert_eq!(second.expect("second chunk"), Bytes::from_static(b"second"));
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -7,7 +7,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
     HeaderMap, HeaderValue, StatusCode,
-    header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
+    header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, USER_AGENT},
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
 use tokio::time::{Instant, timeout_at};
@@ -209,17 +209,10 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
         body_len = prepared.body_len
     );
 
-    let client = build_client(
-        &call_config,
-        request_deadline,
-        prepared.request.url().scheme() == "https",
-        &prepared.method,
-    )
-    .await?;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
-    let result = execute_inner(client, prepared, request_deadline).await;
+    let result = execute_inner(&call_config, prepared, request_deadline).await;
 
     log_result("execute", &method, &request_url, body_len, &result);
 
@@ -252,20 +245,13 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
         body_len = prepared.body_len
     );
 
-    let client = build_client(
-        &call_config,
-        request_deadline,
-        prepared.request.url().scheme() == "https",
-        &prepared.method,
-    )
-    .await?;
     let idle_timeout = call_config.stream_idle_timeout;
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
 
     let result = stream_inner(
-        client,
+        &call_config,
         prepared,
         call_config.request_timeout,
         request_deadline,
@@ -279,25 +265,20 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
 }
 
 async fn execute_inner(
-    client: Client,
+    call_config: &ResolvedCallConfig,
     prepared: PreparedRequest,
     request_deadline: Option<Instant>,
 ) -> Result<HttpResponse, HttpError> {
-    let response = send_with_deadline(
-        client,
-        prepared.request,
-        &prepared.request_url,
-        request_deadline,
-    )
-    .await?;
+    let request_url = prepared.request_url.clone();
+    let response = send_with_redirects(call_config, prepared, request_deadline).await?;
 
     if !response.status().is_success() {
-        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await?);
+        return Err(collect_status_error(response, request_deadline, &request_url).await?);
     }
 
     let status = response.status();
     let headers = response.headers().clone();
-    let body = collect_success_body(response, request_deadline, &prepared.request_url).await?;
+    let body = collect_success_body(response, request_deadline, &request_url).await?;
 
     Ok(HttpResponse {
         status,
@@ -307,28 +288,23 @@ async fn execute_inner(
 }
 
 async fn stream_inner(
-    client: Client,
+    call_config: &ResolvedCallConfig,
     prepared: PreparedRequest,
     request_timeout: Option<Duration>,
     request_deadline: Option<Instant>,
     idle_timeout: Option<Duration>,
 ) -> Result<HttpStreamResponse, HttpError> {
-    let response = send_with_deadline(
-        client,
-        prepared.request,
-        &prepared.request_url,
-        request_deadline,
-    )
-    .await?;
+    let request_url = prepared.request_url.clone();
+    let response = send_with_redirects(call_config, prepared, request_deadline).await?;
 
     if !response.status().is_success() {
-        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await?);
+        return Err(collect_status_error(response, request_deadline, &request_url).await?);
     }
 
     let status = response.status();
     let headers = response.headers().clone();
     let body = wrap_stream(
-        prepared.request_url.clone(),
+        request_url,
         request_timeout.and_then(|_| remaining_duration_until(request_deadline)),
         idle_timeout,
         response.bytes_stream(),
@@ -350,6 +326,62 @@ async fn send(
         .execute(request)
         .await
         .map_err(|error| map_transport_error(error, request_url))
+}
+
+async fn send_with_redirects(
+    call_config: &ResolvedCallConfig,
+    prepared: PreparedRequest,
+    request_deadline: Option<Instant>,
+) -> Result<reqwest::Response, HttpError> {
+    let mut request = prepared.request;
+    let method = prepared.method;
+    let request_url = prepared.request_url;
+    let mut redirect_count = 0_usize;
+
+    loop {
+        check_request_deadline(request_deadline)?;
+        let client = build_client(
+            call_config,
+            request_deadline,
+            request.url().scheme() == "https",
+        )
+        .await?;
+        let redirect_template = if matches!(method, HttpMethod::Get) {
+            Some(
+                request
+                    .try_clone()
+                    .ok_or_else(|| build_error("failed to clone redirectable request"))?,
+            )
+        } else {
+            None
+        };
+        let response = send_with_deadline(client, request, &request_url, request_deadline).await?;
+
+        if matches!(method, HttpMethod::Get) && response.status().is_redirection() {
+            if redirect_count >= 10 {
+                return Err(build_error("too many redirects"));
+            }
+
+            let Some(location) = response.headers().get(LOCATION) else {
+                return Ok(response);
+            };
+            let location = location.to_str().map_err(|error| {
+                build_error(format!("invalid redirect location header: {error}"))
+            })?;
+            let next_url = response
+                .url()
+                .join(location)
+                .map_err(|error| build_error(format!("invalid redirect target URL: {error}")))?;
+            let mut next_request = redirect_template
+                .ok_or_else(|| build_error("missing redirect request template"))?;
+            *next_request.url_mut() = next_url;
+            request = next_request;
+            redirect_count += 1;
+            continue;
+        }
+
+        return Ok(response);
+    }
 }
 
 async fn send_with_deadline(
@@ -641,16 +673,10 @@ async fn build_client(
     call_config: &ResolvedCallConfig,
     request_deadline: Option<Instant>,
     uses_tls: bool,
-    method: &HttpMethod,
 ) -> Result<Client, HttpError> {
-    let redirect_policy = if matches!(method, HttpMethod::Get) {
-        reqwest::redirect::Policy::limited(10)
-    } else {
-        reqwest::redirect::Policy::none()
-    };
     let mut builder = Client::builder()
         .retry(reqwest::retry::never())
-        .redirect(redirect_policy);
+        .redirect(reqwest::redirect::Policy::none());
 
     if let Some(connect_timeout) = call_config.connect_timeout {
         builder = builder.connect_timeout(connect_timeout);
@@ -670,15 +696,10 @@ async fn build_client(
             .as_deref()
             .and_then(|proxy_url| Url::parse(proxy_url).ok())
             .is_some_and(|proxy_url| proxy_url.scheme() == "https");
-        let ca_load_is_optional = !uses_tls && !tls_proxy && matches!(method, HttpMethod::Get);
 
-        let certificates = match load_ca_bundle(path, request_deadline).await {
-            Ok(certificates) => Some(certificates),
-            Err(_) if ca_load_is_optional => None,
-            Err(error) => return Err(error),
-        };
+        if uses_tls || tls_proxy {
+            let certificates = load_ca_bundle(path, request_deadline).await?;
 
-        if let Some(certificates) = certificates {
             for certificate in certificates {
                 builder = builder.add_root_certificate(certificate);
             }
@@ -1263,7 +1284,6 @@ mod tests {
             },
             None,
             true,
-            &HttpMethod::Get,
         )
         .await
         .expect_err("invalid proxy must fail");

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -327,6 +327,26 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn request_compression_rejects_existing_integrity_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::HeaderName::from_static("digest"),
+            HeaderValue::from_static("sha-256=abc"),
+        );
+
+        let body = PreparedBody::Buffered {
+            bytes: Bytes::from_static(b"payload"),
+            content_type_if_missing: None,
+        };
+
+        let error = maybe_compress_body(body, RequestCompression::Zstd, &mut headers)
+            .await
+            .expect_err("integrity headers must fail");
+
+        assert!(matches!(error, HttpError::Build { .. }));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn json_body_sets_default_content_type() {
         let request = HttpRequest {
             method: HttpMethod::Post,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -10,7 +10,7 @@ use http::{
     header::{CONTENT_ENCODING, CONTENT_TYPE, USER_AGENT},
 };
 use reqwest::{Certificate, Client, Method, Proxy, Url};
-use tokio::time::{Instant, timeout, timeout_at};
+use tokio::time::{Instant, timeout_at};
 use url::form_urlencoded;
 
 macro_rules! log_event {
@@ -208,11 +208,8 @@ pub async fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
     let request_url = prepared.request_url.clone();
     let method = prepared.method.clone();
     let body_len = prepared.body_len;
-
-    let result = run_with_timeout(request_timeout, async move {
-        execute_inner(client, prepared).await
-    })
-    .await;
+    let request_deadline = request_timeout.map(|duration| Instant::now() + duration);
+    let result = execute_inner(client, prepared, request_deadline).await;
 
     log_result("execute", &method, &request_url, body_len, &result);
 
@@ -250,7 +247,7 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
     let request_deadline = request_timeout.map(|duration| Instant::now() + duration);
     let result = stream_inner(client, prepared, request_deadline, idle_timeout).await;
 
-    log_result("stream", &method, &request_url, body_len, &result);
+    log_stream_result(&method, &request_url, body_len, &result);
 
     result
 }
@@ -258,19 +255,23 @@ pub async fn stream(request: HttpRequest) -> Result<HttpStreamResponse, HttpErro
 async fn execute_inner(
     client: Client,
     prepared: PreparedRequest,
+    request_deadline: Option<Instant>,
 ) -> Result<HttpResponse, HttpError> {
-    let response = send(client, prepared.request, &prepared.request_url).await?;
+    let response = send_with_deadline(
+        client,
+        prepared.request,
+        &prepared.request_url,
+        request_deadline,
+    )
+    .await?;
 
     if !response.status().is_success() {
-        return Err(collect_status_error(response, None, &prepared.request_url).await);
+        return Err(collect_status_error(response, request_deadline, &prepared.request_url).await);
     }
 
     let status = response.status();
     let headers = response.headers().clone();
-    let body = response
-        .bytes()
-        .await
-        .map_err(|error| map_transport_error(error, &prepared.request_url))?;
+    let body = collect_success_body(response, request_deadline, &prepared.request_url).await?;
 
     Ok(HttpResponse {
         status,
@@ -390,6 +391,30 @@ async fn collect_status_error(
         headers,
         body: body.freeze(),
     })
+}
+
+async fn collect_success_body(
+    response: reqwest::Response,
+    deadline: Option<Instant>,
+    request_url: &str,
+) -> Result<Bytes, HttpError> {
+    let mut body = BytesMut::new();
+    let mut stream = Box::pin(response.bytes_stream());
+
+    loop {
+        let next_chunk = match deadline {
+            Some(deadline) => timeout_at(deadline, stream.next())
+                .await
+                .map_err(|_| HttpError::Timeout)?,
+            None => stream.next().await,
+        };
+
+        match next_chunk {
+            Some(Ok(chunk)) => body.extend_from_slice(&chunk),
+            Some(Err(error)) => return Err(map_transport_error(error, request_url)),
+            None => return Ok(body.freeze()),
+        }
+    }
 }
 
 fn resolve_call_config(
@@ -674,27 +699,21 @@ fn wrap_stream(
                     yield Err(mapped);
                     break;
                 }
-                None => break,
+                None => {
+                    log_event!(
+                        selvedge_logging::LogLevel::Debug,
+                        "http stream finished";
+                        mode = "stream",
+                        url = request_url.as_str(),
+                        outcome = "success"
+                    );
+                    break;
+                }
             }
         }
     };
 
     Box::pin(stream)
-}
-
-async fn run_with_timeout<F, T>(
-    timeout_duration: Option<Duration>,
-    future: F,
-) -> Result<T, HttpError>
-where
-    F: std::future::Future<Output = Result<T, HttpError>>,
-{
-    match timeout_duration {
-        Some(timeout_duration) => timeout(timeout_duration, future)
-            .await
-            .map_err(|_| HttpError::Timeout)?,
-        None => future.await,
-    }
 }
 
 fn map_transport_error(error: reqwest::Error, request_url: &str) -> HttpError {
@@ -799,6 +818,40 @@ fn log_result<T>(
         }
         Err(error) => {
             log_transport_error(mode, request_url, error);
+        }
+    }
+}
+
+fn log_stream_result(
+    method: &HttpMethod,
+    request_url: &str,
+    body_len: usize,
+    result: &Result<HttpStreamResponse, HttpError>,
+) {
+    match result {
+        Ok(_) => {
+            log_event!(
+                selvedge_logging::LogLevel::Debug,
+                "http stream established";
+                mode = "stream",
+                method = method.as_str(),
+                url = request_url,
+                body_len = body_len
+            );
+        }
+        Err(HttpError::Status(error)) => {
+            log_event!(
+                selvedge_logging::LogLevel::Warn,
+                "http request returned non-success status";
+                mode = "stream",
+                method = method.as_str(),
+                url = error.url.as_str(),
+                status = error.status.as_u16(),
+                body_len = error.body.len()
+            );
+        }
+        Err(error) => {
+            log_transport_error("stream", request_url, error);
         }
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -117,10 +117,11 @@ enum PreparedBody {
 #[derive(Debug, Clone, Copy)]
 enum StreamTimeoutState {
     AwaitingFirstByte {
-        request_timeout: Option<Duration>,
+        request_timeout_remaining: Option<Duration>,
         idle_timeout: Option<Duration>,
     },
     Streaming {
+        request_timeout_remaining: Option<Duration>,
         idle_timeout: Option<Duration>,
     },
 }
@@ -700,11 +701,12 @@ fn wrap_stream(
     let stream = async_stream::stream! {
         let mut stream = Box::pin(stream);
         let mut timeout_state = StreamTimeoutState::AwaitingFirstByte {
-            request_timeout,
+            request_timeout_remaining: request_timeout,
             idle_timeout,
         };
 
         loop {
+            let wait_started_at = Instant::now();
             let next_item = match timeout_state.deadline() {
                 Some(deadline) => match timeout_at(deadline, stream.next()).await {
                     Ok(item) => item,
@@ -721,6 +723,8 @@ fn wrap_stream(
                 },
                 None => stream.next().await,
             };
+            let waited = wait_started_at.elapsed();
+            timeout_state = timeout_state.after_wait(waited);
 
             match next_item {
                 Some(Ok(bytes)) => {
@@ -826,6 +830,10 @@ fn relative_deadline(timeout: Option<Duration>) -> Option<Instant> {
 
 fn remaining_duration_until(deadline: Option<Instant>) -> Option<Duration> {
     deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()))
+}
+
+fn subtract_duration(duration: Option<Duration>, waited: Duration) -> Option<Duration> {
+    duration.map(|duration| duration.saturating_sub(waited))
 }
 
 fn min_deadline(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
@@ -998,24 +1006,32 @@ impl StreamTimeoutState {
     fn deadline(self) -> Option<Instant> {
         match self {
             Self::AwaitingFirstByte {
-                request_timeout,
+                request_timeout_remaining,
                 idle_timeout,
             } => min_deadline(
-                relative_deadline(request_timeout),
+                relative_deadline(request_timeout_remaining),
                 relative_deadline(idle_timeout),
             ),
-            Self::Streaming { idle_timeout } => {
-                idle_timeout.map(|timeout| Instant::now() + timeout)
-            }
+            Self::Streaming {
+                request_timeout_remaining,
+                idle_timeout,
+            } => min_deadline(
+                relative_deadline(request_timeout_remaining),
+                relative_deadline(idle_timeout),
+            ),
         }
     }
 
     fn timeout_message(self) -> &'static str {
         match self {
             Self::AwaitingFirstByte {
-                request_timeout,
+                request_timeout_remaining,
                 idle_timeout,
-            } => match (request_timeout, idle_timeout) {
+            }
+            | Self::Streaming {
+                request_timeout_remaining,
+                idle_timeout,
+            } => match (request_timeout_remaining, idle_timeout) {
                 (Some(request_timeout), Some(idle_timeout)) => {
                     if idle_timeout <= request_timeout {
                         "http stream idle timeout"
@@ -1027,26 +1043,53 @@ impl StreamTimeoutState {
                 (None, Some(_)) => "http stream idle timeout",
                 (None, None) => "http stream request timeout",
             },
-            Self::Streaming { .. } => "http stream idle timeout",
+        }
+    }
+
+    fn after_wait(self, waited: Duration) -> Self {
+        match self {
+            Self::AwaitingFirstByte {
+                request_timeout_remaining,
+                idle_timeout,
+            } => Self::AwaitingFirstByte {
+                request_timeout_remaining: subtract_duration(request_timeout_remaining, waited),
+                idle_timeout,
+            },
+            Self::Streaming {
+                request_timeout_remaining,
+                idle_timeout,
+            } => Self::Streaming {
+                request_timeout_remaining: subtract_duration(request_timeout_remaining, waited),
+                idle_timeout,
+            },
         }
     }
 
     fn on_chunk(self, chunk: &Bytes) -> Self {
         match self {
             Self::AwaitingFirstByte {
-                request_timeout,
+                request_timeout_remaining,
                 idle_timeout,
             } => {
                 if chunk.is_empty() {
                     Self::AwaitingFirstByte {
-                        request_timeout,
+                        request_timeout_remaining,
                         idle_timeout,
                     }
                 } else {
-                    Self::Streaming { idle_timeout }
+                    Self::Streaming {
+                        request_timeout_remaining,
+                        idle_timeout,
+                    }
                 }
             }
-            Self::Streaming { idle_timeout } => Self::Streaming { idle_timeout },
+            Self::Streaming {
+                request_timeout_remaining,
+                idle_timeout,
+            } => Self::Streaming {
+                request_timeout_remaining,
+                idle_timeout,
+            },
         }
     }
 }

--- a/crates/client/src/redaction.rs
+++ b/crates/client/src/redaction.rs
@@ -1,0 +1,106 @@
+use std::fmt;
+
+use reqwest::Url;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SanitizedUrl(String);
+
+impl SanitizedUrl {
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub(crate) fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for SanitizedUrl {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+pub(crate) fn sanitize_url(raw: &str) -> SanitizedUrl {
+    let Ok(parsed) = Url::parse(raw) else {
+        return SanitizedUrl("<invalid-url>".to_owned());
+    };
+
+    sanitize_parsed_url(&parsed)
+}
+
+pub(crate) fn sanitize_parsed_url(url: &Url) -> SanitizedUrl {
+    let mut parsed = url.clone();
+
+    if !parsed.username().is_empty() {
+        let _ = parsed.set_username("");
+    }
+
+    if parsed.password().is_some() {
+        let _ = parsed.set_password(None);
+    }
+
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+
+    SanitizedUrl(parsed.to_string())
+}
+
+pub(crate) fn sanitize_error_text(text: &str, known_urls: &[&str]) -> String {
+    let mut sanitized = text.to_owned();
+
+    for raw_url in known_urls {
+        sanitized = sanitized.replace(raw_url, sanitize_url(raw_url).as_str());
+    }
+
+    scrub_embedded_urls(&sanitized)
+}
+
+fn scrub_embedded_urls(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut index = 0_usize;
+
+    while index < text.len() {
+        let remainder = &text[index..];
+        let Some((offset, scheme)) = find_next_scheme(remainder) else {
+            output.push_str(remainder);
+            break;
+        };
+
+        let absolute_start = index + offset;
+        output.push_str(&text[index..absolute_start]);
+        let absolute_end = scan_url_end(text, absolute_start + scheme.len());
+        let candidate = &text[absolute_start..absolute_end];
+        output.push_str(sanitize_url(candidate).as_str());
+        index = absolute_end;
+    }
+
+    output
+}
+
+fn find_next_scheme(text: &str) -> Option<(usize, &'static str)> {
+    let http = text.find("http://");
+    let https = text.find("https://");
+
+    match (http, https) {
+        (Some(http), Some(https)) if http <= https => Some((http, "http://")),
+        (Some(http), Some(_)) => Some((http, "http://")),
+        (Some(http), None) => Some((http, "http://")),
+        (None, Some(https)) => Some((https, "https://")),
+        (None, None) => None,
+    }
+}
+
+fn scan_url_end(text: &str, mut index: usize) -> usize {
+    while index < text.len() {
+        let byte = text.as_bytes()[index];
+
+        if byte.is_ascii_whitespace() || matches!(byte, b'"' | b'\'' | b')' | b']' | b'>') {
+            break;
+        }
+
+        index += 1;
+    }
+
+    index
+}

--- a/crates/client/src/redaction.rs
+++ b/crates/client/src/redaction.rs
@@ -84,7 +84,7 @@ fn find_next_scheme(text: &str) -> Option<(usize, &'static str)> {
 
     match (http, https) {
         (Some(http), Some(https)) if http <= https => Some((http, "http://")),
-        (Some(http), Some(_)) => Some((http, "http://")),
+        (Some(_), Some(https)) => Some((https, "https://")),
         (Some(http), None) => Some((http, "http://")),
         (None, Some(https)) => Some((https, "https://")),
         (None, None) => None,

--- a/crates/client/src/redirect_runtime.rs
+++ b/crates/client/src/redirect_runtime.rs
@@ -1,0 +1,173 @@
+use http::{StatusCode, header::LOCATION};
+
+use crate::{HttpError, HttpMethod, HttpRequest, HttpResponse, HttpStreamResponse, build_error};
+use crate::{
+    config_resolution::ResolvedCallConfig,
+    request_prep::{PreparedRequest, prepare_request},
+    runtime::{
+        RequestBudget, collect_status_error, collect_success_body, same_origin,
+        strip_origin_bound_headers, wrap_stream,
+    },
+    single_hop::send_single_hop,
+};
+
+const MAX_REDIRECT_HOPS: usize = 10;
+
+pub(crate) async fn execute_inner(
+    call_config: &ResolvedCallConfig,
+    request: HttpRequest,
+    initial_prepared: PreparedRequest,
+    mut request_budget: RequestBudget,
+) -> Result<HttpResponse, HttpError> {
+    let (response, request_url) =
+        send_request(call_config, request, initial_prepared, &mut request_budget).await?;
+
+    if !response.status().is_success() {
+        return Err(collect_status_error(response, &mut request_budget, &request_url).await?);
+    }
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = collect_success_body(response, &mut request_budget, &request_url).await?;
+
+    Ok(HttpResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+pub(crate) async fn stream_inner(
+    call_config: &ResolvedCallConfig,
+    request: HttpRequest,
+    initial_prepared: PreparedRequest,
+    mut request_budget: RequestBudget,
+    idle_timeout: Option<std::time::Duration>,
+) -> Result<HttpStreamResponse, HttpError> {
+    let (response, request_url) =
+        send_request(call_config, request, initial_prepared, &mut request_budget).await?;
+
+    if !response.status().is_success() {
+        return Err(collect_status_error(response, &mut request_budget, &request_url).await?);
+    }
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = wrap_stream(
+        request_url,
+        request_budget,
+        idle_timeout,
+        response.bytes_stream(),
+    );
+
+    Ok(HttpStreamResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+async fn send_request(
+    call_config: &ResolvedCallConfig,
+    request: HttpRequest,
+    initial_prepared: PreparedRequest,
+    request_budget: &mut RequestBudget,
+) -> Result<(reqwest::Response, String), HttpError> {
+    let mut current_request = request;
+    let mut next_prepared = Some(initial_prepared);
+    let mut hop = 0_usize;
+
+    loop {
+        let prepared = match next_prepared.take() {
+            Some(prepared) => prepared,
+            None => prepare_request(current_request.clone(), call_config).await?,
+        };
+        let request_url = prepared.request_url.clone();
+        let response = send_single_hop(call_config, prepared, request_budget).await?;
+
+        if should_follow_redirect(&current_request.method, response.status()) {
+            let next_request = build_redirect_request(current_request, &response, hop)?;
+            current_request = next_request;
+            hop += 1;
+            continue;
+        }
+
+        return Ok((response, request_url));
+    }
+}
+
+fn should_follow_redirect(method: &HttpMethod, status: StatusCode) -> bool {
+    matches!(method, HttpMethod::Get)
+        && matches!(
+            status,
+            StatusCode::MOVED_PERMANENTLY
+                | StatusCode::FOUND
+                | StatusCode::SEE_OTHER
+                | StatusCode::TEMPORARY_REDIRECT
+                | StatusCode::PERMANENT_REDIRECT
+        )
+}
+
+fn build_redirect_request(
+    mut current_request: HttpRequest,
+    response: &reqwest::Response,
+    hop: usize,
+) -> Result<HttpRequest, HttpError> {
+    if hop >= MAX_REDIRECT_HOPS {
+        return Err(build_error("too many redirects"));
+    }
+
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .ok_or_else(|| build_error("redirect response did not include Location header"))?;
+    let location = location
+        .to_str()
+        .map_err(|error| build_error(format!("invalid redirect location header: {error}")))?;
+    let next_url = response
+        .url()
+        .join(location)
+        .map_err(|error| build_error(format!("invalid redirect target URL: {error}")))?;
+
+    if !same_origin(response.url(), &next_url) {
+        strip_origin_bound_headers(&mut current_request.headers);
+    }
+
+    let from_url = crate::redaction::sanitize_parsed_url(response.url());
+    let to_url = crate::redaction::sanitize_parsed_url(&next_url);
+
+    crate::log_event!(
+        selvedge_logging::LogLevel::Debug,
+        "http request redirected";
+        from = from_url.as_str(),
+        to = to_url.as_str(),
+        status = response.status().as_u16(),
+        hop = hop + 1
+    );
+
+    current_request.url = next_url.into();
+
+    Ok(current_request)
+}
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    use crate::HttpMethod;
+
+    use super::should_follow_redirect;
+
+    #[test]
+    fn only_get_redirects_are_followed() {
+        assert!(should_follow_redirect(&HttpMethod::Get, StatusCode::FOUND));
+        assert!(!should_follow_redirect(
+            &HttpMethod::Post,
+            StatusCode::FOUND
+        ));
+        assert!(!should_follow_redirect(
+            &HttpMethod::Get,
+            StatusCode::BAD_REQUEST
+        ));
+    }
+}

--- a/crates/client/src/request_prep.rs
+++ b/crates/client/src/request_prep.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use bytes::Bytes;
 use http::{
-    HeaderMap, HeaderValue,
+    HeaderMap, HeaderName, HeaderValue,
     header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
 };
 use reqwest::Url;
@@ -166,6 +166,12 @@ pub(crate) async fn maybe_compress_body(
                     "cannot apply request compression when Content-Encoding is already set",
                 ));
             }
+            if let Some(integrity_header) = find_integrity_header(headers) {
+                return Err(build_error(format!(
+                    "cannot apply request compression when {} is already set",
+                    integrity_header.as_str()
+                )));
+            }
 
             let compressed = run_blocking(move || compress_bytes(bytes)).await?;
             headers.insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
@@ -176,6 +182,20 @@ pub(crate) async fn maybe_compress_body(
             })
         }
     }
+}
+
+fn find_integrity_header(headers: &HeaderMap) -> Option<HeaderName> {
+    headers
+        .keys()
+        .find(|name| is_integrity_header(name))
+        .cloned()
+}
+
+fn is_integrity_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str().to_ascii_lowercase().as_str(),
+        "content-md5" | "digest" | "content-digest" | "repr-digest"
+    )
 }
 
 fn reconcile_content_length(body: &PreparedBody, headers: &mut HeaderMap) -> Result<(), HttpError> {

--- a/crates/client/src/request_prep.rs
+++ b/crates/client/src/request_prep.rs
@@ -1,0 +1,207 @@
+use std::io::Write;
+
+use bytes::Bytes;
+use http::{
+    HeaderMap, HeaderValue,
+    header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
+};
+use reqwest::Url;
+use url::form_urlencoded;
+
+use crate::{
+    HttpError, HttpMethod, HttpRequest, HttpRequestBody, RequestCompression, build_error,
+    run_blocking,
+};
+use crate::{config_resolution::ResolvedCallConfig, redaction::sanitize_url};
+
+#[derive(Debug)]
+pub(crate) struct PreparedRequest {
+    pub(crate) request: reqwest::Request,
+    pub(crate) method: HttpMethod,
+    pub(crate) request_url: String,
+    pub(crate) body_len: usize,
+}
+
+#[derive(Debug)]
+pub(crate) enum PreparedBody {
+    Empty,
+    Buffered {
+        bytes: Bytes,
+        content_type_if_missing: Option<HeaderValue>,
+    },
+}
+
+impl PreparedBody {
+    pub(crate) fn into_bytes(self) -> Option<Bytes> {
+        match self {
+            Self::Empty => None,
+            Self::Buffered { bytes, .. } => Some(bytes),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::Buffered { bytes, .. } => bytes.len(),
+        }
+    }
+}
+
+pub(crate) async fn prepare_request(
+    request: HttpRequest,
+    call_config: &ResolvedCallConfig,
+) -> Result<PreparedRequest, HttpError> {
+    let url = parse_absolute_http_url(&request.url)?;
+    let mut headers = request.headers;
+    let mut body = encode_body(request.body)?;
+
+    if !headers.contains_key(USER_AGENT)
+        && let Some(user_agent) = &call_config.user_agent
+    {
+        let user_agent = HeaderValue::from_str(user_agent)
+            .map_err(|_| build_error("network.user_agent violated config-model invariant"))?;
+        headers.insert(USER_AGENT, user_agent);
+    }
+
+    finalize_headers(&mut headers, &body);
+    body = maybe_compress_body(body, request.compression, &mut headers).await?;
+
+    let body_len = body.len();
+    reconcile_content_length(&body, &mut headers)?;
+    let mut reqwest_request = reqwest::Request::new(request.method.clone().into(), url);
+    *reqwest_request.headers_mut() = headers;
+
+    if let Some(bytes) = body.into_bytes() {
+        *reqwest_request.body_mut() = Some(bytes.into());
+    }
+
+    Ok(PreparedRequest {
+        request: reqwest_request,
+        method: request.method,
+        request_url: sanitize_url(&request.url).into_string(),
+        body_len,
+    })
+}
+
+pub(crate) fn parse_absolute_http_url(url: &str) -> Result<Url, HttpError> {
+    let parsed = Url::parse(url)
+        .map_err(|error| build_error(format!("url must be an absolute URL: {error}")))?;
+
+    if !parsed.has_host() || parsed.cannot_be_a_base() {
+        return Err(build_error("url must be an absolute URL"));
+    }
+
+    match parsed.scheme() {
+        "http" | "https" => Ok(parsed),
+        other => Err(build_error(format!(
+            "url scheme must be http or https, got {other}"
+        ))),
+    }
+}
+
+pub(crate) fn encode_body(body: HttpRequestBody) -> Result<PreparedBody, HttpError> {
+    match body {
+        HttpRequestBody::Empty => Ok(PreparedBody::Empty),
+        HttpRequestBody::Json(value) => {
+            let bytes = serde_json::to_vec(&value)
+                .map(Bytes::from)
+                .map_err(|error| build_error(format!("failed to encode json body: {error}")))?;
+
+            Ok(PreparedBody::Buffered {
+                bytes,
+                content_type_if_missing: Some(HeaderValue::from_static("application/json")),
+            })
+        }
+        HttpRequestBody::FormUrlEncoded(pairs) => {
+            let mut encoded = pairs.into_iter().fold(
+                form_urlencoded::Serializer::new(String::new()),
+                |mut serializer, (key, value)| {
+                    serializer.append_pair(&key, &value);
+                    serializer
+                },
+            );
+
+            Ok(PreparedBody::Buffered {
+                bytes: Bytes::from(encoded.finish()),
+                content_type_if_missing: Some(HeaderValue::from_static(
+                    "application/x-www-form-urlencoded",
+                )),
+            })
+        }
+        HttpRequestBody::Bytes(bytes) => Ok(PreparedBody::Buffered {
+            bytes,
+            content_type_if_missing: None,
+        }),
+    }
+}
+
+fn finalize_headers(headers: &mut HeaderMap, body: &PreparedBody) {
+    if let PreparedBody::Buffered {
+        content_type_if_missing: Some(content_type),
+        ..
+    } = body
+        && !headers.contains_key(CONTENT_TYPE)
+    {
+        headers.insert(CONTENT_TYPE, content_type.clone());
+    }
+}
+
+pub(crate) async fn maybe_compress_body(
+    body: PreparedBody,
+    compression: RequestCompression,
+    headers: &mut HeaderMap,
+) -> Result<PreparedBody, HttpError> {
+    match (body, compression) {
+        (PreparedBody::Empty, _) => Ok(PreparedBody::Empty),
+        (body, RequestCompression::None) => Ok(body),
+        (
+            PreparedBody::Buffered {
+                bytes,
+                content_type_if_missing,
+            },
+            RequestCompression::Zstd,
+        ) => {
+            if headers.contains_key(CONTENT_ENCODING) {
+                return Err(build_error(
+                    "cannot apply request compression when Content-Encoding is already set",
+                ));
+            }
+
+            let compressed = run_blocking(move || compress_bytes(bytes)).await?;
+            headers.insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+
+            Ok(PreparedBody::Buffered {
+                bytes: compressed,
+                content_type_if_missing,
+            })
+        }
+    }
+}
+
+fn reconcile_content_length(body: &PreparedBody, headers: &mut HeaderMap) -> Result<(), HttpError> {
+    if headers.contains_key(CONTENT_LENGTH) {
+        let content_length = HeaderValue::from_str(&body.len().to_string()).map_err(|error| {
+            build_error(format!("invalid computed Content-Length header: {error}"))
+        })?;
+        headers.insert(CONTENT_LENGTH, content_length);
+    }
+
+    Ok(())
+}
+
+fn compress_bytes(bytes: Bytes) -> Result<Bytes, HttpError> {
+    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0)
+        .map_err(|error| build_error(format!("failed to start zstd encoder: {error}")))?;
+
+    for chunk in bytes.chunks(64 * 1024) {
+        encoder
+            .write_all(chunk)
+            .map_err(|error| build_error(format!("failed to encode zstd body: {error}")))?;
+    }
+
+    let compressed = encoder
+        .finish()
+        .map_err(|error| build_error(format!("failed to finish zstd body: {error}")))?;
+
+    Ok(Bytes::from(compressed))
+}

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -486,31 +486,45 @@ fn is_cross_origin_sensitive_header(name: &HeaderName) -> bool {
         .collect::<String>();
     let tokens = lower
         .split(|character: char| !character.is_ascii_alphanumeric())
-        .filter(|token| !token.is_empty());
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
 
     if matches_compact_sensitive_header(&compact) {
         return true;
     }
 
-    tokens.into_iter().any(|token| {
-        matches!(
-            token,
-            "auth" | "authorization" | "token" | "key" | "secret" | "credential" | "session"
-        )
-    })
+    matches_sensitive_token_pattern(&tokens)
 }
 
 fn matches_compact_sensitive_header(compact: &str) -> bool {
     [
         "apikey",
         "authtoken",
+        "accesstoken",
+        "refreshtoken",
         "sessionid",
         "sessionkey",
+        "clientsecret",
+        "clienttoken",
         "credential",
-        "secret",
     ]
     .iter()
     .any(|needle| compact.contains(needle))
+}
+
+fn matches_sensitive_token_pattern(tokens: &[&str]) -> bool {
+    matches!(
+        tokens,
+        ["api", "key"]
+            | ["auth", "token"]
+            | ["access", "token"]
+            | ["refresh", "token"]
+            | ["session", "id"]
+            | ["session", "key"]
+            | ["client", "secret"]
+            | ["client", "token"]
+            | ["credential"]
+    )
 }
 
 fn is_tls_error(error: &reqwest::Error) -> bool {

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -87,14 +87,6 @@ impl WaitBudget {
         request_remaining: Option<Duration>,
         idle_remaining: Option<Duration>,
     ) -> Result<Self, TimeoutReason> {
-        if request_remaining.is_some_and(|duration| duration.is_zero()) {
-            return Err(TimeoutReason::Request);
-        }
-
-        if idle_remaining.is_some_and(|duration| duration.is_zero()) {
-            return Err(TimeoutReason::Idle);
-        }
-
         let timeout_reason = match (request_remaining, idle_remaining) {
             (Some(request_remaining), Some(idle_remaining)) => {
                 if idle_remaining <= request_remaining {
@@ -603,5 +595,42 @@ fn timeout_message(reason: TimeoutReason) -> &'static str {
     match reason {
         TimeoutReason::Request => "http stream request timeout",
         TimeoutReason::Idle => "http stream idle timeout",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{TimeoutReason, WaitBudget, run_wait};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn zero_request_budget_allows_ready_poll() {
+        let wait_budget = WaitBudget::new(Some(Duration::ZERO), None).expect("zero request budget");
+        let (value, _) = run_wait(wait_budget, std::future::ready(7_u8))
+            .await
+            .expect("ready future must succeed");
+
+        assert_eq!(value, 7);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn zero_idle_budget_allows_ready_poll() {
+        let wait_budget = WaitBudget::new(None, Some(Duration::ZERO)).expect("zero idle budget");
+        let (value, _) = run_wait(wait_budget, std::future::ready(9_u8))
+            .await
+            .expect("ready future must succeed");
+
+        assert_eq!(value, 9);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn zero_budget_still_times_out_pending_poll() {
+        let wait_budget = WaitBudget::new(Some(Duration::ZERO), None).expect("zero request budget");
+        let error = run_wait(wait_budget, std::future::pending::<()>())
+            .await
+            .expect_err("pending future must time out");
+
+        assert!(matches!(error, TimeoutReason::Request));
     }
 }

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -496,9 +496,17 @@ fn is_cross_origin_sensitive_header(name: &HeaderName) -> bool {
     }
 
     let lower = name.as_str().to_ascii_lowercase();
+    let compact = lower
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .collect::<String>();
     let tokens = lower
         .split(|character: char| !character.is_ascii_alphanumeric())
         .filter(|token| !token.is_empty());
+
+    if matches_compact_sensitive_header(&compact) {
+        return true;
+    }
 
     tokens.into_iter().any(|token| {
         matches!(
@@ -506,6 +514,19 @@ fn is_cross_origin_sensitive_header(name: &HeaderName) -> bool {
             "auth" | "authorization" | "token" | "key" | "secret" | "credential" | "session"
         )
     })
+}
+
+fn matches_compact_sensitive_header(compact: &str) -> bool {
+    [
+        "apikey",
+        "authtoken",
+        "sessionid",
+        "sessionkey",
+        "credential",
+        "secret",
+    ]
+    .iter()
+    .any(|needle| compact.contains(needle))
 }
 
 fn is_tls_error(error: &reqwest::Error) -> bool {

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -1,0 +1,676 @@
+use std::{error::Error as StdError, future::Future, path::Path, time::Duration};
+
+use bytes::{Bytes, BytesMut};
+use futures::{Stream, StreamExt};
+use http::{
+    HeaderMap,
+    header::{AUTHORIZATION, COOKIE, HOST, LOCATION, ORIGIN, REFERER},
+};
+use reqwest::{Certificate, Client, Url};
+use tokio::{fs as tokio_fs, time::Instant};
+
+use crate::{
+    ByteStream, HttpError, HttpMethod, HttpResponse, HttpStatusError, HttpStreamResponse,
+    build_error, run_blocking,
+};
+use crate::{
+    config_resolution::ResolvedCallConfig,
+    redaction::{sanitize_error_text, sanitize_parsed_url},
+    request_prep::PreparedRequest,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RequestBudget {
+    remaining: Option<Duration>,
+}
+
+impl RequestBudget {
+    pub(crate) fn new(timeout: Option<Duration>) -> Self {
+        Self { remaining: timeout }
+    }
+
+    fn remaining(self) -> Option<Duration> {
+        self.remaining
+    }
+
+    fn charge(&mut self, elapsed: Duration) {
+        if let Some(remaining) = &mut self.remaining {
+            *remaining = remaining.saturating_sub(elapsed);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct IdleBudget {
+    configured: Option<Duration>,
+    remaining: Option<Duration>,
+}
+
+impl IdleBudget {
+    fn new(timeout: Option<Duration>) -> Self {
+        Self {
+            configured: timeout,
+            remaining: timeout,
+        }
+    }
+
+    fn remaining(self) -> Option<Duration> {
+        self.remaining
+    }
+
+    fn charge(&mut self, elapsed: Duration) {
+        if let Some(remaining) = &mut self.remaining {
+            *remaining = remaining.saturating_sub(elapsed);
+        }
+    }
+
+    fn on_chunk(&mut self, chunk: &Bytes) {
+        if !chunk.is_empty() {
+            self.remaining = self.configured;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TimeoutReason {
+    Request,
+    Idle,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WaitBudget {
+    timeout: Option<Duration>,
+    timeout_reason: Option<TimeoutReason>,
+}
+
+impl WaitBudget {
+    fn new(
+        request_remaining: Option<Duration>,
+        idle_remaining: Option<Duration>,
+    ) -> Result<Self, TimeoutReason> {
+        if request_remaining.is_some_and(|duration| duration.is_zero()) {
+            return Err(TimeoutReason::Request);
+        }
+
+        if idle_remaining.is_some_and(|duration| duration.is_zero()) {
+            return Err(TimeoutReason::Idle);
+        }
+
+        let timeout_reason = match (request_remaining, idle_remaining) {
+            (Some(request_remaining), Some(idle_remaining)) => {
+                if idle_remaining <= request_remaining {
+                    Some(TimeoutReason::Idle)
+                } else {
+                    Some(TimeoutReason::Request)
+                }
+            }
+            (Some(_), None) => Some(TimeoutReason::Request),
+            (None, Some(_)) => Some(TimeoutReason::Idle),
+            (None, None) => None,
+        };
+        let timeout = min_duration(request_remaining, idle_remaining);
+
+        Ok(Self {
+            timeout,
+            timeout_reason,
+        })
+    }
+}
+
+pub(crate) async fn execute_inner(
+    call_config: &ResolvedCallConfig,
+    prepared: PreparedRequest,
+    mut request_budget: RequestBudget,
+) -> Result<HttpResponse, HttpError> {
+    let request_url = prepared.request_url.clone();
+    let response = send_with_redirects(call_config, prepared, &mut request_budget).await?;
+
+    if !response.status().is_success() {
+        return Err(collect_status_error(response, &mut request_budget, &request_url).await?);
+    }
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = collect_success_body(response, &mut request_budget, &request_url).await?;
+
+    Ok(HttpResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+pub(crate) async fn stream_inner(
+    call_config: &ResolvedCallConfig,
+    prepared: PreparedRequest,
+    mut request_budget: RequestBudget,
+    idle_timeout: Option<Duration>,
+) -> Result<HttpStreamResponse, HttpError> {
+    let request_url = prepared.request_url.clone();
+    let response = send_with_redirects(call_config, prepared, &mut request_budget).await?;
+
+    if !response.status().is_success() {
+        return Err(collect_status_error(response, &mut request_budget, &request_url).await?);
+    }
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = wrap_stream(
+        request_url,
+        request_budget,
+        idle_timeout,
+        response.bytes_stream(),
+    );
+
+    Ok(HttpStreamResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+async fn send_with_redirects(
+    call_config: &ResolvedCallConfig,
+    prepared: PreparedRequest,
+    request_budget: &mut RequestBudget,
+) -> Result<reqwest::Response, HttpError> {
+    let mut request = prepared.request;
+    let method = prepared.method;
+    let mut redirect_count = 0_usize;
+
+    loop {
+        let current_request_url = sanitize_parsed_url(request.url());
+        let client = build_client(call_config, request.url().scheme() == "https").await?;
+        let redirect_template = if matches!(method, HttpMethod::Get) {
+            Some(
+                request
+                    .try_clone()
+                    .ok_or_else(|| build_error("failed to clone redirectable request"))?,
+            )
+        } else {
+            None
+        };
+        let response = send_with_budget(
+            client,
+            request,
+            current_request_url.as_str(),
+            request_budget,
+        )
+        .await?;
+
+        if matches!(method, HttpMethod::Get) && response.status().is_redirection() {
+            if redirect_count >= 10 {
+                return Err(build_error("too many redirects"));
+            }
+
+            let Some(location) = response.headers().get(LOCATION) else {
+                return Ok(response);
+            };
+            let location = location.to_str().map_err(|error| {
+                build_error(format!("invalid redirect location header: {error}"))
+            })?;
+            let next_url = response
+                .url()
+                .join(location)
+                .map_err(|error| build_error(format!("invalid redirect target URL: {error}")))?;
+            let mut next_request = redirect_template
+                .ok_or_else(|| build_error("missing redirect request template"))?;
+            if !same_origin(response.url(), &next_url) {
+                strip_origin_bound_headers(next_request.headers_mut());
+            }
+            *next_request.url_mut() = next_url;
+            request = next_request;
+            redirect_count += 1;
+            continue;
+        }
+
+        return Ok(response);
+    }
+}
+
+async fn send_with_budget(
+    client: Client,
+    request: reqwest::Request,
+    request_url: &str,
+    request_budget: &mut RequestBudget,
+) -> Result<reqwest::Response, HttpError> {
+    let wait_budget =
+        WaitBudget::new(request_budget.remaining(), None).map_err(timeout_reason_to_error)?;
+    let (response, elapsed) = run_wait(wait_budget, client.execute(request))
+        .await
+        .map_err(timeout_reason_to_error)?;
+    request_budget.charge(elapsed);
+
+    response.map_err(|error| map_transport_error(error, request_url))
+}
+
+async fn collect_status_error(
+    response: reqwest::Response,
+    request_budget: &mut RequestBudget,
+    request_url: &str,
+) -> Result<HttpError, HttpError> {
+    let url = sanitize_parsed_url(response.url()).into_string();
+    let status = response.status();
+    let headers = response.headers().clone();
+    let mut body = BytesMut::new();
+    let mut stream = Box::pin(response.bytes_stream());
+
+    loop {
+        let wait_budget = match WaitBudget::new(request_budget.remaining(), None) {
+            Ok(wait_budget) => wait_budget,
+            Err(_) => {
+                crate::log_event!(
+                    selvedge_logging::LogLevel::Warn,
+                    "http non-success response body timed out";
+                    url = url.as_str(),
+                    status = status.as_u16()
+                );
+                return Err(HttpError::Timeout);
+            }
+        };
+        let (next_chunk, elapsed) = match run_wait(wait_budget, stream.next()).await {
+            Ok(result) => result,
+            Err(_) => {
+                crate::log_event!(
+                    selvedge_logging::LogLevel::Warn,
+                    "http non-success response body timed out";
+                    url = url.as_str(),
+                    status = status.as_u16()
+                );
+                return Err(HttpError::Timeout);
+            }
+        };
+        request_budget.charge(elapsed);
+
+        match next_chunk {
+            Some(Ok(chunk)) => body.extend_from_slice(&chunk),
+            Some(Err(error)) => {
+                let mapped = map_transport_error(error, request_url);
+                crate::log_event!(
+                    selvedge_logging::LogLevel::Warn,
+                    "http non-success response body truncated";
+                    url = url.as_str(),
+                    status = status.as_u16(),
+                    error = mapped.to_string()
+                );
+                break;
+            }
+            None => break,
+        }
+    }
+
+    Ok(HttpError::Status(HttpStatusError {
+        url,
+        status,
+        headers,
+        body: body.freeze(),
+    }))
+}
+
+async fn collect_success_body(
+    response: reqwest::Response,
+    request_budget: &mut RequestBudget,
+    request_url: &str,
+) -> Result<Bytes, HttpError> {
+    let mut body = BytesMut::new();
+    let mut stream = Box::pin(response.bytes_stream());
+
+    loop {
+        let wait_budget =
+            WaitBudget::new(request_budget.remaining(), None).map_err(timeout_reason_to_error)?;
+        let (next_chunk, elapsed) = run_wait(wait_budget, stream.next())
+            .await
+            .map_err(timeout_reason_to_error)?;
+        request_budget.charge(elapsed);
+
+        match next_chunk {
+            Some(Ok(chunk)) => body.extend_from_slice(&chunk),
+            Some(Err(error)) => return Err(map_transport_error(error, request_url)),
+            None => return Ok(body.freeze()),
+        }
+    }
+}
+
+pub(crate) fn wrap_stream(
+    request_url: String,
+    mut request_budget: RequestBudget,
+    idle_timeout: Option<Duration>,
+    stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+) -> ByteStream {
+    let stream = async_stream::stream! {
+        let mut stream = Box::pin(stream);
+        let mut idle_budget = IdleBudget::new(idle_timeout);
+
+        loop {
+            let wait_budget = match WaitBudget::new(
+                request_budget.remaining(),
+                idle_budget.remaining(),
+            ) {
+                Ok(wait_budget) => wait_budget,
+                Err(reason) => {
+                    crate::log_event!(
+                        selvedge_logging::LogLevel::Warn,
+                        timeout_message(reason);
+                        mode = "stream",
+                        url = request_url.as_str()
+                    );
+                    yield Err(HttpError::Timeout);
+                    break;
+                }
+            };
+
+            let (next_item, elapsed) = match run_wait(wait_budget, stream.next()).await {
+                Ok(result) => result,
+                Err(reason) => {
+                    crate::log_event!(
+                        selvedge_logging::LogLevel::Warn,
+                        timeout_message(reason);
+                        mode = "stream",
+                        url = request_url.as_str()
+                    );
+                    yield Err(HttpError::Timeout);
+                    break;
+                }
+            };
+            request_budget.charge(elapsed);
+            idle_budget.charge(elapsed);
+
+            match next_item {
+                Some(Ok(bytes)) => {
+                    idle_budget.on_chunk(&bytes);
+                    yield Ok(bytes);
+                }
+                Some(Err(error)) => {
+                    let mapped = map_transport_error(error, &request_url);
+                    log_transport_error("stream", &request_url, &mapped);
+                    yield Err(mapped);
+                    break;
+                }
+                None => {
+                    crate::log_event!(
+                        selvedge_logging::LogLevel::Debug,
+                        "http stream finished";
+                        mode = "stream",
+                        url = request_url.as_str(),
+                        outcome = "success"
+                    );
+                    break;
+                }
+            }
+        }
+    };
+
+    Box::pin(stream)
+}
+
+pub(crate) fn map_transport_error(error: reqwest::Error, request_url: &str) -> HttpError {
+    let error_url = error.url().map(|url| url.as_str().to_owned());
+    let mut known_urls = Vec::new();
+
+    if let Some(error_url) = error_url.as_deref() {
+        known_urls.push(error_url);
+    }
+
+    let rendered = sanitize_error_text(&render_error_chain(&error), &known_urls);
+    let reason = format!("{request_url}: {rendered}");
+
+    if error.is_timeout() {
+        HttpError::Timeout
+    } else if is_tls_error(&error) {
+        HttpError::Tls { reason }
+    } else if error.is_connect() {
+        HttpError::Connect { reason }
+    } else if error.is_builder() || error.is_redirect() || error.is_request() {
+        HttpError::Build { reason }
+    } else {
+        HttpError::Io { reason }
+    }
+}
+
+pub(crate) fn log_result<T>(
+    mode: &str,
+    method: &HttpMethod,
+    request_url: &str,
+    body_len: usize,
+    result: &Result<T, HttpError>,
+) {
+    match result {
+        Ok(_) => {
+            crate::log_event!(
+                selvedge_logging::LogLevel::Debug,
+                "http request finished";
+                mode = mode,
+                method = method.as_str(),
+                url = request_url,
+                body_len = body_len,
+                outcome = "success"
+            );
+        }
+        Err(HttpError::Status(error)) => {
+            crate::log_event!(
+                selvedge_logging::LogLevel::Warn,
+                "http request returned non-success status";
+                mode = mode,
+                method = method.as_str(),
+                url = error.url.as_str(),
+                status = error.status.as_u16(),
+                body_len = error.body.len()
+            );
+        }
+        Err(error) => {
+            log_transport_error(mode, request_url, error);
+        }
+    }
+}
+
+pub(crate) fn log_stream_result(
+    method: &HttpMethod,
+    request_url: &str,
+    body_len: usize,
+    result: &Result<HttpStreamResponse, HttpError>,
+) {
+    match result {
+        Ok(_) => {
+            crate::log_event!(
+                selvedge_logging::LogLevel::Debug,
+                "http stream established";
+                mode = "stream",
+                method = method.as_str(),
+                url = request_url,
+                body_len = body_len
+            );
+        }
+        Err(HttpError::Status(error)) => {
+            crate::log_event!(
+                selvedge_logging::LogLevel::Warn,
+                "http request returned non-success status";
+                mode = "stream",
+                method = method.as_str(),
+                url = error.url.as_str(),
+                status = error.status.as_u16(),
+                body_len = error.body.len()
+            );
+        }
+        Err(error) => {
+            log_transport_error("stream", request_url, error);
+        }
+    }
+}
+
+pub(crate) fn log_transport_error(mode: &str, request_url: &str, error: &HttpError) {
+    let message = match error {
+        HttpError::Timeout => "http request timed out",
+        HttpError::Connect { .. } => "http request connect failure",
+        HttpError::Tls { .. } => "http request tls failure",
+        HttpError::Io { .. } => "http request i/o failure",
+        HttpError::Build { .. } => "http request build failure",
+        HttpError::Config { .. } => "http request config failure",
+        HttpError::Status(_) => "http request status failure",
+    };
+
+    crate::log_event!(
+        selvedge_logging::LogLevel::Warn,
+        message;
+        mode = mode,
+        url = request_url,
+        error = error.to_string()
+    );
+}
+
+async fn build_client(
+    call_config: &ResolvedCallConfig,
+    uses_tls: bool,
+) -> Result<Client, HttpError> {
+    let mut builder = Client::builder()
+        .retry(reqwest::retry::never())
+        .redirect(reqwest::redirect::Policy::none());
+
+    if let Some(connect_timeout) = call_config.connect_timeout {
+        builder = builder.connect_timeout(connect_timeout);
+    }
+    builder = builder.no_proxy();
+
+    if let Some(path) = &call_config.ca_bundle_path
+        && uses_tls
+    {
+        let certificates = load_ca_bundle(path).await?;
+
+        for certificate in certificates {
+            builder = builder.add_root_certificate(certificate);
+        }
+    }
+
+    builder
+        .build()
+        .map_err(|error| build_error(format!("failed to build http client: {error}")))
+}
+
+async fn load_ca_bundle(path: &Path) -> Result<Vec<Certificate>, HttpError> {
+    let bundle = tokio_fs::read(path).await.map_err(|error| {
+        build_error(format!(
+            "failed to read network.ca_bundle_path {}: {error}",
+            path.display()
+        ))
+    })?;
+    let path = path.to_path_buf();
+
+    run_blocking(move || {
+        parse_certificates(&bundle).map_err(|error| {
+            build_error(format!(
+                "failed to parse network.ca_bundle_path {}: {error}",
+                path.display()
+            ))
+        })
+    })
+    .await
+}
+
+fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
+    let mut reader = bundle;
+    let mut certificates = Vec::new();
+
+    for parsed in rustls_pemfile::certs(&mut reader) {
+        let parsed = parsed
+            .map_err(|error| build_error(format!("failed to parse pem certificate: {error}")))?;
+        let certificate = Certificate::from_der(parsed.as_ref())
+            .map_err(|error| build_error(format!("failed to load pem certificate: {error}")))?;
+        certificates.push(certificate);
+    }
+
+    if certificates.is_empty() {
+        return Err(build_error("ca bundle did not contain any certificates"));
+    }
+
+    Ok(certificates)
+}
+
+fn same_origin(left: &Url, right: &Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
+}
+
+fn strip_origin_bound_headers(headers: &mut HeaderMap) {
+    headers.remove(AUTHORIZATION);
+    headers.remove(COOKIE);
+    headers.remove(HOST);
+    headers.remove(ORIGIN);
+    headers.remove(REFERER);
+}
+
+fn is_tls_error(error: &reqwest::Error) -> bool {
+    let mut source = error.source();
+
+    while let Some(current) = source {
+        let reason = current.to_string().to_ascii_lowercase();
+
+        if [
+            "tls",
+            "rustls",
+            "certificate",
+            "unknown issuer",
+            "self-signed",
+            "dns name",
+            "handshake",
+            "webpki",
+            "peer sent no certificates",
+            "not valid for name",
+        ]
+        .iter()
+        .any(|needle| reason.contains(needle))
+        {
+            return true;
+        }
+
+        source = current.source();
+    }
+
+    false
+}
+
+fn render_error_chain(error: &dyn StdError) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut source = error.source();
+
+    while let Some(current) = source {
+        parts.push(current.to_string());
+        source = current.source();
+    }
+
+    parts.join(": ")
+}
+
+async fn run_wait<T, F>(wait_budget: WaitBudget, future: F) -> Result<(T, Duration), TimeoutReason>
+where
+    F: Future<Output = T>,
+{
+    let started = Instant::now();
+    let output = match wait_budget.timeout {
+        Some(timeout) => tokio::time::timeout(timeout, future)
+            .await
+            .map_err(|_| wait_budget.timeout_reason.unwrap_or(TimeoutReason::Request))?,
+        None => future.await,
+    };
+
+    Ok((output, started.elapsed()))
+}
+
+fn min_duration(left: Option<Duration>, right: Option<Duration>) -> Option<Duration> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn timeout_reason_to_error(_: TimeoutReason) -> HttpError {
+    HttpError::Timeout
+}
+
+fn timeout_message(reason: TimeoutReason) -> &'static str {
+    match reason {
+        TimeoutReason::Request => "http stream request timeout",
+        TimeoutReason::Idle => "http stream idle timeout",
+    }
+}

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -504,6 +504,7 @@ fn matches_compact_sensitive_header(compact: &str) -> bool {
         "refreshtoken",
         "sessionid",
         "sessionkey",
+        "sessiontoken",
         "clientsecret",
         "clienttoken",
         "credential",
@@ -521,6 +522,7 @@ fn matches_sensitive_token_pattern(tokens: &[&str]) -> bool {
             | ["refresh", "token"]
             | ["session", "id"]
             | ["session", "key"]
+            | ["session", "token"]
             | ["client", "secret"]
             | ["client", "token"]
             | ["credential"]

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -4,7 +4,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
     HeaderMap, HeaderName,
-    header::{AUTHORIZATION, COOKIE, HOST, ORIGIN, PROXY_AUTHORIZATION, REFERER},
+    header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, PRAGMA, USER_AGENT},
 };
 use reqwest::{Certificate, Client, Url};
 use tokio::{fs as tokio_fs, time::Instant};
@@ -465,7 +465,7 @@ pub(crate) fn same_origin(left: &Url, right: &Url) -> bool {
 pub(crate) fn strip_origin_bound_headers(headers: &mut HeaderMap) {
     let names_to_remove = headers
         .keys()
-        .filter(|name| is_cross_origin_sensitive_header(name))
+        .filter(|name| !is_cross_origin_whitelisted_header(name))
         .cloned()
         .collect::<Vec<_>>();
 
@@ -474,63 +474,10 @@ pub(crate) fn strip_origin_bound_headers(headers: &mut HeaderMap) {
     }
 }
 
-fn is_cross_origin_sensitive_header(name: &HeaderName) -> bool {
-    if matches!(
-        *name,
-        AUTHORIZATION | COOKIE | HOST | ORIGIN | PROXY_AUTHORIZATION | REFERER
-    ) {
-        return true;
-    }
-
-    let lower = name.as_str().to_ascii_lowercase();
-    let compact = lower
-        .chars()
-        .filter(|character| character.is_ascii_alphanumeric())
-        .collect::<String>();
-    let tokens = lower
-        .split(|character: char| !character.is_ascii_alphanumeric())
-        .filter(|token| !token.is_empty())
-        .collect::<Vec<_>>();
-
-    if matches_compact_sensitive_header(&compact) {
-        return true;
-    }
-
-    matches_sensitive_token_pattern(&tokens)
-}
-
-fn matches_compact_sensitive_header(compact: &str) -> bool {
-    [
-        "apikey",
-        "apitoken",
-        "authtoken",
-        "accesstoken",
-        "refreshtoken",
-        "sessionid",
-        "sessionkey",
-        "sessiontoken",
-        "clientsecret",
-        "clienttoken",
-        "credential",
-    ]
-    .iter()
-    .any(|needle| compact.contains(needle))
-}
-
-fn matches_sensitive_token_pattern(tokens: &[&str]) -> bool {
+fn is_cross_origin_whitelisted_header(name: &HeaderName) -> bool {
     matches!(
-        tokens,
-        ["api", "key"]
-            | ["api", "token"]
-            | ["auth", "token"]
-            | ["access", "token"]
-            | ["refresh", "token"]
-            | ["session", "id"]
-            | ["session", "key"]
-            | ["session", "token"]
-            | ["client", "secret"]
-            | ["client", "token"]
-            | ["credential"]
+        *name,
+        ACCEPT | ACCEPT_ENCODING | ACCEPT_LANGUAGE | CACHE_CONTROL | PRAGMA | USER_AGENT
     )
 }
 

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -4,19 +4,18 @@ use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
     HeaderMap,
-    header::{AUTHORIZATION, COOKIE, HOST, LOCATION, ORIGIN, REFERER},
+    header::{AUTHORIZATION, COOKIE, HOST, ORIGIN, REFERER},
 };
 use reqwest::{Certificate, Client, Url};
 use tokio::{fs as tokio_fs, time::Instant};
 
 use crate::{
-    ByteStream, HttpError, HttpMethod, HttpResponse, HttpStatusError, HttpStreamResponse,
-    build_error, run_blocking,
+    ByteStream, HttpError, HttpMethod, HttpStatusError, HttpStreamResponse, build_error,
+    run_blocking,
 };
 use crate::{
     config_resolution::ResolvedCallConfig,
     redaction::{sanitize_error_text, sanitize_parsed_url},
-    request_prep::PreparedRequest,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -117,118 +116,7 @@ impl WaitBudget {
     }
 }
 
-pub(crate) async fn execute_inner(
-    call_config: &ResolvedCallConfig,
-    prepared: PreparedRequest,
-    mut request_budget: RequestBudget,
-) -> Result<HttpResponse, HttpError> {
-    let request_url = prepared.request_url.clone();
-    let response = send_with_redirects(call_config, prepared, &mut request_budget).await?;
-
-    if !response.status().is_success() {
-        return Err(collect_status_error(response, &mut request_budget, &request_url).await?);
-    }
-
-    let status = response.status();
-    let headers = response.headers().clone();
-    let body = collect_success_body(response, &mut request_budget, &request_url).await?;
-
-    Ok(HttpResponse {
-        status,
-        headers,
-        body,
-    })
-}
-
-pub(crate) async fn stream_inner(
-    call_config: &ResolvedCallConfig,
-    prepared: PreparedRequest,
-    mut request_budget: RequestBudget,
-    idle_timeout: Option<Duration>,
-) -> Result<HttpStreamResponse, HttpError> {
-    let request_url = prepared.request_url.clone();
-    let response = send_with_redirects(call_config, prepared, &mut request_budget).await?;
-
-    if !response.status().is_success() {
-        return Err(collect_status_error(response, &mut request_budget, &request_url).await?);
-    }
-
-    let status = response.status();
-    let headers = response.headers().clone();
-    let body = wrap_stream(
-        request_url,
-        request_budget,
-        idle_timeout,
-        response.bytes_stream(),
-    );
-
-    Ok(HttpStreamResponse {
-        status,
-        headers,
-        body,
-    })
-}
-
-async fn send_with_redirects(
-    call_config: &ResolvedCallConfig,
-    prepared: PreparedRequest,
-    request_budget: &mut RequestBudget,
-) -> Result<reqwest::Response, HttpError> {
-    let mut request = prepared.request;
-    let method = prepared.method;
-    let mut redirect_count = 0_usize;
-
-    loop {
-        let current_request_url = sanitize_parsed_url(request.url());
-        let client = build_client(call_config, request.url().scheme() == "https").await?;
-        let redirect_template = if matches!(method, HttpMethod::Get) {
-            Some(
-                request
-                    .try_clone()
-                    .ok_or_else(|| build_error("failed to clone redirectable request"))?,
-            )
-        } else {
-            None
-        };
-        let response = send_with_budget(
-            client,
-            request,
-            current_request_url.as_str(),
-            request_budget,
-        )
-        .await?;
-
-        if matches!(method, HttpMethod::Get) && response.status().is_redirection() {
-            if redirect_count >= 10 {
-                return Err(build_error("too many redirects"));
-            }
-
-            let Some(location) = response.headers().get(LOCATION) else {
-                return Ok(response);
-            };
-            let location = location.to_str().map_err(|error| {
-                build_error(format!("invalid redirect location header: {error}"))
-            })?;
-            let next_url = response
-                .url()
-                .join(location)
-                .map_err(|error| build_error(format!("invalid redirect target URL: {error}")))?;
-            let mut next_request = redirect_template
-                .ok_or_else(|| build_error("missing redirect request template"))?;
-            if !same_origin(response.url(), &next_url) {
-                strip_origin_bound_headers(next_request.headers_mut());
-            }
-            *next_request.url_mut() = next_url;
-            request = next_request;
-            redirect_count += 1;
-            continue;
-        }
-
-        return Ok(response);
-    }
-}
-
-async fn send_with_budget(
+pub(crate) async fn send_with_budget(
     client: Client,
     request: reqwest::Request,
     request_url: &str,
@@ -244,7 +132,7 @@ async fn send_with_budget(
     response.map_err(|error| map_transport_error(error, request_url))
 }
 
-async fn collect_status_error(
+pub(crate) async fn collect_status_error(
     response: reqwest::Response,
     request_budget: &mut RequestBudget,
     request_url: &str,
@@ -307,7 +195,7 @@ async fn collect_status_error(
     }))
 }
 
-async fn collect_success_body(
+pub(crate) async fn collect_success_body(
     response: reqwest::Response,
     request_budget: &mut RequestBudget,
     request_url: &str,
@@ -517,7 +405,7 @@ pub(crate) fn log_transport_error(mode: &str, request_url: &str, error: &HttpErr
     );
 }
 
-async fn build_client(
+pub(crate) async fn build_client(
     call_config: &ResolvedCallConfig,
     uses_tls: bool,
 ) -> Result<Client, HttpError> {
@@ -584,13 +472,13 @@ fn parse_certificates(bundle: &[u8]) -> Result<Vec<Certificate>, HttpError> {
     Ok(certificates)
 }
 
-fn same_origin(left: &Url, right: &Url) -> bool {
+pub(crate) fn same_origin(left: &Url, right: &Url) -> bool {
     left.scheme() == right.scheme()
         && left.host_str() == right.host_str()
         && left.port_or_known_default() == right.port_or_known_default()
 }
 
-fn strip_origin_bound_headers(headers: &mut HeaderMap) {
+pub(crate) fn strip_origin_bound_headers(headers: &mut HeaderMap) {
     headers.remove(AUTHORIZATION);
     headers.remove(COOKIE);
     headers.remove(HOST);

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -138,15 +138,7 @@ pub(crate) async fn collect_status_error(
     loop {
         let wait_budget = match WaitBudget::new(request_budget.remaining(), None) {
             Ok(wait_budget) => wait_budget,
-            Err(_) => {
-                crate::log_event!(
-                    selvedge_logging::LogLevel::Warn,
-                    "http non-success response body timed out";
-                    url = url.as_str(),
-                    status = status.as_u16()
-                );
-                return Err(HttpError::Timeout);
-            }
+            Err(_) => unreachable!("status body collection does not use idle timeout"),
         };
         let (next_chunk, elapsed) = match run_wait(wait_budget, stream.next()).await {
             Ok(result) => result,
@@ -157,7 +149,7 @@ pub(crate) async fn collect_status_error(
                     url = url.as_str(),
                     status = status.as_u16()
                 );
-                return Err(HttpError::Timeout);
+                break;
             }
         };
         request_budget.charge(elapsed);

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -4,7 +4,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
     HeaderMap, HeaderName,
-    header::{AUTHORIZATION, COOKIE, HOST, ORIGIN, REFERER},
+    header::{AUTHORIZATION, COOKIE, HOST, ORIGIN, PROXY_AUTHORIZATION, REFERER},
 };
 use reqwest::{Certificate, Client, Url};
 use tokio::{fs as tokio_fs, time::Instant};
@@ -475,7 +475,10 @@ pub(crate) fn strip_origin_bound_headers(headers: &mut HeaderMap) {
 }
 
 fn is_cross_origin_sensitive_header(name: &HeaderName) -> bool {
-    if matches!(*name, AUTHORIZATION | COOKIE | HOST | ORIGIN | REFERER) {
+    if matches!(
+        *name,
+        AUTHORIZATION | COOKIE | HOST | ORIGIN | PROXY_AUTHORIZATION | REFERER
+    ) {
         return true;
     }
 

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -502,6 +502,7 @@ fn is_cross_origin_sensitive_header(name: &HeaderName) -> bool {
 fn matches_compact_sensitive_header(compact: &str) -> bool {
     [
         "apikey",
+        "apitoken",
         "authtoken",
         "accesstoken",
         "refreshtoken",
@@ -520,6 +521,7 @@ fn matches_sensitive_token_pattern(tokens: &[&str]) -> bool {
     matches!(
         tokens,
         ["api", "key"]
+            | ["api", "token"]
             | ["auth", "token"]
             | ["access", "token"]
             | ["refresh", "token"]

--- a/crates/client/src/runtime.rs
+++ b/crates/client/src/runtime.rs
@@ -3,7 +3,7 @@ use std::{error::Error as StdError, future::Future, path::Path, time::Duration};
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use http::{
-    HeaderMap,
+    HeaderMap, HeaderName,
     header::{AUTHORIZATION, COOKIE, HOST, ORIGIN, REFERER},
 };
 use reqwest::{Certificate, Client, Url};
@@ -479,11 +479,33 @@ pub(crate) fn same_origin(left: &Url, right: &Url) -> bool {
 }
 
 pub(crate) fn strip_origin_bound_headers(headers: &mut HeaderMap) {
-    headers.remove(AUTHORIZATION);
-    headers.remove(COOKIE);
-    headers.remove(HOST);
-    headers.remove(ORIGIN);
-    headers.remove(REFERER);
+    let names_to_remove = headers
+        .keys()
+        .filter(|name| is_cross_origin_sensitive_header(name))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for name in names_to_remove {
+        headers.remove(name);
+    }
+}
+
+fn is_cross_origin_sensitive_header(name: &HeaderName) -> bool {
+    if matches!(*name, AUTHORIZATION | COOKIE | HOST | ORIGIN | REFERER) {
+        return true;
+    }
+
+    let lower = name.as_str().to_ascii_lowercase();
+    let tokens = lower
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty());
+
+    tokens.into_iter().any(|token| {
+        matches!(
+            token,
+            "auth" | "authorization" | "token" | "key" | "secret" | "credential" | "session"
+        )
+    })
 }
 
 fn is_tls_error(error: &reqwest::Error) -> bool {

--- a/crates/client/src/single_hop.rs
+++ b/crates/client/src/single_hop.rs
@@ -1,0 +1,18 @@
+use crate::{
+    HttpError,
+    config_resolution::ResolvedCallConfig,
+    request_prep::PreparedRequest,
+    runtime::{RequestBudget, build_client, send_with_budget},
+};
+
+pub(crate) async fn send_single_hop(
+    call_config: &ResolvedCallConfig,
+    prepared: PreparedRequest,
+    request_budget: &mut RequestBudget,
+) -> Result<reqwest::Response, HttpError> {
+    let request_url = prepared.request_url;
+    let request = prepared.request;
+    let client = build_client(call_config, request.url().scheme() == "https").await?;
+
+    send_with_budget(client, request, request_url.as_str(), request_budget).await
+}

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -1,0 +1,550 @@
+mod support;
+
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::Redirect,
+    routing::{get, post},
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use selvedge_client::{
+    HttpError, HttpMethod, HttpRequest, HttpRequestBody, RequestCompression, execute, stream,
+};
+use support::{
+    assert_child_success, child_mode, init_client_test, run_child, spawn_http_proxy,
+    spawn_http_server, spawn_https_server,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    task::JoinHandle,
+    time::sleep,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_returns_full_response_body() {
+    const FLAG: &str = "SELVEDGE_CLIENT_EXECUTE_SUCCESS_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_returns_full_response_body", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let server =
+        spawn_http_server(Router::new().route("/ok", get(|| async { (StatusCode::OK, "ready") })))
+            .await;
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/ok"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: None,
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("execute request");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body, Bytes::from_static(b"ready"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_returns_status_error_after_redirect_without_retrying() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_STATUS_CHILD";
+
+    if !child_mode(FLAG) {
+        let output = run_child(
+            "execute_returns_status_error_after_redirect_without_retrying",
+            FLAG,
+        );
+        assert_child_success(&output);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("http request returned non-success status"));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_for_state = Arc::clone(&hits);
+    let app = Router::new()
+        .route("/redirect", get(|| async { Redirect::temporary("/final") }))
+        .route(
+            "/final",
+            get(|State(hits): State<Arc<AtomicUsize>>| async move {
+                hits.fetch_add(1, Ordering::SeqCst);
+                (StatusCode::IM_A_TEAPOT, "nope")
+            }),
+        )
+        .with_state(hits_for_state);
+    let server = spawn_http_server(app).await;
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/redirect"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: None,
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("redirect target should return status error");
+
+    match error {
+        HttpError::Status(status) => {
+            assert_eq!(status.status, StatusCode::IM_A_TEAPOT);
+            assert_eq!(status.url, server.url("/final"));
+            assert_eq!(status.body, Bytes::from_static(b"nope"));
+        }
+        other => panic!("expected status error, got {other:?}"),
+    }
+
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_applies_request_compression() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_applies_request_compression", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new().route(
+        "/capture",
+        post(|headers: HeaderMap, body: Bytes| async move {
+            let encoding = headers
+                .get("content-encoding")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            let decoded = tokio::task::spawn_blocking(move || {
+                zstd::stream::decode_all(body.as_ref()).expect("decode request body")
+            })
+            .await
+            .expect("join decoder");
+
+            Json(serde_json::json!({
+                "encoding": encoding,
+                "body": String::from_utf8(decoded).expect("utf8 body"),
+            }))
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Post,
+        url: server.url("/capture"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Bytes(Bytes::from_static(b"payload")),
+        timeout: None,
+        compression: RequestCompression::Zstd,
+    })
+    .await
+    .expect("compressed request");
+
+    let payload: serde_json::Value = serde_json::from_slice(&response.body).expect("json body");
+    assert_eq!(payload["encoding"], "zstd");
+    assert_eq!(payload["body"], "payload");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_uses_config_user_agent_when_missing() {
+    const FLAG: &str = "SELVEDGE_CLIENT_USER_AGENT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_uses_config_user_agent_when_missing",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    selvedge_config::update_runtime("network.user_agent", "selvedge-client/test")
+        .expect("set user agent");
+    let app = Router::new().route(
+        "/agent",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("user-agent")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/agent"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: None,
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("execute request");
+
+    assert_eq!(response.body, Bytes::from_static(b"selvedge-client/test"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_keeps_raw_zstd_response_bytes() {
+    const FLAG: &str = "SELVEDGE_CLIENT_RAW_ZSTD_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_keeps_raw_zstd_response_bytes", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let compressed = tokio::task::spawn_blocking(|| {
+        zstd::stream::encode_all("compressed".as_bytes(), 0).expect("compress response")
+    })
+    .await
+    .expect("join compressor");
+    let expected = Bytes::from(compressed);
+    let response_body = expected.clone();
+    let app = Router::new().route(
+        "/compressed",
+        get(move || {
+            let response_body = response_body.clone();
+            async move {
+                (
+                    [(
+                        http::header::CONTENT_ENCODING,
+                        HeaderValue::from_static("zstd"),
+                    )],
+                    response_body,
+                )
+            }
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/compressed"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: None,
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("execute request");
+
+    assert_eq!(response.body, expected);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_times_out_entire_request() {
+    const FLAG: &str = "SELVEDGE_CLIENT_EXECUTE_TIMEOUT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_times_out_entire_request", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new().route(
+        "/slow",
+        get(|| async move {
+            sleep(Duration::from_millis(150)).await;
+            (StatusCode::OK, "late")
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/slow"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_millis(50)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("request should time out");
+
+    assert!(matches!(error, HttpError::Timeout));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_maps_connect_failure() {
+    const FLAG: &str = "SELVEDGE_CLIENT_CONNECT_FAILURE_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_maps_connect_failure", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: format!("http://127.0.0.1:{port}/missing"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_millis(200)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("connect should fail");
+
+    assert!(matches!(error, HttpError::Connect { .. }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_maps_tls_failure() {
+    const FLAG: &str = "SELVEDGE_CLIENT_TLS_FAILURE_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_maps_tls_failure", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let server = spawn_https_server(StatusCode::OK, Bytes::from_static(b"secure")).await;
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url.clone(),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("tls should fail without custom ca");
+
+    assert!(matches!(error, HttpError::Tls { .. }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_accepts_custom_ca_bundle() {
+    const FLAG: &str = "SELVEDGE_CLIENT_CA_BUNDLE_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_accepts_custom_ca_bundle", FLAG));
+        return;
+    }
+
+    let tempdir = init_client_test().await;
+    let server = spawn_https_server(StatusCode::OK, Bytes::from_static(b"secure")).await;
+    let bundle_path = tempdir.path().join("ca.pem");
+    std::fs::write(&bundle_path, server.ca_cert_pem.as_bytes()).expect("write ca bundle");
+    selvedge_config::update_runtime(
+        "network.ca_bundle_path",
+        bundle_path.to_string_lossy().to_string(),
+    )
+    .expect("set ca bundle");
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url.clone(),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("custom ca should succeed");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body, Bytes::from_static(b"secure"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_uses_explicit_proxy() {
+    const FLAG: &str = "SELVEDGE_CLIENT_PROXY_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("execute_uses_explicit_proxy", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let origin = spawn_http_server(
+        Router::new().route("/proxied", get(|| async { (StatusCode::OK, "proxied") })),
+    )
+    .await;
+    let proxy = spawn_http_proxy().await;
+    selvedge_config::update_runtime("network.proxy_url", proxy.url.clone()).expect("set proxy");
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: origin.url("/proxied"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("request through proxy");
+
+    assert_eq!(response.body, Bytes::from_static(b"proxied"));
+    assert_eq!(proxy.hit_count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_returns_status_before_entering_body() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_STATUS_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_returns_status_before_entering_body",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let server = spawn_http_server(Router::new().route(
+        "/status",
+        get(|| async { (StatusCode::BAD_REQUEST, "bad request") }),
+    ))
+    .await;
+
+    let error = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/status"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(1)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("stream should return status error");
+
+    match error {
+        HttpError::Status(status) => {
+            assert_eq!(status.status, StatusCode::BAD_REQUEST);
+            assert_eq!(status.body, Bytes::from_static(b"bad request"));
+        }
+        other => panic!("expected status error, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_times_out_on_idle_gap() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_IDLE_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("stream_times_out_on_idle_gap", FLAG));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    selvedge_config::update_runtime("network.stream_idle_timeout_ms", 50_u64)
+        .expect("set idle timeout");
+    let app = Router::new().route(
+        "/stream",
+        get(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"first"));
+                sleep(Duration::from_millis(120)).await;
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"second"));
+            });
+
+            (StatusCode::OK, body)
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/stream"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(1)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("start stream");
+
+    let chunks = response.body.collect::<Vec<_>>().await;
+
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(
+        chunks[0].as_ref().expect("first chunk"),
+        &Bytes::from_static(b"first")
+    );
+    assert!(matches!(chunks[1], Err(HttpError::Timeout)));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_returns_transport_error_once_after_body_starts() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_TRANSPORT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_returns_transport_error_once_after_body_starts",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let (url, server_handle) = spawn_broken_chunked_server().await;
+
+    let response = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url,
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(1)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("start stream");
+
+    let chunks = response.body.collect::<Vec<_>>().await;
+
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(
+        chunks[0].as_ref().expect("first chunk"),
+        &Bytes::from_static(b"first")
+    );
+    assert!(matches!(chunks[1], Err(HttpError::Io { .. })));
+    server_handle.abort();
+}
+
+async fn spawn_broken_chunked_server() -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind broken chunked server");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept socket");
+        let mut buffer = [0_u8; 2048];
+        let _ = socket.read(&mut buffer).await.expect("read request");
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n5\r\nfirst\r\n")
+            .await
+            .expect("write partial chunked response");
+        socket.shutdown().await.expect("shutdown socket");
+    });
+
+    (format!("http://{addr}/stream"), handle)
+}

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -408,6 +408,43 @@ async fn execute_uses_explicit_proxy() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_preserves_status_when_error_body_is_truncated() {
+    const FLAG: &str = "SELVEDGE_CLIENT_TRUNCATED_STATUS_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_preserves_status_when_error_body_is_truncated",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let (url, server_handle) = spawn_truncated_status_server().await;
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url,
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(1)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("truncated error body should still return status");
+
+    match error {
+        HttpError::Status(status) => {
+            assert_eq!(status.status, StatusCode::BAD_GATEWAY);
+            assert_eq!(status.body, Bytes::from_static(b"par"));
+        }
+        other => panic!("expected status error, got {other:?}"),
+    }
+
+    server_handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_returns_status_before_entering_body() {
     const FLAG: &str = "SELVEDGE_CLIENT_STREAM_STATUS_CHILD";
 
@@ -444,6 +481,49 @@ async fn stream_returns_status_before_entering_body() {
         }
         other => panic!("expected status error, got {other:?}"),
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_request_timeout_covers_wait_for_first_chunk() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_FIRST_CHUNK_TIMEOUT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_request_timeout_covers_wait_for_first_chunk",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new().route(
+        "/stream",
+        get(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                sleep(Duration::from_millis(120)).await;
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"late"));
+            });
+
+            (StatusCode::OK, body)
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/stream"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_millis(50)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("response head should arrive");
+
+    let chunks = response.body.collect::<Vec<_>>().await;
+
+    assert_eq!(chunks.len(), 1);
+    assert!(matches!(chunks[0], Err(HttpError::Timeout)));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -547,4 +627,23 @@ async fn spawn_broken_chunked_server() -> (String, JoinHandle<()>) {
     });
 
     (format!("http://{addr}/stream"), handle)
+}
+
+async fn spawn_truncated_status_server() -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind truncated status server");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept socket");
+        let mut buffer = [0_u8; 2048];
+        let _ = socket.read(&mut buffer).await.expect("read request");
+        socket
+            .write_all(b"HTTP/1.1 502 Bad Gateway\r\ncontent-length: 7\r\n\r\npar")
+            .await
+            .expect("write partial error response");
+        socket.shutdown().await.expect("shutdown socket");
+    });
+
+    (format!("http://{addr}/status"), handle)
 }

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -823,6 +823,100 @@ async fn stream_idle_timeout_covers_wait_for_first_chunk() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_request_timeout_excludes_delay_before_first_poll() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_DELAYED_FIRST_POLL_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_request_timeout_excludes_delay_before_first_poll",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new().route(
+        "/stream",
+        get(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"ready"));
+            });
+
+            (StatusCode::OK, body)
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/stream"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_millis(50)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("response head should arrive");
+
+    sleep(Duration::from_millis(120)).await;
+
+    let mut body = response.body;
+    let first = body.next().await.expect("first stream item");
+
+    assert_eq!(first.expect("first chunk"), Bytes::from_static(b"ready"));
+    assert!(body.next().await.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_request_timeout_excludes_consumer_processing_time() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_CONSUMER_DELAY_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_request_timeout_excludes_consumer_processing_time",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new().route(
+        "/stream",
+        get(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"first"));
+                sleep(Duration::from_millis(20)).await;
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"second"));
+            });
+
+            (StatusCode::OK, body)
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/stream"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_millis(50)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("start stream");
+
+    let mut body = response.body;
+    let first = body.next().await.expect("first stream item");
+    assert_eq!(first.expect("first chunk"), Bytes::from_static(b"first"));
+
+    sleep(Duration::from_millis(120)).await;
+
+    let second = body.next().await.expect("second stream item");
+    assert_eq!(second.expect("second chunk"), Bytes::from_static(b"second"));
+    assert!(body.next().await.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_times_out_on_idle_gap() {
     const FLAG: &str = "SELVEDGE_CLIENT_STREAM_IDLE_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -780,12 +780,12 @@ async fn execute_preserves_status_when_error_body_is_truncated() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn execute_times_out_on_slow_non_success_body() {
+async fn execute_preserves_status_on_slow_non_success_body() {
     const FLAG: &str = "SELVEDGE_CLIENT_SLOW_ERROR_BODY_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "execute_times_out_on_slow_non_success_body",
+            "execute_preserves_status_on_slow_non_success_body",
             FLAG,
         ));
         return;
@@ -815,9 +815,15 @@ async fn execute_times_out_on_slow_non_success_body() {
         compression: RequestCompression::None,
     })
     .await
-    .expect_err("slow non-success body should time out");
+    .expect_err("slow non-success body should preserve status");
 
-    assert!(matches!(error, HttpError::Timeout));
+    match error {
+        HttpError::Status(status) => {
+            assert_eq!(status.status, StatusCode::BAD_REQUEST);
+            assert_eq!(status.body, Bytes::from_static(b"part"));
+        }
+        other => panic!("expected status error, got {other:?}"),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -435,6 +435,59 @@ async fn execute_redirect_drops_session_token_headers_on_cross_origin_redirect()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_drops_proxy_authorization_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_PROXY_AUTH_STRIP_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_drops_proxy_authorization_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("proxy-authorization")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "proxy-authorization",
+        HeaderValue::from_static("Basic c2VjcmV0"),
+    );
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::new());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_applies_request_compression() {
     const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -673,6 +673,51 @@ async fn stream_request_timeout_covers_wait_for_first_chunk() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_idle_timeout_covers_wait_for_first_chunk() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_FIRST_CHUNK_IDLE_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_idle_timeout_covers_wait_for_first_chunk",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    selvedge_config::update_runtime("network.stream_idle_timeout_ms", 50_u64)
+        .expect("set idle timeout");
+    let app = Router::new().route(
+        "/stream",
+        get(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                sleep(Duration::from_millis(120)).await;
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"late"));
+            });
+
+            (StatusCode::OK, body)
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let response = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/stream"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: None,
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("response head should arrive");
+
+    let chunks = response.body.collect::<Vec<_>>().await;
+
+    assert_eq!(chunks.len(), 1);
+    assert!(matches!(chunks[0], Err(HttpError::Timeout)));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_times_out_on_idle_gap() {
     const FLAG: &str = "SELVEDGE_CLIENT_STREAM_IDLE_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -425,6 +425,40 @@ async fn execute_maps_tls_failure() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redacts_sensitive_url_parts_in_transport_errors() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDACTED_ERROR_URL_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redacts_sensitive_url_parts_in_transport_errors",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let server = spawn_https_server(StatusCode::OK, Bytes::from_static(b"secure")).await;
+    let server_url = reqwest::Url::parse(&server.url).expect("parse server url");
+    let port = server_url.port().expect("server port");
+    let url = format!("https://user:pass@localhost:{port}/?token=secret");
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url,
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("tls should fail without custom ca");
+
+    let rendered = error.to_string();
+    assert!(!rendered.contains("user:pass"));
+    assert!(!rendered.contains("token=secret"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_accepts_custom_ca_bundle() {
     const FLAG: &str = "SELVEDGE_CLIENT_CA_BUNDLE_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -562,6 +562,40 @@ async fn execute_ignores_ambient_proxy_without_config_proxy_url() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_http_request_ignores_invalid_ca_bundle_path() {
+    const FLAG: &str = "SELVEDGE_CLIENT_HTTP_IGNORES_CA_BUNDLE_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_http_request_ignores_invalid_ca_bundle_path",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    selvedge_config::update_runtime("network.ca_bundle_path", "/definitely/missing-ca.pem")
+        .expect("set invalid ca bundle path");
+    let server = spawn_http_server(
+        Router::new().route("/direct", get(|| async { (StatusCode::OK, "direct") })),
+    )
+    .await;
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/direct"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("http requests should ignore ca bundle path");
+
+    assert_eq!(response.body, Bytes::from_static(b"direct"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_preserves_status_when_error_body_is_truncated() {
     const FLAG: &str = "SELVEDGE_CLIENT_TRUNCATED_STATUS_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -710,6 +710,46 @@ async fn stream_request_timeout_covers_wait_for_first_chunk() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_preserves_remaining_first_chunk_budget_after_slow_headers() {
+    const FLAG: &str = "SELVEDGE_CLIENT_STREAM_REMAINING_BUDGET_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_preserves_remaining_first_chunk_budget_after_slow_headers",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let (url, server_handle) = spawn_slow_header_then_chunk_server().await;
+    let started_at = tokio::time::Instant::now();
+
+    let response = stream(HttpRequest {
+        method: HttpMethod::Get,
+        url,
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_millis(50)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("response head should arrive before timeout");
+
+    let chunks = response.body.collect::<Vec<_>>().await;
+    let elapsed = started_at.elapsed();
+
+    assert_eq!(chunks.len(), 1);
+    assert!(matches!(chunks[0], Err(HttpError::Timeout)));
+    assert!(
+        elapsed < Duration::from_millis(80),
+        "remaining budget should be preserved, got {:?}",
+        elapsed
+    );
+    server_handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_idle_timeout_covers_wait_for_first_chunk() {
     const FLAG: &str = "SELVEDGE_CLIENT_STREAM_FIRST_CHUNK_IDLE_CHILD";
 
@@ -851,6 +891,31 @@ async fn spawn_broken_chunked_server() -> (String, JoinHandle<()>) {
             .write_all(b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n5\r\nfirst\r\n")
             .await
             .expect("write partial chunked response");
+        socket.shutdown().await.expect("shutdown socket");
+    });
+
+    (format!("http://{addr}/stream"), handle)
+}
+
+async fn spawn_slow_header_then_chunk_server() -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind slow header server");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept socket");
+        let mut buffer = [0_u8; 2048];
+        let _ = socket.read(&mut buffer).await.expect("read request");
+        sleep(Duration::from_millis(35)).await;
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n")
+            .await
+            .expect("write response head");
+        sleep(Duration::from_millis(40)).await;
+        socket
+            .write_all(b"4\r\nlate\r\n0\r\n\r\n")
+            .await
+            .expect("write response body");
         socket.shutdown().await.expect("shutdown socket");
     });
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -266,46 +266,25 @@ async fn execute_uses_config_user_agent_when_missing() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn execute_ignores_invalid_config_user_agent_when_request_sets_one() {
-    const FLAG: &str = "SELVEDGE_CLIENT_EXPLICIT_USER_AGENT_CHILD";
+async fn invalid_config_user_agent_is_rejected_before_request() {
+    const FLAG: &str = "SELVEDGE_CLIENT_INVALID_USER_AGENT_CONFIG_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "execute_ignores_invalid_config_user_agent_when_request_sets_one",
+            "invalid_config_user_agent_is_rejected_before_request",
             FLAG,
         ));
         return;
     }
 
     let _tempdir = init_client_test().await;
-    selvedge_config::update_runtime("network.user_agent", "bad\r\nvalue")
-        .expect("set invalid user agent");
-    let app = Router::new().route(
-        "/agent",
-        get(|headers: HeaderMap| async move {
-            headers
-                .get("user-agent")
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_owned()
-        }),
-    );
-    let server = spawn_http_server(app).await;
-    let mut headers = HeaderMap::new();
-    headers.insert("user-agent", HeaderValue::from_static("explicit-agent"));
+    let error = selvedge_config::update_runtime("network.user_agent", "bad\r\nvalue")
+        .expect_err("invalid user agent must fail during config update");
 
-    let response = execute(HttpRequest {
-        method: HttpMethod::Get,
-        url: server.url("/agent"),
-        headers,
-        body: HttpRequestBody::Empty,
-        timeout: None,
-        compression: RequestCompression::None,
-    })
-    .await
-    .expect("explicit header should win");
-
-    assert_eq!(response.body, Bytes::from_static(b"explicit-agent"));
+    assert!(matches!(
+        error,
+        selvedge_config::ConfigError::ValidationFailed(_)
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -23,8 +23,8 @@ use selvedge_client::{
     HttpError, HttpMethod, HttpRequest, HttpRequestBody, RequestCompression, execute, stream,
 };
 use support::{
-    assert_child_success, child_mode, init_client_test, run_child, run_child_with_env,
-    spawn_http_proxy, spawn_http_server, spawn_https_server,
+    assert_child_success, child_mode, init_client_test, run_child, spawn_http_server,
+    spawn_https_server,
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -540,75 +540,6 @@ async fn execute_accepts_custom_ca_bundle() {
 
     assert_eq!(response.status, StatusCode::OK);
     assert_eq!(response.body, Bytes::from_static(b"secure"));
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn execute_uses_explicit_proxy() {
-    const FLAG: &str = "SELVEDGE_CLIENT_PROXY_CHILD";
-
-    if !child_mode(FLAG) {
-        assert_child_success(&run_child("execute_uses_explicit_proxy", FLAG));
-        return;
-    }
-
-    let _tempdir = init_client_test().await;
-    let origin = spawn_http_server(
-        Router::new().route("/proxied", get(|| async { (StatusCode::OK, "proxied") })),
-    )
-    .await;
-    let proxy = spawn_http_proxy().await;
-    selvedge_config::update_runtime("network.proxy_url", proxy.url.clone()).expect("set proxy");
-
-    let response = execute(HttpRequest {
-        method: HttpMethod::Get,
-        url: origin.url("/proxied"),
-        headers: HeaderMap::new(),
-        body: HttpRequestBody::Empty,
-        timeout: Some(Duration::from_secs(2)),
-        compression: RequestCompression::None,
-    })
-    .await
-    .expect("request through proxy");
-
-    assert_eq!(response.body, Bytes::from_static(b"proxied"));
-    assert_eq!(proxy.hit_count(), 1);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn execute_ignores_ambient_proxy_without_config_proxy_url() {
-    const FLAG: &str = "SELVEDGE_CLIENT_IGNORE_ENV_PROXY_CHILD";
-
-    if !child_mode(FLAG) {
-        let output = run_child_with_env(
-            "execute_ignores_ambient_proxy_without_config_proxy_url",
-            FLAG,
-            &[
-                ("HTTP_PROXY", "http://127.0.0.1:9"),
-                ("HTTPS_PROXY", "http://127.0.0.1:9"),
-            ],
-        );
-        assert_child_success(&output);
-        return;
-    }
-
-    let _tempdir = init_client_test().await;
-    let server = spawn_http_server(
-        Router::new().route("/direct", get(|| async { (StatusCode::OK, "direct") })),
-    )
-    .await;
-
-    let response = execute(HttpRequest {
-        method: HttpMethod::Get,
-        url: server.url("/direct"),
-        headers: HeaderMap::new(),
-        body: HttpRequestBody::Empty,
-        timeout: Some(Duration::from_secs(2)),
-        compression: RequestCompression::None,
-    })
-    .await
-    .expect("ambient proxy should be ignored");
-
-    assert_eq!(response.body, Bytes::from_static(b"direct"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -164,6 +164,67 @@ async fn execute_applies_request_compression() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_recomputes_content_length_after_compression() {
+    const FLAG: &str = "SELVEDGE_CLIENT_COMPRESSED_LENGTH_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_recomputes_content_length_after_compression",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new().route(
+        "/capture",
+        post(|headers: HeaderMap, body: Bytes| async move {
+            let content_length = headers
+                .get("content-length")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            let received_len = body.len();
+            let decoded = tokio::task::spawn_blocking(move || {
+                zstd::stream::decode_all(body.as_ref()).expect("decode request body")
+            })
+            .await
+            .expect("join decoder");
+
+            Json(serde_json::json!({
+                "content_length": content_length,
+                "received_len": received_len,
+                "body": String::from_utf8(decoded).expect("utf8 body"),
+            }))
+        }),
+    );
+    let server = spawn_http_server(app).await;
+    let mut headers = HeaderMap::new();
+    headers.insert("content-length", HeaderValue::from_static("7"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Post,
+        url: server.url("/capture"),
+        headers,
+        body: HttpRequestBody::Bytes(Bytes::from_static(b"payload")),
+        timeout: None,
+        compression: RequestCompression::Zstd,
+    })
+    .await
+    .expect("compressed request with explicit content-length");
+
+    let payload: serde_json::Value = serde_json::from_slice(&response.body).expect("json body");
+    assert_eq!(payload["body"], "payload");
+    assert_eq!(
+        payload["content_length"],
+        payload["received_len"]
+            .as_u64()
+            .expect("received length")
+            .to_string()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_uses_config_user_agent_when_missing() {
     const FLAG: &str = "SELVEDGE_CLIENT_USER_AGENT_CHILD";
 
@@ -485,6 +546,47 @@ async fn execute_preserves_status_when_error_body_is_truncated() {
     }
 
     server_handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_times_out_on_slow_non_success_body() {
+    const FLAG: &str = "SELVEDGE_CLIENT_SLOW_ERROR_BODY_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_times_out_on_slow_non_success_body",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new().route(
+        "/error",
+        get(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"part"));
+                sleep(Duration::from_millis(120)).await;
+                yield Ok::<Bytes, Infallible>(Bytes::from_static(b"late"));
+            });
+
+            (StatusCode::BAD_REQUEST, body)
+        }),
+    );
+    let server = spawn_http_server(app).await;
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/error"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_millis(50)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("slow non-success body should time out");
+
+    assert!(matches!(error, HttpError::Timeout));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -232,6 +232,56 @@ async fn execute_redirect_drops_origin_bound_headers_on_cross_origin_redirect() 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_drops_custom_credential_headers_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_CUSTOM_CREDENTIAL_STRIP_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_drops_custom_credential_headers_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("x-api-key")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert("x-api-key", HeaderValue::from_static("secret-key"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::new());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_applies_request_compression() {
     const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -23,8 +23,8 @@ use selvedge_client::{
     HttpError, HttpMethod, HttpRequest, HttpRequestBody, RequestCompression, execute, stream,
 };
 use support::{
-    assert_child_success, child_mode, init_client_test, run_child, spawn_http_proxy,
-    spawn_http_server, spawn_https_server,
+    assert_child_success, child_mode, init_client_test, run_child, run_child_with_env,
+    spawn_http_proxy, spawn_http_server, spawn_https_server,
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -509,6 +509,43 @@ async fn execute_uses_explicit_proxy() {
 
     assert_eq!(response.body, Bytes::from_static(b"proxied"));
     assert_eq!(proxy.hit_count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_ignores_ambient_proxy_without_config_proxy_url() {
+    const FLAG: &str = "SELVEDGE_CLIENT_IGNORE_ENV_PROXY_CHILD";
+
+    if !child_mode(FLAG) {
+        let output = run_child_with_env(
+            "execute_ignores_ambient_proxy_without_config_proxy_url",
+            FLAG,
+            &[
+                ("HTTP_PROXY", "http://127.0.0.1:9"),
+                ("HTTPS_PROXY", "http://127.0.0.1:9"),
+            ],
+        );
+        assert_child_success(&output);
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let server = spawn_http_server(
+        Router::new().route("/direct", get(|| async { (StatusCode::OK, "direct") })),
+    )
+    .await;
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/direct"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("ambient proxy should be ignored");
+
+    assert_eq!(response.body, Bytes::from_static(b"direct"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -332,12 +332,12 @@ async fn execute_redirect_drops_compact_custom_credential_headers_on_cross_origi
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn execute_redirect_preserves_non_secret_metadata_headers_on_cross_origin_redirect() {
+async fn execute_redirect_drops_non_whitelisted_headers_on_cross_origin_redirect() {
     const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_METADATA_HEADER_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "execute_redirect_preserves_non_secret_metadata_headers_on_cross_origin_redirect",
+            "execute_redirect_drops_non_whitelisted_headers_on_cross_origin_redirect",
             FLAG,
         ));
         return;
@@ -378,7 +378,57 @@ async fn execute_redirect_preserves_non_secret_metadata_headers_on_cross_origin_
     .await
     .expect("cross-origin redirect request");
 
-    assert_eq!(response.body, Bytes::from_static(b"feature-a"));
+    assert_eq!(response.body, Bytes::new());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_preserves_whitelisted_headers_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_WHITELIST_HEADER_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_preserves_whitelisted_headers_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("accept-language")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert("accept-language", HeaderValue::from_static("en-US"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::from_static(b"en-US"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -116,6 +116,56 @@ async fn execute_returns_status_error_after_redirect_without_retrying() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_drops_origin_bound_headers_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_HEADER_STRIP_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_drops_origin_bound_headers_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert("authorization", HeaderValue::from_static("Bearer secret"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::new());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_applies_request_compression() {
     const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -282,6 +282,56 @@ async fn execute_redirect_drops_custom_credential_headers_on_cross_origin_redire
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_drops_compact_custom_credential_headers_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_COMPACT_CREDENTIAL_STRIP_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_drops_compact_custom_credential_headers_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("x-apikey")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert("x-apikey", HeaderValue::from_static("secret-key"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::new());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_applies_request_compression() {
     const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -577,15 +577,15 @@ async fn execute_http_request_ignores_invalid_ca_bundle_path() {
     selvedge_config::update_runtime("network.ca_bundle_path", "/definitely/missing-ca.pem")
         .expect("set invalid ca bundle path");
     let server = spawn_http_server(
-        Router::new().route("/direct", post(|| async { (StatusCode::OK, "direct") })),
+        Router::new().route("/direct", get(|| async { (StatusCode::OK, "direct") })),
     )
     .await;
 
     let response = execute(HttpRequest {
-        method: HttpMethod::Post,
+        method: HttpMethod::Get,
         url: server.url("/direct"),
         headers: HeaderMap::new(),
-        body: HttpRequestBody::Bytes(Bytes::from_static(b"payload")),
+        body: HttpRequestBody::Empty,
         timeout: Some(Duration::from_secs(2)),
         compression: RequestCompression::None,
     })

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -205,6 +205,49 @@ async fn execute_uses_config_user_agent_when_missing() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_ignores_invalid_config_user_agent_when_request_sets_one() {
+    const FLAG: &str = "SELVEDGE_CLIENT_EXPLICIT_USER_AGENT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_ignores_invalid_config_user_agent_when_request_sets_one",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    selvedge_config::update_runtime("network.user_agent", "bad\r\nvalue")
+        .expect("set invalid user agent");
+    let app = Router::new().route(
+        "/agent",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("user-agent")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    );
+    let server = spawn_http_server(app).await;
+    let mut headers = HeaderMap::new();
+    headers.insert("user-agent", HeaderValue::from_static("explicit-agent"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/agent"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: None,
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("explicit header should win");
+
+    assert_eq!(response.body, Bytes::from_static(b"explicit-agent"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_keeps_raw_zstd_response_bytes() {
     const FLAG: &str = "SELVEDGE_CLIENT_RAW_ZSTD_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -577,15 +577,15 @@ async fn execute_http_request_ignores_invalid_ca_bundle_path() {
     selvedge_config::update_runtime("network.ca_bundle_path", "/definitely/missing-ca.pem")
         .expect("set invalid ca bundle path");
     let server = spawn_http_server(
-        Router::new().route("/direct", get(|| async { (StatusCode::OK, "direct") })),
+        Router::new().route("/direct", post(|| async { (StatusCode::OK, "direct") })),
     )
     .await;
 
     let response = execute(HttpRequest {
-        method: HttpMethod::Get,
+        method: HttpMethod::Post,
         url: server.url("/direct"),
         headers: HeaderMap::new(),
-        body: HttpRequestBody::Empty,
+        body: HttpRequestBody::Bytes(Bytes::from_static(b"payload")),
         timeout: Some(Duration::from_secs(2)),
         compression: RequestCompression::None,
     })

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -488,10 +488,11 @@ async fn stream_request_timeout_covers_wait_for_first_chunk() {
     const FLAG: &str = "SELVEDGE_CLIENT_STREAM_FIRST_CHUNK_TIMEOUT_CHILD";
 
     if !child_mode(FLAG) {
-        assert_child_success(&run_child(
-            "stream_request_timeout_covers_wait_for_first_chunk",
-            FLAG,
-        ));
+        let output = run_child("stream_request_timeout_covers_wait_for_first_chunk", FLAG);
+        assert_child_success(&output);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("http stream request timeout"));
+        assert!(!stderr.contains("message=\"http request finished\""));
         return;
     }
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -116,6 +116,72 @@ async fn execute_returns_status_error_after_redirect_without_retrying() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_without_location_fails_build() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_MISSING_LOCATION_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_without_location_fails_build",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let server = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(|| async { (StatusCode::FOUND, HeaderMap::new(), Bytes::new()) }),
+    ))
+    .await;
+
+    let error = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/redirect"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(1)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect_err("redirect without location must fail");
+
+    assert!(matches!(error, HttpError::Build { .. }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_logs_redirect_hops() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_LOG_CHILD";
+
+    if !child_mode(FLAG) {
+        let output = run_child("execute_logs_redirect_hops", FLAG);
+        assert_child_success(&output);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("http request redirected"));
+        assert!(stderr.contains("hop=\"1\""));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let app = Router::new()
+        .route("/redirect", get(|| async { Redirect::temporary("/ok") }))
+        .route("/ok", get(|| async { (StatusCode::OK, "ready") }));
+    let server = spawn_http_server(app).await;
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: server.url("/redirect"),
+        headers: HeaderMap::new(),
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(1)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("redirect should succeed");
+
+    assert_eq!(response.body, Bytes::from_static(b"ready"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_redirect_drops_origin_bound_headers_on_cross_origin_redirect() {
     const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_HEADER_STRIP_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -332,6 +332,56 @@ async fn execute_redirect_drops_compact_custom_credential_headers_on_cross_origi
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_preserves_non_secret_metadata_headers_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_METADATA_HEADER_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_preserves_non_secret_metadata_headers_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("x-feature-key")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert("x-feature-key", HeaderValue::from_static("feature-a"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::from_static(b"feature-a"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_applies_request_compression() {
     const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -382,6 +382,59 @@ async fn execute_redirect_preserves_non_secret_metadata_headers_on_cross_origin_
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_drops_session_token_headers_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_SESSION_TOKEN_STRIP_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_drops_session_token_headers_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("x-session-token")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-session-token",
+        HeaderValue::from_static("session-secret"),
+    );
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::new());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_applies_request_compression() {
     const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
 

--- a/crates/client/tests/http_integration.rs
+++ b/crates/client/tests/http_integration.rs
@@ -488,6 +488,56 @@ async fn execute_redirect_drops_proxy_authorization_on_cross_origin_redirect() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_redirect_drops_api_token_headers_on_cross_origin_redirect() {
+    const FLAG: &str = "SELVEDGE_CLIENT_REDIRECT_API_TOKEN_STRIP_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "execute_redirect_drops_api_token_headers_on_cross_origin_redirect",
+            FLAG,
+        ));
+        return;
+    }
+
+    let _tempdir = init_client_test().await;
+    let target = spawn_http_server(Router::new().route(
+        "/final",
+        get(|headers: HeaderMap| async move {
+            headers
+                .get("x-api-token")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }),
+    ))
+    .await;
+    let redirect_target = target.url("/final");
+    let redirect = spawn_http_server(Router::new().route(
+        "/redirect",
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::temporary(&redirect_target) }
+        }),
+    ))
+    .await;
+    let mut headers = HeaderMap::new();
+    headers.insert("x-api-token", HeaderValue::from_static("api-secret"));
+
+    let response = execute(HttpRequest {
+        method: HttpMethod::Get,
+        url: redirect.url("/redirect"),
+        headers,
+        body: HttpRequestBody::Empty,
+        timeout: Some(Duration::from_secs(2)),
+        compression: RequestCompression::None,
+    })
+    .await
+    .expect("cross-origin redirect request");
+
+    assert_eq!(response.body, Bytes::new());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_applies_request_compression() {
     const FLAG: &str = "SELVEDGE_CLIENT_REQUEST_COMPRESSION_CHILD";
 

--- a/crates/client/tests/support/mod.rs
+++ b/crates/client/tests/support/mod.rs
@@ -1,0 +1,269 @@
+use std::{
+    net::SocketAddr,
+    process::{Command, Output},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use axum::Router;
+use bytes::Bytes;
+use rcgen::generate_simple_self_signed;
+use tempfile::TempDir;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    task::JoinHandle,
+};
+use tokio_rustls::{
+    TlsAcceptor,
+    rustls::{
+        self,
+        pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+    },
+};
+
+pub fn child_mode(flag: &str) -> bool {
+    std::env::var_os(flag).is_some()
+}
+
+pub fn run_child(test_name: &str, flag: &str) -> Output {
+    let current_executable = std::env::current_exe().expect("current test executable");
+
+    Command::new(current_executable)
+        .arg("--exact")
+        .arg(test_name)
+        .env(flag, "1")
+        .output()
+        .expect("run child test")
+}
+
+pub fn assert_child_success(output: &Output) {
+    assert!(output.status.success(), "child test failed: {output:?}");
+}
+
+pub async fn init_client_test() -> TempDir {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_home = tempdir.path().join(".selvedge");
+    let config_path = config_home.join("config.toml");
+
+    std::fs::create_dir_all(&config_home).expect("create config home");
+    std::fs::write(
+        &config_path,
+        r#"
+[server]
+host = "127.0.0.1"
+port = 8080
+request_timeout_ms = 5000
+
+[logging]
+level = "debug"
+"#,
+    )
+    .expect("write config");
+
+    selvedge_config::init_with_home(&config_home).expect("init config");
+    selvedge_logging::init().expect("init logging");
+
+    tempdir
+}
+
+pub struct TestServer {
+    pub addr: SocketAddr,
+    pub handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    pub fn url(&self, path: &str) -> String {
+        format!("http://{}{}", self.addr, path)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+pub async fn spawn_http_server(router: Router) -> TestServer {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("serve http test app");
+    });
+
+    TestServer { addr, handle }
+}
+
+pub struct HttpsServer {
+    pub url: String,
+    pub ca_cert_pem: String,
+    handle: JoinHandle<()>,
+}
+
+impl Drop for HttpsServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+pub async fn spawn_https_server(status: http::StatusCode, body: Bytes) -> HttpsServer {
+    install_rustls_provider();
+    let certificate = generate_simple_self_signed(vec!["localhost".to_owned()])
+        .expect("generate self-signed certificate");
+    let cert_der: CertificateDer<'static> = certificate.cert.der().clone();
+    let key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
+        certificate.signing_key.serialize_der(),
+    ));
+    let ca_cert_pem = certificate.cert.pem();
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .expect("server tls config");
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind tls test server");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = tokio::spawn(async move {
+        loop {
+            let (socket, _) = listener.accept().await.expect("accept tls socket");
+            let acceptor = acceptor.clone();
+            let body = body.clone();
+
+            tokio::spawn(async move {
+                let mut tls_stream = acceptor.accept(socket).await.expect("tls accept");
+                let mut buffer = vec![0; 4096];
+                let _ = tls_stream.read(&mut buffer).await.expect("read request");
+                let response = format!(
+                    "HTTP/1.1 {} {}\r\ncontent-length: {}\r\n\r\n",
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or("OK"),
+                    body.len()
+                );
+
+                tls_stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write response head");
+                tls_stream
+                    .write_all(&body)
+                    .await
+                    .expect("write response body");
+                tls_stream.shutdown().await.expect("shutdown tls stream");
+            });
+        }
+    });
+
+    HttpsServer {
+        url: format!("https://localhost:{}/", addr.port()),
+        ca_cert_pem,
+        handle,
+    }
+}
+
+pub struct ProxyServer {
+    pub url: String,
+    pub hits: Arc<AtomicUsize>,
+    handle: JoinHandle<()>,
+}
+
+impl ProxyServer {
+    pub fn hit_count(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for ProxyServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+pub async fn spawn_http_proxy() -> ProxyServer {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy server");
+    let addr = listener.local_addr().expect("local addr");
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_for_server = Arc::clone(&hits);
+    let handle = tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = listener.accept().await.expect("accept proxy socket");
+            let hits = Arc::clone(&hits_for_server);
+            tokio::spawn(async move {
+                hits.fetch_add(1, Ordering::SeqCst);
+                handle_proxy_connection(&mut socket)
+                    .await
+                    .expect("proxy request");
+            });
+        }
+    });
+
+    ProxyServer {
+        url: format!("http://{addr}"),
+        hits,
+        handle,
+    }
+}
+
+async fn handle_proxy_connection(socket: &mut TcpStream) -> Result<(), Box<dyn std::error::Error>> {
+    let mut request_buffer = Vec::new();
+
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let bytes_read = socket.read(&mut chunk).await?;
+
+        if bytes_read == 0 {
+            break;
+        }
+
+        request_buffer.extend_from_slice(&chunk[..bytes_read]);
+
+        if request_buffer
+            .windows(4)
+            .any(|window| window == b"\r\n\r\n")
+        {
+            break;
+        }
+    }
+
+    let request = String::from_utf8(request_buffer)?;
+    let request_line = request.lines().next().expect("proxy request line");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().expect("proxy request method");
+    let target = parts.next().expect("proxy request target");
+    let response = reqwest::Client::new()
+        .request(reqwest::Method::from_bytes(method.as_bytes())?, target)
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.bytes().await?;
+    let response_head = format!(
+        "HTTP/1.1 {} {}\r\ncontent-length: {}\r\n\r\n",
+        status.as_u16(),
+        status.canonical_reason().unwrap_or("OK"),
+        body.len()
+    );
+
+    socket.write_all(response_head.as_bytes()).await?;
+    socket.write_all(&body).await?;
+    socket.shutdown().await?;
+
+    Ok(())
+}
+
+fn install_rustls_provider() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+
+    INSTALLED.get_or_init(|| {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("install rustls crypto provider");
+    });
+}

--- a/crates/client/tests/support/mod.rs
+++ b/crates/client/tests/support/mod.rs
@@ -1,10 +1,7 @@
 use std::{
     net::SocketAddr,
     process::{Command, Output},
-    sync::{
-        Arc, OnceLock,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, OnceLock},
 };
 
 use axum::Router;
@@ -13,7 +10,7 @@ use rcgen::generate_simple_self_signed;
 use tempfile::TempDir;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
+    net::TcpListener,
     task::JoinHandle,
 };
 use tokio_rustls::{
@@ -37,19 +34,6 @@ pub fn run_child(test_name: &str, flag: &str) -> Output {
         .env(flag, "1")
         .output()
         .expect("run child test")
-}
-
-pub fn run_child_with_env(test_name: &str, flag: &str, envs: &[(&str, &str)]) -> Output {
-    let current_executable = std::env::current_exe().expect("current test executable");
-    let mut command = Command::new(current_executable);
-
-    command.arg("--exact").arg(test_name).env(flag, "1");
-
-    for (key, value) in envs {
-        command.env(key, value);
-    }
-
-    command.output().expect("run child test with env")
 }
 
 pub fn assert_child_success(output: &Output) {
@@ -178,97 +162,6 @@ pub async fn spawn_https_server(status: http::StatusCode, body: Bytes) -> HttpsS
         ca_cert_pem,
         handle,
     }
-}
-
-pub struct ProxyServer {
-    pub url: String,
-    pub hits: Arc<AtomicUsize>,
-    handle: JoinHandle<()>,
-}
-
-impl ProxyServer {
-    pub fn hit_count(&self) -> usize {
-        self.hits.load(Ordering::SeqCst)
-    }
-}
-
-impl Drop for ProxyServer {
-    fn drop(&mut self) {
-        self.handle.abort();
-    }
-}
-
-pub async fn spawn_http_proxy() -> ProxyServer {
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind proxy server");
-    let addr = listener.local_addr().expect("local addr");
-    let hits = Arc::new(AtomicUsize::new(0));
-    let hits_for_server = Arc::clone(&hits);
-    let handle = tokio::spawn(async move {
-        loop {
-            let (mut socket, _) = listener.accept().await.expect("accept proxy socket");
-            let hits = Arc::clone(&hits_for_server);
-            tokio::spawn(async move {
-                hits.fetch_add(1, Ordering::SeqCst);
-                handle_proxy_connection(&mut socket)
-                    .await
-                    .expect("proxy request");
-            });
-        }
-    });
-
-    ProxyServer {
-        url: format!("http://{addr}"),
-        hits,
-        handle,
-    }
-}
-
-async fn handle_proxy_connection(socket: &mut TcpStream) -> Result<(), Box<dyn std::error::Error>> {
-    let mut request_buffer = Vec::new();
-
-    loop {
-        let mut chunk = [0_u8; 1024];
-        let bytes_read = socket.read(&mut chunk).await?;
-
-        if bytes_read == 0 {
-            break;
-        }
-
-        request_buffer.extend_from_slice(&chunk[..bytes_read]);
-
-        if request_buffer
-            .windows(4)
-            .any(|window| window == b"\r\n\r\n")
-        {
-            break;
-        }
-    }
-
-    let request = String::from_utf8(request_buffer)?;
-    let request_line = request.lines().next().expect("proxy request line");
-    let mut parts = request_line.split_whitespace();
-    let method = parts.next().expect("proxy request method");
-    let target = parts.next().expect("proxy request target");
-    let response = reqwest::Client::new()
-        .request(reqwest::Method::from_bytes(method.as_bytes())?, target)
-        .send()
-        .await?;
-    let status = response.status();
-    let body = response.bytes().await?;
-    let response_head = format!(
-        "HTTP/1.1 {} {}\r\ncontent-length: {}\r\n\r\n",
-        status.as_u16(),
-        status.canonical_reason().unwrap_or("OK"),
-        body.len()
-    );
-
-    socket.write_all(response_head.as_bytes()).await?;
-    socket.write_all(&body).await?;
-    socket.shutdown().await?;
-
-    Ok(())
 }
 
 fn install_rustls_provider() {

--- a/crates/client/tests/support/mod.rs
+++ b/crates/client/tests/support/mod.rs
@@ -39,6 +39,19 @@ pub fn run_child(test_name: &str, flag: &str) -> Output {
         .expect("run child test")
 }
 
+pub fn run_child_with_env(test_name: &str, flag: &str, envs: &[(&str, &str)]) -> Output {
+    let current_executable = std::env::current_exe().expect("current test executable");
+    let mut command = Command::new(current_executable);
+
+    command.arg("--exact").arg(test_name).env(flag, "1");
+
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+
+    command.output().expect("run child test with env")
+}
+
 pub fn assert_child_success(output: &Output) {
     assert!(output.status.success(), "child test failed: {output:?}");
 }

--- a/crates/config-model/Cargo.toml
+++ b/crates/config-model/Cargo.toml
@@ -8,7 +8,6 @@ http = "1.3.1"
 serde = { version = "1.0.215", features = ["derive"] }
 thiserror = "2.0.3"
 toml = "0.8.19"
-url = "2.5.7"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/config-model/Cargo.toml
+++ b/crates/config-model/Cargo.toml
@@ -4,9 +4,11 @@ edition = "2024"
 publish = false
 
 [dependencies]
+http = "1.3.1"
 serde = { version = "1.0.215", features = ["derive"] }
 thiserror = "2.0.3"
 toml = "0.8.19"
+url = "2.5.7"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/config-model/README.md
+++ b/crates/config-model/README.md
@@ -77,6 +77,13 @@ let connect_timeout = config.network.connect_timeout_ms;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+`NetworkConfig` intentionally keeps transport-facing settings optional.
+
+- unset `network.*` fields stay `None` in `AppConfig`
+- `config-model` does not inject fallback transport defaults for those fields
+- downstream transport crates decide whether `None` means "do not set this option" or "treat this as an error"
+- this is different from fields such as `server.request_timeout_ms`, which materialize to a concrete default value inside the config model
+
 ## Validation
 
 Each config type validates its own invariants.

--- a/crates/config-model/README.md
+++ b/crates/config-model/README.md
@@ -11,6 +11,7 @@ Use it to:
 - define validation rules next to those structs
 - materialize `AppConfig` from raw TOML input
 - expose strongly typed logging levels and module-level log overrides
+- expose strongly typed network settings consumed by transport crates
 
 ## This crate is not for
 
@@ -62,6 +63,17 @@ Callers read strongly typed fields from `AppConfig`.
 # let config = AppConfig::try_from(toml::Table::new())?;
 let timeout_ms = config.server.request_timeout_ms;
 # let _ = timeout_ms;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Network-facing modules read from `config.network`.
+
+```no_run
+# use std::convert::TryFrom;
+# use selvedge_config_model::AppConfig;
+# let config = AppConfig::try_from(toml::Table::new())?;
+let connect_timeout = config.network.connect_timeout_ms;
+# let _ = connect_timeout;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -6,7 +6,6 @@ use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use toml::{Table, Value};
-use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AppConfig {
@@ -70,7 +69,6 @@ pub struct NetworkConfig {
     pub connect_timeout_ms: Option<u64>,
     pub request_timeout_ms: Option<u64>,
     pub stream_idle_timeout_ms: Option<u64>,
-    pub proxy_url: Option<String>,
     pub ca_bundle_path: Option<std::path::PathBuf>,
     pub user_agent: Option<String>,
 }
@@ -87,15 +85,6 @@ impl NetworkConfig {
 
         if self.stream_idle_timeout_ms == Some(0) {
             return Err(ValidationError::InvalidStreamIdleTimeout);
-        }
-
-        if let Some(proxy_url) = &self.proxy_url {
-            let parsed = Url::parse(proxy_url)
-                .map_err(|_| ValidationError::InvalidProxyUrl(proxy_url.clone()))?;
-            match parsed.scheme() {
-                "http" | "https" => {}
-                _ => return Err(ValidationError::InvalidProxyUrl(proxy_url.clone())),
-            }
         }
 
         if let Some(user_agent) = &self.user_agent {
@@ -190,8 +179,6 @@ pub enum ValidationError {
     InvalidNetworkRequestTimeout,
     #[error("network.stream_idle_timeout_ms must be greater than zero")]
     InvalidStreamIdleTimeout,
-    #[error("network.proxy_url must be a valid absolute URL, got {0}")]
-    InvalidProxyUrl(String),
     #[error("network.user_agent must be a valid HTTP header value, got {0}")]
     InvalidUserAgent(String),
     #[error("feature.rollout_percentage must be between 0 and 100, got {0}")]
@@ -248,7 +235,6 @@ struct NetworkConfigInput {
     connect_timeout_ms: Option<u64>,
     request_timeout_ms: Option<u64>,
     stream_idle_timeout_ms: Option<u64>,
-    proxy_url: Option<String>,
     ca_bundle_path: Option<std::path::PathBuf>,
     user_agent: Option<String>,
 }
@@ -259,7 +245,6 @@ impl NetworkConfigInput {
             connect_timeout_ms: self.connect_timeout_ms,
             request_timeout_ms: self.request_timeout_ms,
             stream_idle_timeout_ms: self.stream_idle_timeout_ms,
-            proxy_url: self.proxy_url,
             ca_bundle_path: self.ca_bundle_path,
             user_agent: self.user_agent,
         }
@@ -316,7 +301,6 @@ mod tests {
         assert_eq!(config.network.connect_timeout_ms, None);
         assert_eq!(config.network.request_timeout_ms, None);
         assert_eq!(config.network.stream_idle_timeout_ms, None);
-        assert_eq!(config.network.proxy_url, None);
         assert_eq!(config.network.ca_bundle_path, None);
         assert_eq!(config.network.user_agent, None);
         assert_eq!(config.logging.level, LogFilter::Info);
@@ -366,7 +350,6 @@ mod tests {
             connect_timeout_ms = 1_000
             request_timeout_ms = 30_000
             stream_idle_timeout_ms = 300_000
-            proxy_url = "http://localhost:8080"
             ca_bundle_path = "/tmp/ca.pem"
             user_agent = "selvedge-client/test"
         };
@@ -376,10 +359,6 @@ mod tests {
         assert_eq!(config.network.connect_timeout_ms, Some(1_000));
         assert_eq!(config.network.request_timeout_ms, Some(30_000));
         assert_eq!(config.network.stream_idle_timeout_ms, Some(300_000));
-        assert_eq!(
-            config.network.proxy_url.as_deref(),
-            Some("http://localhost:8080")
-        );
         assert_eq!(
             config.network.ca_bundle_path.as_deref(),
             Some(std::path::Path::new("/tmp/ca.pem"))

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -9,6 +9,7 @@ use toml::{Table, Value};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AppConfig {
     pub server: ServerConfig,
+    pub network: NetworkConfig,
     pub logging: LoggingConfig,
     pub feature: FeatureConfig,
 }
@@ -16,6 +17,7 @@ pub struct AppConfig {
 impl AppConfig {
     pub fn validate(&self) -> Result<(), ValidationError> {
         self.server.validate()?;
+        self.network.validate()?;
         self.logging.validate()?;
         self.feature.validate()?;
 
@@ -55,6 +57,34 @@ impl ServerConfig {
 
         if self.request_timeout_ms == 0 {
             return Err(ValidationError::InvalidRequestTimeout);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NetworkConfig {
+    pub connect_timeout_ms: Option<u64>,
+    pub request_timeout_ms: Option<u64>,
+    pub stream_idle_timeout_ms: Option<u64>,
+    pub proxy_url: Option<String>,
+    pub ca_bundle_path: Option<std::path::PathBuf>,
+    pub user_agent: Option<String>,
+}
+
+impl NetworkConfig {
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.connect_timeout_ms == Some(0) {
+            return Err(ValidationError::InvalidConnectTimeout);
+        }
+
+        if self.request_timeout_ms == Some(0) {
+            return Err(ValidationError::InvalidNetworkRequestTimeout);
+        }
+
+        if self.stream_idle_timeout_ms == Some(0) {
+            return Err(ValidationError::InvalidStreamIdleTimeout);
         }
 
         Ok(())
@@ -138,6 +168,12 @@ pub enum ValidationError {
     InvalidPort,
     #[error("server.request_timeout_ms must be greater than zero")]
     InvalidRequestTimeout,
+    #[error("network.connect_timeout_ms must be greater than zero")]
+    InvalidConnectTimeout,
+    #[error("network.request_timeout_ms must be greater than zero")]
+    InvalidNetworkRequestTimeout,
+    #[error("network.stream_idle_timeout_ms must be greater than zero")]
+    InvalidStreamIdleTimeout,
     #[error("feature.rollout_percentage must be between 0 and 100, got {0}")]
     InvalidRolloutPercentage(u8),
     #[error("feature.rollout_percentage must be greater than zero when feature.enabled is true")]
@@ -148,6 +184,7 @@ pub enum ValidationError {
 #[serde(default, deny_unknown_fields)]
 struct AppConfigInput {
     server: ServerConfigInput,
+    network: NetworkConfigInput,
     logging: LoggingConfigInput,
     feature: FeatureConfigInput,
 }
@@ -156,6 +193,7 @@ impl AppConfigInput {
     fn materialize(self) -> AppConfig {
         AppConfig {
             server: self.server.materialize(),
+            network: self.network.materialize(),
             logging: self.logging.materialize(),
             feature: self.feature.materialize(),
         }
@@ -180,6 +218,30 @@ impl ServerConfigInput {
             request_timeout_ms: self
                 .request_timeout_ms
                 .unwrap_or(ServerConfig::DEFAULT_REQUEST_TIMEOUT_MS),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct NetworkConfigInput {
+    connect_timeout_ms: Option<u64>,
+    request_timeout_ms: Option<u64>,
+    stream_idle_timeout_ms: Option<u64>,
+    proxy_url: Option<String>,
+    ca_bundle_path: Option<std::path::PathBuf>,
+    user_agent: Option<String>,
+}
+
+impl NetworkConfigInput {
+    fn materialize(self) -> NetworkConfig {
+        NetworkConfig {
+            connect_timeout_ms: self.connect_timeout_ms,
+            request_timeout_ms: self.request_timeout_ms,
+            stream_idle_timeout_ms: self.stream_idle_timeout_ms,
+            proxy_url: self.proxy_url,
+            ca_bundle_path: self.ca_bundle_path,
+            user_agent: self.user_agent,
         }
     }
 }
@@ -231,6 +293,12 @@ mod tests {
     fn logging_defaults_to_info_without_module_overrides() {
         let config = AppConfig::try_from(toml::Table::new()).expect("default config");
 
+        assert_eq!(config.network.connect_timeout_ms, None);
+        assert_eq!(config.network.request_timeout_ms, None);
+        assert_eq!(config.network.stream_idle_timeout_ms, None);
+        assert_eq!(config.network.proxy_url, None);
+        assert_eq!(config.network.ca_bundle_path, None);
+        assert_eq!(config.network.user_agent, None);
         assert_eq!(config.logging.level, LogFilter::Info);
         assert!(config.logging.module_levels.is_empty());
     }
@@ -269,5 +337,36 @@ mod tests {
 
         assert_eq!(config.logging.level, LogFilter::Info);
         assert!(config.logging.module_levels.is_empty());
+    }
+
+    #[test]
+    fn network_accepts_optional_transport_settings() {
+        let table = toml::toml! {
+            [network]
+            connect_timeout_ms = 1_000
+            request_timeout_ms = 30_000
+            stream_idle_timeout_ms = 300_000
+            proxy_url = "http://localhost:8080"
+            ca_bundle_path = "/tmp/ca.pem"
+            user_agent = "selvedge-client/test"
+        };
+
+        let config = AppConfig::try_from(table).expect("network config");
+
+        assert_eq!(config.network.connect_timeout_ms, Some(1_000));
+        assert_eq!(config.network.request_timeout_ms, Some(30_000));
+        assert_eq!(config.network.stream_idle_timeout_ms, Some(300_000));
+        assert_eq!(
+            config.network.proxy_url.as_deref(),
+            Some("http://localhost:8080")
+        );
+        assert_eq!(
+            config.network.ca_bundle_path.as_deref(),
+            Some(std::path::Path::new("/tmp/ca.pem"))
+        );
+        assert_eq!(
+            config.network.user_agent.as_deref(),
+            Some("selvedge-client/test")
+        );
     }
 }

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -2,9 +2,11 @@
 
 use std::{collections::BTreeMap, fmt::Display};
 
+use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use toml::{Table, Value};
+use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AppConfig {
@@ -85,6 +87,16 @@ impl NetworkConfig {
 
         if self.stream_idle_timeout_ms == Some(0) {
             return Err(ValidationError::InvalidStreamIdleTimeout);
+        }
+
+        if let Some(proxy_url) = &self.proxy_url {
+            Url::parse(proxy_url)
+                .map_err(|_| ValidationError::InvalidProxyUrl(proxy_url.clone()))?;
+        }
+
+        if let Some(user_agent) = &self.user_agent {
+            HeaderValue::from_str(user_agent)
+                .map_err(|_| ValidationError::InvalidUserAgent(user_agent.clone()))?;
         }
 
         Ok(())
@@ -174,6 +186,10 @@ pub enum ValidationError {
     InvalidNetworkRequestTimeout,
     #[error("network.stream_idle_timeout_ms must be greater than zero")]
     InvalidStreamIdleTimeout,
+    #[error("network.proxy_url must be a valid absolute URL, got {0}")]
+    InvalidProxyUrl(String),
+    #[error("network.user_agent must be a valid HTTP header value, got {0}")]
+    InvalidUserAgent(String),
     #[error("feature.rollout_percentage must be between 0 and 100, got {0}")]
     InvalidRolloutPercentage(u8),
     #[error("feature.rollout_percentage must be greater than zero when feature.enabled is true")]

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -90,8 +90,12 @@ impl NetworkConfig {
         }
 
         if let Some(proxy_url) = &self.proxy_url {
-            Url::parse(proxy_url)
+            let parsed = Url::parse(proxy_url)
                 .map_err(|_| ValidationError::InvalidProxyUrl(proxy_url.clone()))?;
+            match parsed.scheme() {
+                "http" | "https" => {}
+                _ => return Err(ValidationError::InvalidProxyUrl(proxy_url.clone())),
+            }
         }
 
         if let Some(user_agent) = &self.user_agent {

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -73,6 +73,19 @@ fn invalid_proxy_url_is_rejected() {
 }
 
 #[test]
+fn unsupported_proxy_scheme_is_rejected() {
+    let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
+    config.network.proxy_url = Some("mailto://example.com".to_owned());
+
+    assert_eq!(
+        config.validate(),
+        Err(ValidationError::InvalidProxyUrl(
+            "mailto://example.com".to_owned()
+        ))
+    );
+}
+
+#[test]
 fn invalid_user_agent_is_rejected() {
     let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
     config.network.user_agent = Some("bad\r\nvalue".to_owned());

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -8,6 +8,9 @@ fn empty_table_materializes_to_valid_defaults() {
     let config = AppConfig::try_from(Table::new()).expect("materialize config");
 
     assert!(config.validate().is_ok());
+    assert_eq!(config.network.connect_timeout_ms, None);
+    assert_eq!(config.network.request_timeout_ms, None);
+    assert_eq!(config.network.stream_idle_timeout_ms, None);
 }
 
 #[test]
@@ -44,5 +47,16 @@ fn cross_field_constraint_is_rejected() {
     assert_eq!(
         config.validate(),
         Err(ValidationError::EnabledFeatureRequiresRollout)
+    );
+}
+
+#[test]
+fn zero_network_timeout_is_rejected() {
+    let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
+    config.network.request_timeout_ms = Some(0);
+
+    assert_eq!(
+        config.validate(),
+        Err(ValidationError::InvalidNetworkRequestTimeout)
     );
 }

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -60,3 +60,25 @@ fn zero_network_timeout_is_rejected() {
         Err(ValidationError::InvalidNetworkRequestTimeout)
     );
 }
+
+#[test]
+fn invalid_proxy_url_is_rejected() {
+    let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
+    config.network.proxy_url = Some("://bad-proxy".to_owned());
+
+    assert_eq!(
+        config.validate(),
+        Err(ValidationError::InvalidProxyUrl("://bad-proxy".to_owned()))
+    );
+}
+
+#[test]
+fn invalid_user_agent_is_rejected() {
+    let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
+    config.network.user_agent = Some("bad\r\nvalue".to_owned());
+
+    assert_eq!(
+        config.validate(),
+        Err(ValidationError::InvalidUserAgent("bad\r\nvalue".to_owned()))
+    );
+}

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -62,30 +62,6 @@ fn zero_network_timeout_is_rejected() {
 }
 
 #[test]
-fn invalid_proxy_url_is_rejected() {
-    let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
-    config.network.proxy_url = Some("://bad-proxy".to_owned());
-
-    assert_eq!(
-        config.validate(),
-        Err(ValidationError::InvalidProxyUrl("://bad-proxy".to_owned()))
-    );
-}
-
-#[test]
-fn unsupported_proxy_scheme_is_rejected() {
-    let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
-    config.network.proxy_url = Some("mailto://example.com".to_owned());
-
-    assert_eq!(
-        config.validate(),
-        Err(ValidationError::InvalidProxyUrl(
-            "mailto://example.com".to_owned()
-        ))
-    );
-}
-
-#[test]
 fn invalid_user_agent_is_rejected() {
     let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
     config.network.user_agent = Some("bad\r\nvalue".to_owned());


### PR DESCRIPTION
## Summary
- add the new `selvedge-client` crate with function-only HTTP APIs for full and streaming requests
- add `network` config modeling plus transport semantics for timeout, proxy, CA bundle, compression, status handling, and structured client logs
- document that unset `network.*` timeout fields remain optional and are passed through to the underlying HTTP client instead of being replaced with a client-side fallback

## Validation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo xtask agents-index check`
- `codex-review-final main`