### PR TITLE
[codex] Fix worktree integration Git environment leakage

### DIFF
--- a/tests/worktree_tool_integration.rs
+++ b/tests/worktree_tool_integration.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tempfile::TempDir;
 
@@ -52,13 +52,33 @@ fn script_creates_branch_and_worktree_in_hidden_directory() {
 
 #[test]
 fn script_resets_stale_isolated_git_config_before_running_git_commands() {
+    let test_binary = std::env::current_exe().expect("current test binary");
+    let tempdir = TempDir::new().expect("tempdir");
+    let isolated_home = tempdir.path().join("isolated-home");
+    let isolated_git_config = isolated_home.join("gitconfig");
+
+    fs::create_dir_all(isolated_home.join(".config")).expect("create isolated home");
     fs::write(
-        isolated_git_config_path(),
+        &isolated_git_config,
         "[commit]\n\tgpgSign = true\n[gpg]\n\tprogram = /definitely/missing/git-gpg\n",
     )
     .expect("write stale isolated git config");
 
-    assert_script_creates_branch_and_worktree_in_hidden_directory();
+    let output = Command::new(test_binary)
+        .args([
+            "--exact",
+            "script_creates_branch_and_worktree_in_hidden_directory",
+        ])
+        .env("SELVEDGE_TEST_GIT_ENV_ROOT", &isolated_home)
+        .output()
+        .expect("run nested worktree test");
+
+    assert!(
+        output.status.success(),
+        "expected stale isolated git config to be reset before running git commands\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn assert_script_creates_branch_and_worktree_in_hidden_directory() {
@@ -624,38 +644,33 @@ fn isolated_command(program: &str) -> Command {
         }
     }
 
-    let isolated_home = isolated_home_dir();
-    let isolated_git_config = reset_isolated_git_config();
+    let isolated_home = isolated_environment_root();
+    let isolated_git_config = isolated_home.join("gitconfig");
 
-    command.env("HOME", isolated_home);
+    fs::create_dir_all(isolated_home.join(".config")).expect("create isolated home dir");
+    fs::write(&isolated_git_config, "").expect("reset isolated git config");
+
+    command.env("HOME", &isolated_home);
     command.env("XDG_CONFIG_HOME", isolated_home.join(".config"));
-    command.env("GIT_CONFIG_GLOBAL", isolated_git_config);
-    command.env("GIT_CONFIG_SYSTEM", isolated_git_config);
+    command.env("GIT_CONFIG_GLOBAL", &isolated_git_config);
+    command.env("GIT_CONFIG_SYSTEM", &isolated_git_config);
     command.env("GIT_CONFIG_NOSYSTEM", "1");
 
     command
 }
 
-fn isolated_home_dir() -> &'static Path {
-    static ISOLATED_HOME_DIR: OnceLock<PathBuf> = OnceLock::new();
+fn isolated_environment_root() -> PathBuf {
+    if let Some(path) = std::env::var_os("SELVEDGE_TEST_GIT_ENV_ROOT") {
+        return PathBuf::from(path);
+    }
 
-    ISOLATED_HOME_DIR.get_or_init(|| {
-        let path = std::env::temp_dir().join(format!("selvedge-test-home-{}", std::process::id()));
-        fs::create_dir_all(path.join(".config")).expect("create isolated home dir");
-        path
-    })
-}
+    static ISOLATED_ENV_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-fn isolated_git_config_path() -> &'static Path {
-    static ISOLATED_GIT_CONFIG_PATH: OnceLock<PathBuf> = OnceLock::new();
-
-    ISOLATED_GIT_CONFIG_PATH.get_or_init(|| isolated_home_dir().join("gitconfig"))
-}
-
-fn reset_isolated_git_config() -> &'static Path {
-    let path = isolated_git_config_path();
-    fs::write(path, "").expect("reset isolated git config");
-    path
+    let counter = ISOLATED_ENV_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "selvedge-test-home-{}-{counter}",
+        std::process::id()
+    ))
 }
 
 fn encoded_branch_name(branch_name: &str) -> String {

--- a/tests/worktree_tool_integration.rs
+++ b/tests/worktree_tool_integration.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
 use tempfile::TempDir;
 
@@ -10,6 +11,14 @@ fn script_ignores_inherited_git_environment_when_creating_temp_repo() {
     let repo_root = workspace_root();
     let git_dir = repo_root.join(".git");
     let git_index = git_dir.join("index");
+    let tempdir = TempDir::new().expect("tempdir");
+    let injected_git_config = tempdir.path().join("gitconfig");
+
+    fs::write(
+        &injected_git_config,
+        "[commit]\n\tgpgSign = true\n[gpg]\n\tprogram = /definitely/missing/git-gpg\n",
+    )
+    .expect("write injected git config");
 
     let output = Command::new(test_binary)
         .args([
@@ -19,6 +28,12 @@ fn script_ignores_inherited_git_environment_when_creating_temp_repo() {
         .env("GIT_DIR", &git_dir)
         .env("GIT_WORK_TREE", &repo_root)
         .env("GIT_INDEX_FILE", &git_index)
+        .env("GIT_CONFIG_GLOBAL", &injected_git_config)
+        .env("GIT_CONFIG_COUNT", "2")
+        .env("GIT_CONFIG_KEY_0", "commit.gpgSign")
+        .env("GIT_CONFIG_VALUE_0", "true")
+        .env("GIT_CONFIG_KEY_1", "gpg.program")
+        .env("GIT_CONFIG_VALUE_1", "/definitely/missing/git-gpg")
         .output()
         .expect("run nested worktree test");
 
@@ -589,32 +604,43 @@ fn isolated_command(program: &str) -> Command {
     let mut command = Command::new(program);
 
     for (key, _) in std::env::vars_os() {
-        let key_text = key.to_string_lossy();
-        if key_text.starts_with("GIT_") && !is_allowed_git_env_var(&key_text) {
+        if key.to_string_lossy().starts_with("GIT_") {
             command.env_remove(&key);
         }
     }
 
+    let isolated_home = isolated_home_dir();
+    let isolated_git_config = isolated_git_config_path();
+
+    command.env("HOME", isolated_home);
+    command.env("XDG_CONFIG_HOME", isolated_home.join(".config"));
+    command.env("GIT_CONFIG_GLOBAL", isolated_git_config);
+    command.env("GIT_CONFIG_SYSTEM", isolated_git_config);
+    command.env("GIT_CONFIG_NOSYSTEM", "1");
+
     command
 }
 
-fn is_allowed_git_env_var(key: &str) -> bool {
-    key.starts_with("GIT_CONFIG_KEY_")
-        || key.starts_with("GIT_CONFIG_VALUE_")
-        || matches!(
-            key,
-            "GIT_EXEC_PATH"
-                | "GIT_SSH"
-                | "GIT_SSH_COMMAND"
-                | "GIT_SSL_CAINFO"
-                | "GIT_SSL_NO_VERIFY"
-                | "GIT_CONFIG_COUNT"
-                | "GIT_CONFIG_GLOBAL"
-                | "GIT_CONFIG_SYSTEM"
-                | "GIT_HTTP_PROXY_AUTHMETHOD"
-                | "GIT_ALLOW_PROTOCOL"
-                | "GIT_ASKPASS"
-        )
+fn isolated_home_dir() -> &'static Path {
+    static ISOLATED_HOME_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+    ISOLATED_HOME_DIR.get_or_init(|| {
+        let path = std::env::temp_dir().join(format!("selvedge-test-home-{}", std::process::id()));
+        fs::create_dir_all(path.join(".config")).expect("create isolated home dir");
+        path
+    })
+}
+
+fn isolated_git_config_path() -> &'static Path {
+    static ISOLATED_GIT_CONFIG_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+    ISOLATED_GIT_CONFIG_PATH.get_or_init(|| {
+        let path = isolated_home_dir().join("gitconfig");
+        if !path.exists() {
+            fs::write(&path, "").expect("write isolated git config");
+        }
+        path
+    })
 }
 
 fn encoded_branch_name(branch_name: &str) -> String {

--- a/tests/worktree_tool_integration.rs
+++ b/tests/worktree_tool_integration.rs
@@ -56,7 +56,7 @@ fn script_creates_branch_and_worktree_in_hidden_directory() {
 
     assert!(worktree_path.is_dir(), "worktree directory should exist");
 
-    let branch_output = Command::new("git")
+    let branch_output = isolated_command("git")
         .args(["branch", "--list", "feature/demo"])
         .current_dir(&repo_root)
         .output()
@@ -163,12 +163,12 @@ fn script_bases_new_worktree_on_current_branch_when_current_branch_is_not_main()
         "new worktree should inherit commits from the current branch"
     );
 
-    let head_output = Command::new("git")
+    let head_output = isolated_command("git")
         .args(["rev-parse", "HEAD"])
         .current_dir(&isolated_worktree_path)
         .output()
         .expect("read isolated worktree head");
-    let main_output = Command::new("git")
+    let main_output = isolated_command("git")
         .args(["rev-parse", "feature/source"])
         .current_dir(&repo_root)
         .output()
@@ -248,7 +248,7 @@ fn script_supports_long_branch_names_without_leaving_partial_branch_state() {
             .is_dir()
     );
 
-    let branch_output = Command::new("git")
+    let branch_output = isolated_command("git")
         .args(["branch", "--list", &long_branch_name])
         .current_dir(&repo_root)
         .output()
@@ -278,7 +278,7 @@ fn just_entrypoint_preserves_branch_names_with_shell_syntax() {
     fs::copy(&justfile_source, repo_root.join("Justfile")).expect("copy justfile");
     set_script_executable(&repo_root.join("scripts/create-worktree.sh"));
 
-    let output = Command::new("just")
+    let output = isolated_command("just")
         .args(["worktree", branch_name])
         .current_dir(&repo_root)
         .output()
@@ -296,7 +296,7 @@ fn just_entrypoint_preserves_branch_names_with_shell_syntax() {
             .is_dir()
     );
 
-    let branch_output = Command::new("git")
+    let branch_output = isolated_command("git")
         .args(["branch", "--list", branch_name])
         .current_dir(&repo_root)
         .output()
@@ -421,7 +421,7 @@ fn script_keeps_child_worktree_alive_after_parent_worktree_is_removed() {
         "child worktree should survive parent removal"
     );
 
-    let list_output = Command::new("git")
+    let list_output = isolated_command("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(&repo_root)
         .output()
@@ -545,7 +545,7 @@ fn script_fails_for_nested_path_inside_worktrees_that_is_not_helper_managed() {
 }
 
 fn run_script(repo_root: &Path, branch_name: &str) -> std::process::Output {
-    Command::new("sh")
+    isolated_command("sh")
         .args([
             "-c",
             &format!("./scripts/create-worktree.sh '{branch_name}'"),
@@ -567,7 +567,7 @@ fn init_git_repo(repo_root: &Path) {
 }
 
 fn run_git<const N: usize>(repo_root: &Path, args: [&str; N]) {
-    let output = Command::new("git")
+    let output = isolated_command("git")
         .args(args)
         .current_dir(repo_root)
         .output()
@@ -585,8 +585,40 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+fn isolated_command(program: &str) -> Command {
+    let mut command = Command::new(program);
+
+    for (key, _) in std::env::vars_os() {
+        let key_text = key.to_string_lossy();
+        if key_text.starts_with("GIT_") && !is_allowed_git_env_var(&key_text) {
+            command.env_remove(&key);
+        }
+    }
+
+    command
+}
+
+fn is_allowed_git_env_var(key: &str) -> bool {
+    key.starts_with("GIT_CONFIG_KEY_")
+        || key.starts_with("GIT_CONFIG_VALUE_")
+        || matches!(
+            key,
+            "GIT_EXEC_PATH"
+                | "GIT_SSH"
+                | "GIT_SSH_COMMAND"
+                | "GIT_SSL_CAINFO"
+                | "GIT_SSL_NO_VERIFY"
+                | "GIT_CONFIG_COUNT"
+                | "GIT_CONFIG_GLOBAL"
+                | "GIT_CONFIG_SYSTEM"
+                | "GIT_HTTP_PROXY_AUTHMETHOD"
+                | "GIT_ALLOW_PROTOCOL"
+                | "GIT_ASKPASS"
+        )
+}
+
 fn encoded_branch_name(branch_name: &str) -> String {
-    let output = Command::new("git")
+    let output = isolated_command("git")
         .args(["hash-object", "--stdin"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -616,7 +648,7 @@ fn encoded_branch_name(branch_name: &str) -> String {
 }
 
 fn command_exists(command_name: &str) -> bool {
-    Command::new("sh")
+    isolated_command("sh")
         .args(["-c", &format!("command -v {command_name} >/dev/null 2>&1")])
         .status()
         .expect("check command presence")

--- a/tests/worktree_tool_integration.rs
+++ b/tests/worktree_tool_integration.rs
@@ -5,6 +5,32 @@ use std::process::Command;
 use tempfile::TempDir;
 
 #[test]
+fn script_ignores_inherited_git_environment_when_creating_temp_repo() {
+    let test_binary = std::env::current_exe().expect("current test binary");
+    let repo_root = workspace_root();
+    let git_dir = repo_root.join(".git");
+    let git_index = git_dir.join("index");
+
+    let output = Command::new(test_binary)
+        .args([
+            "--exact",
+            "script_creates_branch_and_worktree_in_hidden_directory",
+        ])
+        .env("GIT_DIR", &git_dir)
+        .env("GIT_WORK_TREE", &repo_root)
+        .env("GIT_INDEX_FILE", &git_index)
+        .output()
+        .expect("run nested worktree test");
+
+    assert!(
+        output.status.success(),
+        "expected test helper commands to ignore inherited git environment\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn script_creates_branch_and_worktree_in_hidden_directory() {
     let tempdir = TempDir::new().expect("tempdir");
     let repo_root = tempdir.path().join("repo");

--- a/tests/worktree_tool_integration.rs
+++ b/tests/worktree_tool_integration.rs
@@ -47,6 +47,21 @@ fn script_ignores_inherited_git_environment_when_creating_temp_repo() {
 
 #[test]
 fn script_creates_branch_and_worktree_in_hidden_directory() {
+    assert_script_creates_branch_and_worktree_in_hidden_directory();
+}
+
+#[test]
+fn script_resets_stale_isolated_git_config_before_running_git_commands() {
+    fs::write(
+        isolated_git_config_path(),
+        "[commit]\n\tgpgSign = true\n[gpg]\n\tprogram = /definitely/missing/git-gpg\n",
+    )
+    .expect("write stale isolated git config");
+
+    assert_script_creates_branch_and_worktree_in_hidden_directory();
+}
+
+fn assert_script_creates_branch_and_worktree_in_hidden_directory() {
     let tempdir = TempDir::new().expect("tempdir");
     let repo_root = tempdir.path().join("repo");
     let script_source = workspace_root().join("scripts/create-worktree.sh");
@@ -610,7 +625,7 @@ fn isolated_command(program: &str) -> Command {
     }
 
     let isolated_home = isolated_home_dir();
-    let isolated_git_config = isolated_git_config_path();
+    let isolated_git_config = reset_isolated_git_config();
 
     command.env("HOME", isolated_home);
     command.env("XDG_CONFIG_HOME", isolated_home.join(".config"));
@@ -634,13 +649,13 @@ fn isolated_home_dir() -> &'static Path {
 fn isolated_git_config_path() -> &'static Path {
     static ISOLATED_GIT_CONFIG_PATH: OnceLock<PathBuf> = OnceLock::new();
 
-    ISOLATED_GIT_CONFIG_PATH.get_or_init(|| {
-        let path = isolated_home_dir().join("gitconfig");
-        if !path.exists() {
-            fs::write(&path, "").expect("write isolated git config");
-        }
-        path
-    })
+    ISOLATED_GIT_CONFIG_PATH.get_or_init(|| isolated_home_dir().join("gitconfig"))
+}
+
+fn reset_isolated_git_config() -> &'static Path {
+    let path = isolated_git_config_path();
+    fs::write(path, "").expect("reset isolated git config");
+    path
 }
 
 fn encoded_branch_name(branch_name: &str) -> String {


### PR DESCRIPTION
## Summary
- isolate every external command in `tests/worktree_tool_integration.rs` from inherited `GIT_*` repository bindings
- give each spawned command its own reset Git config sandbox so user-level Git config and stale temp config do not leak into temporary repos
- add regression coverage for inherited Git environment and stale isolated config scenarios

## Why
Issue #14 reports that `pre-push` can fail in the worktree integration tests because temporary repositories inherit Git state from the parent checkout. The root cause was that the test helper commands launched `git`, `sh`, and `just` without sanitizing inherited Git repository and config environment, so child commands could execute against the real checkout or pick up unrelated signing/config settings.

## Impact
The worktree integration tests are now hermetic with respect to inherited Git environment and stale temp Git config. This removes the observed `pre-push` failure mode and keeps the regression covered by tests.

## Validation
- `cargo test --test worktree_tool_integration`
- `pre-commit run --all-files`
- `pre-commit run --all-files --hook-stage pre-push`
- `codex-review-final main`

Fixes #14