### PR TITLE
feat: add chatgpt responses streaming api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,11 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{chatgpt-auth/,chatgpt-login/,client/,config-model/,config/,logging/}
+|crates:{chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,config-model/,config/,logging/}
+|crates/chatgpt-api:{src/,tests/,Cargo.toml,README.md}
+|crates/chatgpt-api/src:{lib.rs}
+|crates/chatgpt-api/tests:{support/,public_api.rs,request_contract.rs,stream_integration.rs}
+|crates/chatgpt-api/tests/support:{mod.rs}
 |crates/chatgpt-auth:{src/,tests/,Cargo.toml,README.md}
 |crates/chatgpt-auth/src:{auth_file.rs,config.rs,jwt.rs,lib.rs,lock.rs,refresh.rs,resolve.rs}
 |crates/chatgpt-auth/tests:{support/,parse_contract.rs,public_api.rs,resolve_integration.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "futures",
  "futures-core",
  "http",
+ "httpdate",
  "selvedge-client",
  "selvedge-config",
  "selvedge-config-model",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chatgpt-api"
+version = "0.0.0"
+dependencies = [
+ "async-stream",
+ "axum",
+ "base64",
+ "bytes",
+ "chatgpt-auth",
+ "futures",
+ "futures-core",
+ "http",
+ "selvedge-client",
+ "selvedge-config",
+ "selvedge-config-model",
+ "selvedge-logging",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "chatgpt-auth"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/chatgpt-api",
     "crates/chatgpt-auth",
     "crates/chatgpt-login",
     "crates/client",

--- a/crates/chatgpt-api/Cargo.toml
+++ b/crates/chatgpt-api/Cargo.toml
@@ -8,6 +8,7 @@ bytes = "1.10.1"
 futures = "0.3.31"
 futures-core = "0.3.31"
 http = "1.3.1"
+httpdate = "1.0.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 selvedge-client = { path = "../client" }

--- a/crates/chatgpt-api/Cargo.toml
+++ b/crates/chatgpt-api/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "chatgpt-api"
+edition = "2024"
+publish = false
+
+[dependencies]
+bytes = "1.10.1"
+futures = "0.3.31"
+futures-core = "0.3.31"
+http = "1.3.1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+selvedge-client = { path = "../client" }
+selvedge-config = { path = "../config" }
+selvedge-config-model = { path = "../config-model" }
+thiserror = "2.0.18"
+tokio = { version = "1.48.0", features = ["rt", "sync", "time"] }
+
+[dependencies.chatgpt-auth]
+path = "../chatgpt-auth"
+package = "chatgpt-auth"
+
+[dev-dependencies]
+async-stream = "0.3.6"
+axum = "0.8.6"
+base64 = "0.22.1"
+selvedge-logging = { path = "../logging" }
+tempfile = "3.23.0"
+tokio = { version = "1.48.0", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/chatgpt-api/README.md
+++ b/crates/chatgpt-api/README.md
@@ -40,3 +40,26 @@ stream_completion_timeout_ms = 1800000
 
 `base_url` is the upstream ChatGPT API base URL. `stream_completion_timeout_ms`
 caps the total lifetime of a single successful response stream.
+
+## Timeout Semantics
+
+This crate enforces two independent timeout layers:
+
+- `network.stream_idle_timeout_ms` belongs to `selvedge-client` and limits how
+  long one body-chunk wait may stay idle.
+- `llm.providers.chatgpt.api.stream_completion_timeout_ms` belongs to this crate
+  and limits the total lifetime of one `/responses` stream.
+
+These settings are intentionally separate and are not merged into one budget.
+Both constraints apply to the same request at the same time.
+
+Failure precedence is simple:
+
+- if the transport layer waits too long for the next body bytes,
+  `selvedge-client` returns `HttpError::Timeout`
+- if the overall `/responses` stream lives too long,
+  this crate returns `ChatgptApiLowerLayerError::StreamCompletionTimeout`
+
+Whichever timeout fires first ends the stream first. Callers should therefore
+treat the client-layer timeout and the API-layer completion timeout as distinct
+failure modes rather than aliases.

--- a/crates/chatgpt-api/README.md
+++ b/crates/chatgpt-api/README.md
@@ -1,0 +1,42 @@
+# chatgpt-api
+
+## This crate is for
+
+This crate implements ChatGPT `/responses` streaming calls for Selvedge.
+
+Use it to:
+
+- validate ChatGPT response-stream requests
+- resolve ChatGPT auth fresh for each call
+- open the `/responses` HTTP stream with bounded pre-stream retries
+- decode SSE events into typed response events
+
+## This crate is not for
+
+This crate is not for:
+
+- exposing a reusable client object
+- caching config, auth, transcript, or turn state across calls
+- persisting caller-visible state between requests
+- hiding endpoint or transport failures behind fallback behavior
+
+## Public API
+
+Callers build a `ChatgptResponsesRequest` and pass it to `stream(...)`.
+
+The returned `ChatgptResponseStream` yields `Result<ChatgptResponseEvent, ChatgptApiError>`.
+Callers are responsible for preserving the full `input` history and the
+`effective_turn_state()` value they want to replay on the next call.
+
+## Config
+
+This crate reads:
+
+```toml
+[llm.providers.chatgpt.api]
+base_url = "https://chatgpt.com/backend-api/codex"
+stream_completion_timeout_ms = 1800000
+```
+
+`base_url` is the upstream ChatGPT API base URL. `stream_completion_timeout_ms`
+caps the total lifetime of a single successful response stream.

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::{
     pin::Pin,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
     time::Duration,
 };
@@ -11,10 +12,7 @@ use futures::StreamExt;
 use futures_core::Stream;
 use http::{HeaderMap, HeaderValue, StatusCode};
 use serde_json::Value;
-use tokio::{
-    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
-    task::JoinHandle,
-};
+use tokio::{sync::mpsc, task::JoinHandle};
 
 pub type JsonObject = serde_json::Map<String, Value>;
 
@@ -37,15 +35,18 @@ pub async fn stream(
         .map(str::to_owned)
         .or_else(|| request.context.turn_state.clone());
 
-    let (sender, receiver) = mpsc::unbounded_channel();
+    let (sender, receiver) = mpsc::channel(32);
+    let terminal_error = Arc::new(Mutex::new(None));
+    let terminal_error_for_driver = Arc::clone(&terminal_error);
     let timeout = Duration::from_millis(api_config.stream_completion_timeout_ms);
     let driver_task = tokio::spawn(async move {
-        drive_response_stream(response.body, sender, timeout).await;
+        drive_response_stream(response.body, sender, terminal_error_for_driver, timeout).await;
     });
 
     Ok(ChatgptResponseStream::empty(
         effective_turn_state,
         receiver,
+        terminal_error,
         Some(driver_task),
     ))
 }
@@ -159,7 +160,8 @@ fn retry_delay_for_attempt(retry_count: u8, error: &selvedge_client::HttpError) 
 
 async fn drive_response_stream(
     mut body: selvedge_client::ByteStream,
-    sender: UnboundedSender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    sender: mpsc::Sender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    terminal_error: Arc<Mutex<Option<ChatgptApiError>>>,
     timeout: Duration,
 ) {
     let deadline = tokio::time::Instant::now() + timeout;
@@ -170,10 +172,14 @@ async fn drive_response_stream(
         if remaining.is_zero() {
             send_stream_item(
                 &sender,
+                &terminal_error,
                 Err(ChatgptApiError::LowerLayer(
                     ChatgptApiLowerLayerError::StreamCompletionTimeout { timeout },
                 )),
-            );
+                deadline,
+                timeout,
+            )
+            .await;
             return;
         }
 
@@ -183,24 +189,56 @@ async fn drive_response_stream(
             Err(_) => {
                 send_stream_item(
                     &sender,
+                    &terminal_error,
                     Err(ChatgptApiError::LowerLayer(
                         ChatgptApiLowerLayerError::StreamCompletionTimeout { timeout },
                     )),
-                );
+                    deadline,
+                    timeout,
+                )
+                .await;
                 return;
             }
         };
 
         let Some(chunk) = maybe_chunk else {
-            let error = if buffer.is_empty() {
-                ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
+            let final_result = if buffer.is_empty() {
+                Err(ChatgptApiError::Endpoint(
+                    ChatgptApiEndpointError::PrematureClose,
+                ))
             } else {
-                ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
-                    reason: "stream ended before the current SSE frame completed".to_owned(),
-                    raw: Some(String::from_utf8_lossy(&buffer).into_owned()),
+                parse_final_sse_frame(&buffer).and_then(|maybe_payload| match maybe_payload {
+                    None => Err(ChatgptApiError::Endpoint(
+                        ChatgptApiEndpointError::PrematureClose,
+                    )),
+                    Some(payload) => match map_stream_event(&payload) {
+                        Ok(MappedEvent::Event(event)) => Ok(Some(event)),
+                        Ok(MappedEvent::Completed(event)) => Ok(Some(event)),
+                        Ok(MappedEvent::EndpointError(error)) => Err(error),
+                        Err(error) => Err(error),
+                    },
                 })
             };
-            send_stream_item(&sender, Err(error));
+
+            match final_result {
+                Ok(Some(event)) => {
+                    if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
+                        .await
+                    {
+                        return;
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    send_stream_item(&sender, &terminal_error, Err(error), deadline, timeout).await;
+                    return;
+                }
+            }
+
+            if buffer.is_empty() {
+                return;
+            }
+
             return;
         };
 
@@ -209,10 +247,14 @@ async fn drive_response_stream(
             Err(error) => {
                 send_stream_item(
                     &sender,
+                    &terminal_error,
                     Err(ChatgptApiError::LowerLayer(
                         ChatgptApiLowerLayerError::Client(error),
                     )),
-                );
+                    deadline,
+                    timeout,
+                )
+                .await;
                 return;
             }
         };
@@ -225,13 +267,17 @@ async fn drive_response_stream(
                 Err(_) => {
                     send_stream_item(
                         &sender,
+                        &terminal_error,
                         Err(ChatgptApiError::Endpoint(
                             ChatgptApiEndpointError::MalformedEvent {
                                 reason: "event stream contained non-utf8 bytes".to_owned(),
                                 raw: None,
                             },
                         )),
-                    );
+                        deadline,
+                        timeout,
+                    )
+                    .await;
                     return;
                 }
             };
@@ -244,25 +290,29 @@ async fn drive_response_stream(
                 Ok(Some(payload)) => payload,
                 Ok(None) => continue,
                 Err(error) => {
-                    send_stream_item(&sender, Err(error));
+                    send_stream_item(&sender, &terminal_error, Err(error), deadline, timeout).await;
                     return;
                 }
             };
 
             match map_stream_event(&payload) {
                 Ok(MappedEvent::Event(event)) => {
-                    send_stream_item(&sender, Ok(event));
+                    if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
+                        .await
+                    {
+                        return;
+                    }
                 }
                 Ok(MappedEvent::Completed(event)) => {
-                    send_stream_item(&sender, Ok(event));
+                    send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout).await;
                     return;
                 }
                 Ok(MappedEvent::EndpointError(error)) => {
-                    send_stream_item(&sender, Err(error));
+                    send_stream_item(&sender, &terminal_error, Err(error), deadline, timeout).await;
                     return;
                 }
                 Err(error) => {
-                    send_stream_item(&sender, Err(error));
+                    send_stream_item(&sender, &terminal_error, Err(error), deadline, timeout).await;
                     return;
                 }
             }
@@ -270,11 +320,36 @@ async fn drive_response_stream(
     }
 }
 
-fn send_stream_item(
-    sender: &UnboundedSender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+async fn send_stream_item(
+    sender: &mpsc::Sender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    terminal_error: &Arc<Mutex<Option<ChatgptApiError>>>,
     item: Result<ChatgptResponseEvent, ChatgptApiError>,
-) {
-    let _ = sender.send(item);
+    deadline: tokio::time::Instant,
+    timeout: Duration,
+) -> bool {
+    match tokio::time::timeout_at(deadline, sender.send(item)).await {
+        Ok(Ok(())) => true,
+        Ok(Err(_)) => false,
+        Err(_) => {
+            if let Ok(mut slot) = terminal_error.lock() {
+                *slot = Some(ChatgptApiError::LowerLayer(
+                    ChatgptApiLowerLayerError::StreamCompletionTimeout { timeout },
+                ));
+            }
+            false
+        }
+    }
+}
+
+fn parse_final_sse_frame(buffer: &[u8]) -> Result<Option<String>, ChatgptApiError> {
+    let frame = std::str::from_utf8(buffer).map_err(|_| {
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
+            reason: "event stream contained non-utf8 bytes".to_owned(),
+            raw: None,
+        })
+    })?;
+
+    parse_sse_frame(&frame.replace("\r\n", "\n").replace('\r', "\n"))
 }
 
 fn take_next_sse_frame(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
@@ -1183,7 +1258,8 @@ fn text_verbosity_to_wire(verbosity: TextVerbosity) -> &'static str {
 
 pub struct ChatgptResponseStream {
     effective_turn_state: Option<String>,
-    receiver: UnboundedReceiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    receiver: mpsc::Receiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    terminal_error: Arc<Mutex<Option<ChatgptApiError>>>,
     driver_task: Option<JoinHandle<()>>,
 }
 
@@ -1194,12 +1270,14 @@ impl ChatgptResponseStream {
 
     fn empty(
         effective_turn_state: Option<String>,
-        receiver: UnboundedReceiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+        receiver: mpsc::Receiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+        terminal_error: Arc<Mutex<Option<ChatgptApiError>>>,
         driver_task: Option<JoinHandle<()>>,
     ) -> Self {
         Self {
             effective_turn_state,
             receiver,
+            terminal_error,
             driver_task,
         }
     }
@@ -1217,7 +1295,19 @@ impl Stream for ChatgptResponseStream {
     type Item = Result<ChatgptResponseEvent, ChatgptApiError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.get_mut().receiver.poll_recv(cx)
+        let stream = self.get_mut();
+
+        match stream.receiver.poll_recv(cx) {
+            Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
+            Poll::Ready(None) => Poll::Ready(stream.take_terminal_error().map(Err)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl ChatgptResponseStream {
+    fn take_terminal_error(&self) -> Option<ChatgptApiError> {
+        self.terminal_error.lock().ok()?.take()
     }
 }
 

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -140,13 +140,14 @@ fn is_retryable_client_error(error: &selvedge_client::HttpError) -> bool {
 
 fn retry_delay_for_attempt(retry_count: u8, error: &selvedge_client::HttpError) -> Duration {
     if let selvedge_client::HttpError::Status(status) = error
-        && let Some(retry_after) = status
-            .headers
-            .get("retry-after")
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.parse::<u64>().ok())
+        && let Some(retry_after) = parse_retry_after_header(
+            status
+                .headers
+                .get("retry-after")
+                .and_then(|value| value.to_str().ok()),
+        )
     {
-        return Duration::from_secs(retry_after.min(30));
+        return retry_after.min(Duration::from_secs(30));
     }
 
     match retry_count {
@@ -717,13 +718,10 @@ fn chatgpt_usage_from_value(value: &Value) -> Result<ChatgptUsage, ChatgptApiErr
 }
 
 fn failed_endpoint_event(object: &JsonObject, event_type: &str) -> ChatgptApiError {
-    let response = object
-        .get("response")
-        .and_then(Value::as_object)
-        .cloned()
-        .unwrap_or_default();
+    let response = object.get("response").and_then(Value::as_object).cloned();
     let error = response
-        .get("error")
+        .as_ref()
+        .and_then(|response| response.get("error"))
         .and_then(Value::as_object)
         .cloned()
         .or_else(|| object.get("error").and_then(Value::as_object).cloned())
@@ -750,10 +748,11 @@ fn failed_endpoint_event(object: &JsonObject, event_type: &str) -> ChatgptApiErr
         });
 
     let response_id = response
-        .get("id")
+        .as_ref()
+        .and_then(|response| response.get("id"))
         .and_then(Value::as_str)
         .map(str::to_owned);
-    let raw = response;
+    let raw = response.unwrap_or_else(|| object.clone());
 
     match failed_endpoint_kind(code.as_deref()) {
         Some(kind) => ChatgptApiError::Endpoint(ChatgptApiEndpointError::Failed(
@@ -834,6 +833,19 @@ fn parse_retry_after(message: &str) -> Option<Duration> {
     seconds.parse::<u64>().ok().map(Duration::from_secs)
 }
 
+fn parse_retry_after_header(value: Option<&str>) -> Option<Duration> {
+    let value = value?;
+
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+
+    let http_date = httpdate::parse_http_date(value).ok()?;
+    let now = std::time::SystemTime::now();
+
+    http_date.duration_since(now).ok()
+}
+
 fn malformed_event(field: &'static str, reason: &'static str) -> ChatgptApiError {
     ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
         reason: format!("{field} {reason}"),
@@ -883,8 +895,11 @@ fn nested_optional_u64(
     parent_field: &'static str,
     child_field: &'static str,
 ) -> Result<Option<u64>, ChatgptApiError> {
-    let Some(Value::Object(child)) = object.get(parent_field) else {
+    let Some(parent) = object.get(parent_field) else {
         return Ok(None);
+    };
+    let Value::Object(child) = parent else {
+        return Err(malformed_event(parent_field, "must be an object"));
     };
 
     optional_u64(child, child_field)
@@ -1781,17 +1796,20 @@ pub struct ChatgptOtherEndpointError {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use chatgpt_auth::ResolvedChatgptAuth;
-    use http::HeaderValue;
+    use http::{HeaderMap, HeaderValue, StatusCode};
     use selvedge_client::{HttpMethod, HttpRequestBody, RequestCompression};
     use selvedge_config_model::ChatgptApiConfig;
 
     use super::{
-        ChatgptModelCapabilities, ChatgptReasoningOptions, ChatgptRequestContext,
+        ChatgptApiEndpointError, ChatgptApiError, ChatgptModelCapabilities,
+        ChatgptOtherEndpointError, ChatgptReasoningOptions, ChatgptRequestContext,
         ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem,
         CustomToolCallItem, JsonObject, MessageItem, ReasoningItem, ResponseItem, TextVerbosity,
         ToolDescriptor, build_http_request, chatgpt_usage_from_value, content_item_from_value,
-        response_item_from_object,
+        failed_endpoint_event, response_item_from_object, retry_delay_for_attempt,
     };
 
     fn base_request() -> ChatgptResponsesRequest {
@@ -2014,6 +2032,25 @@ mod tests {
     }
 
     #[test]
+    fn retry_delay_honors_http_date_retry_after_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "retry-after",
+            HeaderValue::from_static("Wed, 21 Oct 2099 07:28:00 GMT"),
+        );
+        let error = selvedge_client::HttpError::Status(selvedge_client::HttpStatusError {
+            url: "https://chatgpt.com/backend-api/codex/responses".to_owned(),
+            status: StatusCode::TOO_MANY_REQUESTS,
+            headers,
+            body: bytes::Bytes::new(),
+        });
+
+        let delay = retry_delay_for_attempt(0, &error);
+
+        assert!(delay > Duration::from_secs(30) || delay == Duration::from_secs(30));
+    }
+
+    #[test]
     fn build_http_request_preserves_reasoning_effort_without_summary_support() {
         let mut request = base_request();
         request.reasoning.summary = None;
@@ -2081,6 +2118,20 @@ mod tests {
         assert_eq!(usage.output_tokens, Some(7));
         assert_eq!(usage.reasoning_output_tokens, Some(3));
         assert_eq!(usage.total_tokens, Some(17));
+    }
+
+    #[test]
+    fn chatgpt_usage_rejects_malformed_nested_detail_objects() {
+        let error = chatgpt_usage_from_value(&serde_json::json!({
+            "input_tokens": 10,
+            "input_tokens_details": "not-an-object"
+        }))
+        .expect_err("malformed nested usage object must fail");
+
+        assert!(matches!(
+            error,
+            ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent { .. })
+        ));
     }
 
     #[test]
@@ -2156,6 +2207,26 @@ mod tests {
                 summary,
                 ..
             }) if encrypted_content == "cipher" && summary.is_none()
+        ));
+    }
+
+    #[test]
+    fn failed_endpoint_event_keeps_top_level_error_payload_as_raw() {
+        let payload = JsonObject::from_iter([
+            ("type".to_owned(), serde_json::json!("error")),
+            ("code".to_owned(), serde_json::json!("server_busy")),
+            (
+                "message".to_owned(),
+                serde_json::json!("try again in 3 seconds"),
+            ),
+        ]);
+
+        let error = failed_endpoint_event(&payload, "error");
+
+        assert!(matches!(
+            error,
+            ChatgptApiError::Endpoint(ChatgptApiEndpointError::Other(ChatgptOtherEndpointError { raw, .. }))
+                if raw.get("code") == Some(&serde_json::json!("server_busy"))
         ));
     }
 }

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -546,9 +546,9 @@ fn map_stream_event(payload: &str) -> Result<MappedEvent, ChatgptApiError> {
                 text: required_string(&raw_object, "text")?,
             },
         )),
-        "response.completed" => Ok(MappedEvent::Completed(ChatgptResponseEvent::Completed(
-            response_snapshot_from_field(&raw_object)?,
-        ))),
+        "response.completed" | "response.done" => Ok(MappedEvent::Completed(
+            ChatgptResponseEvent::Completed(response_snapshot_from_field(&raw_object)?),
+        )),
         "response.failed" | "error" => Ok(MappedEvent::EndpointError(failed_endpoint_event(
             &raw_object,
             &event_type,
@@ -708,10 +708,16 @@ fn chatgpt_usage_from_value(value: &Value) -> Result<ChatgptUsage, ChatgptApiErr
 
     Ok(ChatgptUsage {
         input_tokens: optional_u64(usage, "input_tokens")?,
-        cached_input_tokens: nested_optional_u64(usage, "input_tokens_details", "cached_tokens")?,
-        output_tokens: optional_u64(usage, "output_tokens")?,
-        reasoning_output_tokens: nested_optional_u64(
+        cached_input_tokens: nested_optional_u64_with_fallback(
             usage,
+            "input_token_details",
+            "input_tokens_details",
+            "cached_tokens",
+        )?,
+        output_tokens: optional_u64(usage, "output_tokens")?,
+        reasoning_output_tokens: nested_optional_u64_with_fallback(
+            usage,
+            "output_token_details",
             "output_tokens_details",
             "reasoning_tokens",
         )?,
@@ -905,6 +911,18 @@ fn nested_optional_u64(
     };
 
     optional_u64(child, child_field)
+}
+
+fn nested_optional_u64_with_fallback(
+    object: &JsonObject,
+    primary_parent_field: &'static str,
+    fallback_parent_field: &'static str,
+    child_field: &'static str,
+) -> Result<Option<u64>, ChatgptApiError> {
+    nested_optional_u64(object, primary_parent_field, child_field)?.map_or_else(
+        || nested_optional_u64(object, fallback_parent_field, child_field),
+        |value| Ok(Some(value)),
+    )
 }
 
 fn required_array<'a>(
@@ -1785,11 +1803,11 @@ mod tests {
     use super::{
         ChatgptApiEndpointError, ChatgptApiError, ChatgptModelCapabilities,
         ChatgptOtherEndpointError, ChatgptReasoningOptions, ChatgptRequestContext,
-        ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem, JsonObject,
-        MessageItem, ReasoningItem, ResponseItem, TextVerbosity, ToolDescriptor,
-        build_http_request, chatgpt_usage_from_value, content_item_from_value,
-        failed_endpoint_event, is_retryable_client_error, response_item_from_object,
-        retry_delay_for_attempt, take_next_sse_frame,
+        ChatgptResponseEvent, ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions,
+        ContentItem, JsonObject, MessageItem, ReasoningItem, ResponseItem, TextVerbosity,
+        ToolDescriptor, build_http_request, chatgpt_usage_from_value, content_item_from_value,
+        failed_endpoint_event, is_retryable_client_error, map_stream_event,
+        response_item_from_object, retry_delay_for_attempt, take_next_sse_frame,
     };
 
     fn base_request() -> ChatgptResponsesRequest {
@@ -2087,11 +2105,11 @@ mod tests {
     fn chatgpt_usage_reads_nested_cache_and_reasoning_counts() {
         let usage = chatgpt_usage_from_value(&serde_json::json!({
             "input_tokens": 10,
-            "input_tokens_details": {
+            "input_token_details": {
                 "cached_tokens": 4
             },
             "output_tokens": 7,
-            "output_tokens_details": {
+            "output_token_details": {
                 "reasoning_tokens": 3
             },
             "total_tokens": 17
@@ -2204,6 +2222,20 @@ mod tests {
             error,
             ChatgptApiError::Endpoint(ChatgptApiEndpointError::Other(ChatgptOtherEndpointError { raw, .. }))
                 if raw.get("code") == Some(&serde_json::json!("server_busy"))
+        ));
+    }
+
+    #[test]
+    fn response_done_maps_to_completed_terminal_event() {
+        let event = map_stream_event(
+            r#"{"type":"response.done","response":{"id":"resp-1","model":"gpt-5"}}"#,
+        )
+        .expect("mapped event");
+
+        assert!(matches!(
+            event,
+            super::MappedEvent::Completed(ChatgptResponseEvent::Completed(snapshot))
+                if snapshot.id.as_deref() == Some("resp-1")
         ));
     }
 

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -426,7 +426,7 @@ fn map_stream_event(payload: &str) -> Result<MappedEvent, ChatgptApiError> {
         "response.completed" => Ok(MappedEvent::Completed(ChatgptResponseEvent::Completed(
             response_snapshot_from_field(&raw_object)?,
         ))),
-        "response.failed" => Ok(MappedEvent::EndpointError(failed_endpoint_event(
+        "response.failed" | "error" => Ok(MappedEvent::EndpointError(failed_endpoint_event(
             &raw_object,
             &event_type,
         ))),
@@ -921,17 +921,18 @@ fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
     }
 
     let reasoning = build_reasoning_body(request);
+    let reasoning_enabled = !reasoning.is_empty();
     body.insert(
         "reasoning".to_owned(),
-        if reasoning.is_empty() {
-            Value::Null
-        } else {
+        if reasoning_enabled {
             Value::Object(reasoning)
+        } else {
+            Value::Null
         },
     );
     body.insert(
         "include".to_owned(),
-        if request.model_capabilities.supports_reasoning_summaries {
+        if reasoning_enabled {
             serde_json::json!(["reasoning.encrypted_content"])
         } else {
             serde_json::json!([])
@@ -1809,7 +1810,10 @@ mod tests {
             body.pointer("/reasoning/effort"),
             Some(&serde_json::json!("high"))
         );
-        assert_eq!(body.get("include"), Some(&serde_json::json!([])));
+        assert_eq!(
+            body.get("include"),
+            Some(&serde_json::json!(["reasoning.encrypted_content"]))
+        );
     }
 
     #[test]

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -1,0 +1,1759 @@
+#![doc = include_str!("../README.md")]
+#![allow(clippy::result_large_err)]
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::StreamExt;
+use futures_core::Stream;
+use http::{HeaderMap, HeaderValue, StatusCode};
+use serde_json::Value;
+use tokio::{sync::mpsc, task::JoinHandle};
+
+pub type JsonObject = serde_json::Map<String, Value>;
+
+pub async fn stream(
+    request: ChatgptResponsesRequest,
+) -> Result<ChatgptResponseStream, ChatgptApiError> {
+    request
+        .validate()
+        .map_err(ChatgptApiLowerLayerError::InvalidInput)
+        .map_err(ChatgptApiError::LowerLayer)?;
+
+    let api_config = selvedge_config::read(|config| config.llm.providers.chatgpt.api.clone())
+        .map_err(ChatgptApiLowerLayerError::Config)
+        .map_err(ChatgptApiError::LowerLayer)?;
+    let response = open_response_stream(&request, &api_config).await?;
+    let effective_turn_state = response
+        .headers
+        .get("x-codex-turn-state")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
+        .or_else(|| request.context.turn_state.clone());
+
+    let (sender, receiver) = mpsc::channel(32);
+    let timeout = Duration::from_millis(api_config.stream_completion_timeout_ms);
+    let driver_task = tokio::spawn(async move {
+        drive_response_stream(response.body, sender, timeout).await;
+    });
+
+    Ok(ChatgptResponseStream::empty(
+        effective_turn_state,
+        receiver,
+        Some(driver_task),
+    ))
+}
+
+async fn open_response_stream(
+    request: &ChatgptResponsesRequest,
+    api_config: &selvedge_config_model::ChatgptApiConfig,
+) -> Result<selvedge_client::HttpStreamResponse, ChatgptApiError> {
+    let mut auth = chatgpt_auth::resolve_for_request()
+        .await
+        .map_err(ChatgptApiLowerLayerError::Auth)
+        .map_err(ChatgptApiError::LowerLayer)?;
+    let mut retry_count = 0_u8;
+    let mut reauth_used = false;
+
+    loop {
+        let http_request = build_http_request(request, &auth, api_config)
+            .map_err(ChatgptApiLowerLayerError::InvalidInput)
+            .map_err(ChatgptApiError::LowerLayer)?;
+
+        match selvedge_client::stream(http_request).await {
+            Ok(response) => {
+                ensure_event_stream_content_type(&response.headers)?;
+                return Ok(response);
+            }
+            Err(selvedge_client::HttpError::Status(status))
+                if status.status == StatusCode::UNAUTHORIZED && !reauth_used =>
+            {
+                auth = chatgpt_auth::resolve_after_unauthorized()
+                    .await
+                    .map_err(ChatgptApiLowerLayerError::Auth)
+                    .map_err(ChatgptApiError::LowerLayer)?;
+                reauth_used = true;
+            }
+            Err(error) if is_retryable_client_error(&error) && retry_count < 5 => {
+                let delay = retry_delay_for_attempt(retry_count, &error);
+                retry_count += 1;
+                tokio::time::sleep(delay).await;
+            }
+            Err(error) => {
+                return Err(ChatgptApiError::LowerLayer(
+                    ChatgptApiLowerLayerError::Client(error),
+                ));
+            }
+        }
+    }
+}
+
+fn ensure_event_stream_content_type(headers: &HeaderMap) -> Result<(), ChatgptApiError> {
+    let content_type = headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+
+    let is_event_stream = content_type
+        .as_deref()
+        .is_some_and(|value| value.starts_with("text/event-stream"));
+
+    if !is_event_stream {
+        return Err(ChatgptApiError::Endpoint(
+            ChatgptApiEndpointError::MalformedResponseHead { content_type },
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_retryable_client_error(error: &selvedge_client::HttpError) -> bool {
+    match error {
+        selvedge_client::HttpError::Timeout
+        | selvedge_client::HttpError::Connect { .. }
+        | selvedge_client::HttpError::Io { .. } => true,
+        selvedge_client::HttpError::Status(status) => matches!(
+            status.status,
+            StatusCode::REQUEST_TIMEOUT
+                | StatusCode::TOO_EARLY
+                | StatusCode::TOO_MANY_REQUESTS
+                | StatusCode::INTERNAL_SERVER_ERROR
+                | StatusCode::BAD_GATEWAY
+                | StatusCode::SERVICE_UNAVAILABLE
+                | StatusCode::GATEWAY_TIMEOUT
+        ),
+        selvedge_client::HttpError::Config(_)
+        | selvedge_client::HttpError::Build { .. }
+        | selvedge_client::HttpError::Tls { .. } => false,
+    }
+}
+
+fn retry_delay_for_attempt(retry_count: u8, error: &selvedge_client::HttpError) -> Duration {
+    if let selvedge_client::HttpError::Status(status) = error
+        && let Some(retry_after) = status
+            .headers
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok())
+    {
+        return Duration::from_secs(retry_after.min(30));
+    }
+
+    match retry_count {
+        0 => Duration::from_millis(200),
+        1 => Duration::from_millis(400),
+        2 => Duration::from_millis(800),
+        3 => Duration::from_millis(1600),
+        _ => Duration::from_millis(3200),
+    }
+}
+
+async fn drive_response_stream(
+    mut body: selvedge_client::ByteStream,
+    sender: mpsc::Sender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let completed = false;
+    let mut buffer = String::new();
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            send_stream_item(
+                &sender,
+                Err(ChatgptApiError::LowerLayer(
+                    ChatgptApiLowerLayerError::StreamCompletionTimeout { timeout },
+                )),
+            )
+            .await;
+            return;
+        }
+
+        let next_chunk = tokio::time::timeout(remaining, body.next()).await;
+        let maybe_chunk = match next_chunk {
+            Ok(chunk) => chunk,
+            Err(_) => {
+                send_stream_item(
+                    &sender,
+                    Err(ChatgptApiError::LowerLayer(
+                        ChatgptApiLowerLayerError::StreamCompletionTimeout { timeout },
+                    )),
+                )
+                .await;
+                return;
+            }
+        };
+
+        let Some(chunk) = maybe_chunk else {
+            if completed {
+                return;
+            }
+
+            let error = if buffer.trim().is_empty() {
+                ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
+            } else {
+                ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
+                    reason: "stream ended before the current SSE frame completed".to_owned(),
+                    raw: Some(buffer),
+                })
+            };
+            send_stream_item(&sender, Err(error)).await;
+            return;
+        };
+
+        let chunk = match chunk {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                send_stream_item(
+                    &sender,
+                    Err(ChatgptApiError::LowerLayer(
+                        ChatgptApiLowerLayerError::Client(error),
+                    )),
+                )
+                .await;
+                return;
+            }
+        };
+
+        let chunk = match std::str::from_utf8(&chunk) {
+            Ok(text) => text.replace("\r\n", "\n").replace('\r', "\n"),
+            Err(_) => {
+                send_stream_item(
+                    &sender,
+                    Err(ChatgptApiError::Endpoint(
+                        ChatgptApiEndpointError::MalformedEvent {
+                            reason: "event stream contained non-utf8 bytes".to_owned(),
+                            raw: None,
+                        },
+                    )),
+                )
+                .await;
+                return;
+            }
+        };
+        buffer.push_str(&chunk);
+
+        while let Some(frame) = take_next_sse_frame(&mut buffer) {
+            if frame.trim().is_empty() {
+                continue;
+            }
+
+            let payload = match parse_sse_frame(&frame) {
+                Ok(Some(payload)) => payload,
+                Ok(None) => continue,
+                Err(error) => {
+                    send_stream_item(&sender, Err(error)).await;
+                    return;
+                }
+            };
+
+            match map_stream_event(&payload) {
+                Ok(MappedEvent::Event(event)) => {
+                    send_stream_item(&sender, Ok(event)).await;
+                }
+                Ok(MappedEvent::Completed(event)) => {
+                    send_stream_item(&sender, Ok(event)).await;
+                    return;
+                }
+                Ok(MappedEvent::EndpointError(error)) => {
+                    send_stream_item(&sender, Err(error)).await;
+                    return;
+                }
+                Err(error) => {
+                    send_stream_item(&sender, Err(error)).await;
+                    return;
+                }
+            }
+        }
+    }
+}
+
+async fn send_stream_item(
+    sender: &mpsc::Sender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    item: Result<ChatgptResponseEvent, ChatgptApiError>,
+) {
+    let _ = sender.send(item).await;
+}
+
+fn take_next_sse_frame(buffer: &mut String) -> Option<String> {
+    let frame_end = buffer.find("\n\n")?;
+    let frame = buffer[..frame_end].to_owned();
+    let remainder = buffer[frame_end + 2..].to_owned();
+    *buffer = remainder;
+
+    Some(frame)
+}
+
+fn parse_sse_frame(frame: &str) -> Result<Option<String>, ChatgptApiError> {
+    let mut data_lines = Vec::new();
+
+    for line in frame.lines() {
+        if line.is_empty() || line.starts_with(':') {
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.trim_start().to_owned());
+        }
+    }
+
+    if data_lines.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(data_lines.join("\n")))
+}
+
+enum MappedEvent {
+    Event(ChatgptResponseEvent),
+    Completed(ChatgptResponseEvent),
+    EndpointError(ChatgptApiError),
+}
+
+fn map_stream_event(payload: &str) -> Result<MappedEvent, ChatgptApiError> {
+    let raw_value = serde_json::from_str::<Value>(payload).map_err(|_| {
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
+            reason: "event payload was not valid JSON".to_owned(),
+            raw: Some(payload.to_owned()),
+        })
+    })?;
+    let Value::Object(raw_object) = raw_value else {
+        return Err(ChatgptApiError::Endpoint(
+            ChatgptApiEndpointError::MalformedEvent {
+                reason: "event payload must be a JSON object".to_owned(),
+                raw: Some(payload.to_owned()),
+            },
+        ));
+    };
+    let event_type = raw_object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
+                reason: "event payload must contain a string type".to_owned(),
+                raw: Some(payload.to_owned()),
+            })
+        })?
+        .to_owned();
+
+    match event_type.as_str() {
+        "response.created" => Ok(MappedEvent::Event(ChatgptResponseEvent::Created(
+            response_snapshot_from_field(&raw_object)?,
+        ))),
+        "response.output_item.added" => {
+            Ok(MappedEvent::Event(ChatgptResponseEvent::OutputItemAdded {
+                output_index: required_u64(&raw_object, "output_index")?,
+                item: response_item_from_field(&raw_object, "item")?,
+            }))
+        }
+        "response.output_item.done" => {
+            Ok(MappedEvent::Event(ChatgptResponseEvent::OutputItemDone {
+                output_index: required_u64(&raw_object, "output_index")?,
+                item: response_item_from_field(&raw_object, "item")?,
+            }))
+        }
+        "response.output_text.delta" => {
+            Ok(MappedEvent::Event(ChatgptResponseEvent::OutputTextDelta {
+                item_id: required_string(&raw_object, "item_id")?,
+                output_index: required_u64(&raw_object, "output_index")?,
+                content_index: required_u64(&raw_object, "content_index")?,
+                delta: required_string(&raw_object, "delta")?,
+            }))
+        }
+        "response.output_text.done" => {
+            Ok(MappedEvent::Event(ChatgptResponseEvent::OutputTextDone {
+                item_id: required_string(&raw_object, "item_id")?,
+                output_index: required_u64(&raw_object, "output_index")?,
+                content_index: required_u64(&raw_object, "content_index")?,
+                text: required_string(&raw_object, "text")?,
+            }))
+        }
+        "response.reasoning_summary_text.delta" => Ok(MappedEvent::Event(
+            ChatgptResponseEvent::ReasoningSummaryTextDelta {
+                item_id: required_string(&raw_object, "item_id")?,
+                output_index: required_u64(&raw_object, "output_index")?,
+                summary_index: required_u64(&raw_object, "summary_index")?,
+                delta: required_string(&raw_object, "delta")?,
+            },
+        )),
+        "response.reasoning_summary_text.done" => Ok(MappedEvent::Event(
+            ChatgptResponseEvent::ReasoningSummaryTextDone {
+                item_id: required_string(&raw_object, "item_id")?,
+                output_index: required_u64(&raw_object, "output_index")?,
+                summary_index: required_u64(&raw_object, "summary_index")?,
+                text: required_string(&raw_object, "text")?,
+            },
+        )),
+        "response.reasoning_text.delta" => Ok(MappedEvent::Event(
+            ChatgptResponseEvent::ReasoningTextDelta {
+                item_id: required_string(&raw_object, "item_id")?,
+                output_index: required_u64(&raw_object, "output_index")?,
+                content_index: required_u64(&raw_object, "content_index")?,
+                delta: required_string(&raw_object, "delta")?,
+            },
+        )),
+        "response.reasoning_text.done" => Ok(MappedEvent::Event(
+            ChatgptResponseEvent::ReasoningTextDone {
+                item_id: required_string(&raw_object, "item_id")?,
+                output_index: required_u64(&raw_object, "output_index")?,
+                content_index: required_u64(&raw_object, "content_index")?,
+                text: required_string(&raw_object, "text")?,
+            },
+        )),
+        "response.completed" => Ok(MappedEvent::Completed(ChatgptResponseEvent::Completed(
+            response_snapshot_from_field(&raw_object)?,
+        ))),
+        "response.failed" => Ok(MappedEvent::EndpointError(failed_endpoint_event(
+            &raw_object,
+            &event_type,
+        ))),
+        "response.incomplete" => Ok(MappedEvent::EndpointError(ChatgptApiError::Endpoint(
+            ChatgptApiEndpointError::Incomplete(incomplete_endpoint_error(&raw_object)),
+        ))),
+        _ => Ok(MappedEvent::Event(ChatgptResponseEvent::Other(
+            ChatgptRawEvent {
+                event_type,
+                payload: raw_object,
+            },
+        ))),
+    }
+}
+
+fn response_snapshot_from_field(
+    object: &JsonObject,
+) -> Result<ChatgptResponseSnapshot, ChatgptApiError> {
+    let response = object
+        .get("response")
+        .and_then(Value::as_object)
+        .ok_or_else(|| malformed_event("response", "must be an object"))?;
+
+    let usage = response
+        .get("usage")
+        .map(chatgpt_usage_from_value)
+        .transpose()?;
+
+    Ok(ChatgptResponseSnapshot {
+        id: optional_string(response, "id")?,
+        model: optional_string(response, "model")?,
+        usage,
+        service_tier: optional_string(response, "service_tier")?,
+        raw: response.clone(),
+    })
+}
+
+fn response_item_from_field(
+    object: &JsonObject,
+    field: &'static str,
+) -> Result<ResponseItem, ChatgptApiError> {
+    let item = object
+        .get(field)
+        .and_then(Value::as_object)
+        .ok_or_else(|| malformed_event(field, "must be an object"))?;
+
+    response_item_from_object(item)
+}
+
+fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptApiError> {
+    let item_type = required_string(item, "type")?;
+
+    match item_type.as_str() {
+        "message" => Ok(ResponseItem::Message(MessageItem {
+            id: optional_string(item, "id")?,
+            status: optional_string(item, "status")?,
+            role: required_string(item, "role")?,
+            content: required_array(item, "content")?
+                .iter()
+                .map(content_item_from_value)
+                .collect::<Result<Vec<_>, _>>()?,
+        })),
+        "function_call" => Ok(ResponseItem::FunctionCall(FunctionCallItem {
+            id: optional_string(item, "id")?,
+            status: optional_string(item, "status")?,
+            name: required_string(item, "name")?,
+            namespace: optional_string(item, "namespace")?,
+            arguments: required_string(item, "arguments")?,
+            call_id: required_string(item, "call_id")?,
+        })),
+        "function_call_output" => Ok(ResponseItem::FunctionCallOutput(FunctionCallOutputItem {
+            id: optional_string(item, "id")?,
+            status: optional_string(item, "status")?,
+            call_id: required_string(item, "call_id")?,
+            output: tool_output_from_value(
+                item.get("output")
+                    .ok_or_else(|| malformed_event("output", "must be present"))?,
+            )?,
+        })),
+        "custom_tool_call_output" => Ok(ResponseItem::CustomToolCallOutput(
+            CustomToolCallOutputItem {
+                id: optional_string(item, "id")?,
+                status: optional_string(item, "status")?,
+                call_id: required_string(item, "call_id")?,
+                output: tool_output_from_value(
+                    item.get("output")
+                        .ok_or_else(|| malformed_event("output", "must be present"))?,
+                )?,
+            },
+        )),
+        "reasoning" => Ok(ResponseItem::Reasoning(ReasoningItem {
+            id: optional_string(item, "id")?,
+            status: optional_string(item, "status")?,
+            summary: item
+                .get("summary")
+                .cloned()
+                .ok_or_else(|| malformed_event("summary", "must be present"))?,
+            content: item
+                .get("content")
+                .map(|value| match value {
+                    Value::Array(values) => values
+                        .iter()
+                        .map(content_item_from_value)
+                        .collect::<Result<Vec<_>, _>>(),
+                    _ => Err(malformed_event("content", "must be an array")),
+                })
+                .transpose()?,
+            encrypted_content: optional_string(item, "encrypted_content")?,
+        })),
+        _ => Ok(ResponseItem::Opaque(OpaqueResponseItem {
+            raw: item.clone(),
+        })),
+    }
+}
+
+fn content_item_from_value(value: &Value) -> Result<ContentItem, ChatgptApiError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| malformed_event("content", "must contain objects"))?;
+    let item_type = required_string(object, "type")?;
+
+    match item_type.as_str() {
+        "input_text" => Ok(ContentItem::InputText {
+            text: required_string(object, "text")?,
+        }),
+        "input_image" => Ok(ContentItem::InputImage {
+            image_url: required_string(object, "image_url")?,
+        }),
+        "output_text" => Ok(ContentItem::OutputText {
+            text: required_string(object, "text")?,
+            raw: object.clone(),
+        }),
+        _ => Ok(ContentItem::Other {
+            raw: object.clone(),
+        }),
+    }
+}
+
+fn tool_output_from_value(value: &Value) -> Result<ToolOutput, ChatgptApiError> {
+    match value {
+        Value::String(text) => Ok(ToolOutput::Text(text.clone())),
+        Value::Array(values) => Ok(ToolOutput::Content(
+            values
+                .iter()
+                .map(content_item_from_value)
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        _ => Err(malformed_event(
+            "output",
+            "must be a string or content array",
+        )),
+    }
+}
+
+fn chatgpt_usage_from_value(value: &Value) -> Result<ChatgptUsage, ChatgptApiError> {
+    let usage = value
+        .as_object()
+        .ok_or_else(|| malformed_event("usage", "must be an object"))?;
+
+    Ok(ChatgptUsage {
+        input_tokens: optional_u64(usage, "input_tokens")?,
+        cached_input_tokens: optional_u64(usage, "cached_input_tokens")?,
+        output_tokens: optional_u64(usage, "output_tokens")?,
+        reasoning_output_tokens: optional_u64(usage, "reasoning_output_tokens")?,
+        total_tokens: optional_u64(usage, "total_tokens")?,
+    })
+}
+
+fn failed_endpoint_event(object: &JsonObject, event_type: &str) -> ChatgptApiError {
+    let response = object
+        .get("response")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let error = response
+        .get("error")
+        .and_then(Value::as_object)
+        .cloned()
+        .or_else(|| object.get("error").and_then(Value::as_object).cloned())
+        .unwrap_or_default();
+    let code = error
+        .get("code")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            object
+                .get("code")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            object
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+
+    let response_id = response
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let raw = response;
+
+    match failed_endpoint_kind(code.as_deref()) {
+        Some(kind) => ChatgptApiError::Endpoint(ChatgptApiEndpointError::Failed(
+            ChatgptFailedEndpointError {
+                kind,
+                response_id,
+                code,
+                message,
+                raw,
+            },
+        )),
+        None => {
+            ChatgptApiError::Endpoint(ChatgptApiEndpointError::Other(ChatgptOtherEndpointError {
+                event_type: Some(event_type.to_owned()),
+                code,
+                message: message.clone(),
+                retry_after: message.as_deref().and_then(parse_retry_after),
+                raw,
+            }))
+        }
+    }
+}
+
+fn incomplete_endpoint_error(object: &JsonObject) -> ChatgptIncompleteEndpointError {
+    let response = object
+        .get("response")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let reason = response
+        .get("reason")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            response
+                .get("incomplete_details")
+                .and_then(Value::as_object)
+                .and_then(|details| details.get("reason"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .or_else(|| {
+            object
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+
+    ChatgptIncompleteEndpointError {
+        response_id: response
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        reason,
+        raw: response,
+    }
+}
+
+fn failed_endpoint_kind(code: Option<&str>) -> Option<ChatgptFailedEndpointKind> {
+    match code {
+        Some("context_length_exceeded") => Some(ChatgptFailedEndpointKind::ContextLengthExceeded),
+        Some("insufficient_quota") => Some(ChatgptFailedEndpointKind::InsufficientQuota),
+        Some("usage_not_included") => Some(ChatgptFailedEndpointKind::UsageNotIncluded),
+        Some("invalid_prompt") => Some(ChatgptFailedEndpointKind::InvalidPrompt),
+        Some("server_overloaded") => Some(ChatgptFailedEndpointKind::ServerOverloaded),
+        _ => None,
+    }
+}
+
+fn parse_retry_after(message: &str) -> Option<Duration> {
+    let marker = "try again in ";
+    let start = message.find(marker)? + marker.len();
+    let seconds = message[start..]
+        .chars()
+        .take_while(|character| character.is_ascii_digit())
+        .collect::<String>();
+
+    seconds.parse::<u64>().ok().map(Duration::from_secs)
+}
+
+fn malformed_event(field: &'static str, reason: &'static str) -> ChatgptApiError {
+    ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
+        reason: format!("{field} {reason}"),
+        raw: None,
+    })
+}
+
+fn required_string(object: &JsonObject, field: &'static str) -> Result<String, ChatgptApiError> {
+    object
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| malformed_event(field, "must be a string"))
+}
+
+fn optional_string(
+    object: &JsonObject,
+    field: &'static str,
+) -> Result<Option<String>, ChatgptApiError> {
+    match object.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(malformed_event(field, "must be a string")),
+    }
+}
+
+fn required_u64(object: &JsonObject, field: &'static str) -> Result<u64, ChatgptApiError> {
+    object
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| malformed_event(field, "must be an unsigned integer"))
+}
+
+fn optional_u64(object: &JsonObject, field: &'static str) -> Result<Option<u64>, ChatgptApiError> {
+    match object.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(number)) => number
+            .as_u64()
+            .map(Some)
+            .ok_or_else(|| malformed_event(field, "must be an unsigned integer")),
+        Some(_) => Err(malformed_event(field, "must be an unsigned integer")),
+    }
+}
+
+fn required_array<'a>(
+    object: &'a JsonObject,
+    field: &'static str,
+) -> Result<&'a Vec<Value>, ChatgptApiError> {
+    object
+        .get(field)
+        .and_then(Value::as_array)
+        .ok_or_else(|| malformed_event(field, "must be an array"))
+}
+
+fn build_http_request(
+    request: &ChatgptResponsesRequest,
+    auth: &chatgpt_auth::ResolvedChatgptAuth,
+    api_config: &selvedge_config_model::ChatgptApiConfig,
+) -> Result<selvedge_client::HttpRequest, RequestValidationError> {
+    request.validate()?;
+    validate_non_blank("auth.access_token", &auth.access_token)?;
+    validate_non_blank("auth.account_id", &auth.account_id)?;
+    validate_header_value("auth.access_token", &auth.access_token)?;
+    validate_header_value("auth.account_id", &auth.account_id)?;
+
+    let mut headers = HeaderMap::new();
+    insert_header(
+        &mut headers,
+        "authorization",
+        &format!("Bearer {}", auth.access_token),
+    )?;
+    insert_header(&mut headers, "chatgpt-account-id", &auth.account_id)?;
+    insert_header(&mut headers, "session_id", &request.context.conversation_id)?;
+    insert_header(
+        &mut headers,
+        "x-client-request-id",
+        &request.context.conversation_id,
+    )?;
+    insert_header(
+        &mut headers,
+        "x-codex-window-id",
+        &format!(
+            "{}:{}",
+            request.context.conversation_id, request.context.window_generation
+        ),
+    )?;
+    insert_header(&mut headers, "accept", "text/event-stream")?;
+
+    if let Some(turn_state) = request.context.turn_state.as_deref() {
+        insert_header(&mut headers, "x-codex-turn-state", turn_state)?;
+    }
+
+    if let Some(turn_metadata) = request.context.turn_metadata.as_deref() {
+        insert_header(&mut headers, "x-codex-turn-metadata", turn_metadata)?;
+    }
+
+    if !request.context.beta_features.is_empty() {
+        insert_header(
+            &mut headers,
+            "x-codex-beta-features",
+            &request.context.beta_features.join(","),
+        )?;
+    }
+
+    if let Some(subagent) = request.context.subagent.as_deref() {
+        insert_header(&mut headers, "x-openai-subagent", subagent)?;
+    }
+
+    if let Some(parent_thread_id) = request.context.parent_thread_id.as_deref() {
+        insert_header(&mut headers, "x-codex-parent-thread-id", parent_thread_id)?;
+    }
+
+    let url = format!("{}/responses", api_config.base_url.trim_end_matches('/'));
+    let body = build_request_body(request);
+
+    Ok(selvedge_client::HttpRequest {
+        method: selvedge_client::HttpMethod::Post,
+        url,
+        headers,
+        body: selvedge_client::HttpRequestBody::Json(body),
+        timeout: None,
+        compression: selvedge_client::RequestCompression::None,
+    })
+}
+
+fn insert_header(
+    headers: &mut HeaderMap,
+    name: &'static str,
+    value: &str,
+) -> Result<(), RequestValidationError> {
+    let header_value = HeaderValue::from_str(value)
+        .map_err(|_| RequestValidationError::new(name, "must be a valid HTTP header value"))?;
+    headers.insert(name, header_value);
+
+    Ok(())
+}
+
+fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
+    let mut body = JsonObject::new();
+
+    body.insert("model".to_owned(), Value::String(request.model.clone()));
+    body.insert(
+        "input".to_owned(),
+        Value::Array(
+            request
+                .input
+                .iter()
+                .map(response_item_to_json)
+                .collect::<Vec<_>>(),
+        ),
+    );
+    body.insert(
+        "tools".to_owned(),
+        Value::Array(
+            request
+                .tools
+                .iter()
+                .map(|tool| Value::Object(tool.0.clone()))
+                .collect::<Vec<_>>(),
+        ),
+    );
+    body.insert("tool_choice".to_owned(), Value::String("auto".to_owned()));
+    body.insert(
+        "parallel_tool_calls".to_owned(),
+        Value::Bool(request.parallel_tool_calls),
+    );
+    body.insert("store".to_owned(), Value::Bool(false));
+    body.insert("stream".to_owned(), Value::Bool(true));
+    body.insert(
+        "prompt_cache_key".to_owned(),
+        Value::String(request.context.conversation_id.clone()),
+    );
+    body.insert(
+        "client_metadata".to_owned(),
+        Value::Object(JsonObject::from_iter([(
+            "x-codex-installation-id".to_owned(),
+            Value::String(request.context.installation_id.clone()),
+        )])),
+    );
+
+    if let Some(instructions) = request
+        .instructions
+        .as_ref()
+        .filter(|value| !value.is_empty())
+    {
+        body.insert(
+            "instructions".to_owned(),
+            Value::String(instructions.clone()),
+        );
+    }
+
+    let reasoning_support = request.model_capabilities.supports_reasoning_summaries;
+    body.insert(
+        "reasoning".to_owned(),
+        if reasoning_support {
+            Value::Object(build_reasoning_body(request))
+        } else {
+            Value::Null
+        },
+    );
+    body.insert(
+        "include".to_owned(),
+        if reasoning_support {
+            serde_json::json!(["reasoning.encrypted_content"])
+        } else {
+            serde_json::json!([])
+        },
+    );
+
+    if let Some(service_tier) = request.service_tier {
+        body.insert(
+            "service_tier".to_owned(),
+            Value::String(service_tier_to_wire(service_tier).to_owned()),
+        );
+    }
+
+    if let Some(text) = build_text_body(&request.text) {
+        body.insert("text".to_owned(), Value::Object(text));
+    }
+
+    Value::Object(body)
+}
+
+fn build_reasoning_body(request: &ChatgptResponsesRequest) -> JsonObject {
+    let mut reasoning = JsonObject::new();
+
+    if let Some(effort) = request
+        .reasoning
+        .effort
+        .clone()
+        .or_else(|| request.model_capabilities.default_reasoning_effort.clone())
+    {
+        reasoning.insert("effort".to_owned(), Value::String(effort));
+    }
+
+    if let Some(summary) = request.reasoning.summary.clone() {
+        reasoning.insert("summary".to_owned(), Value::String(summary));
+    }
+
+    reasoning
+}
+
+fn build_text_body(text: &ChatgptTextOptions) -> Option<JsonObject> {
+    let mut body = JsonObject::new();
+
+    if let Some(verbosity) = text.verbosity {
+        body.insert(
+            "verbosity".to_owned(),
+            Value::String(text_verbosity_to_wire(verbosity).to_owned()),
+        );
+    }
+
+    if let Some(schema) = &text.json_schema {
+        body.insert(
+            "format".to_owned(),
+            Value::Object(JsonObject::from_iter([
+                ("type".to_owned(), Value::String("json_schema".to_owned())),
+                ("strict".to_owned(), Value::Bool(true)),
+                (
+                    "name".to_owned(),
+                    Value::String("codex_output_schema".to_owned()),
+                ),
+                ("schema".to_owned(), Value::Object(schema.clone())),
+            ])),
+        );
+    }
+
+    (!body.is_empty()).then_some(body)
+}
+
+fn response_item_to_json(item: &ResponseItem) -> Value {
+    match item {
+        ResponseItem::Message(message) => Value::Object(JsonObject::from_iter([
+            ("type".to_owned(), Value::String("message".to_owned())),
+            (
+                "id".to_owned(),
+                optional_string_value(message.id.as_deref()),
+            ),
+            (
+                "status".to_owned(),
+                optional_string_value(message.status.as_deref()),
+            ),
+            ("role".to_owned(), Value::String(message.role.clone())),
+            (
+                "content".to_owned(),
+                Value::Array(message.content.iter().map(content_item_to_json).collect()),
+            ),
+        ])),
+        ResponseItem::FunctionCall(call) => Value::Object(JsonObject::from_iter([
+            ("type".to_owned(), Value::String("function_call".to_owned())),
+            ("id".to_owned(), optional_string_value(call.id.as_deref())),
+            (
+                "status".to_owned(),
+                optional_string_value(call.status.as_deref()),
+            ),
+            ("name".to_owned(), Value::String(call.name.clone())),
+            (
+                "namespace".to_owned(),
+                optional_string_value(call.namespace.as_deref()),
+            ),
+            (
+                "arguments".to_owned(),
+                Value::String(call.arguments.clone()),
+            ),
+            ("call_id".to_owned(), Value::String(call.call_id.clone())),
+        ])),
+        ResponseItem::FunctionCallOutput(output) => Value::Object(JsonObject::from_iter([
+            (
+                "type".to_owned(),
+                Value::String("function_call_output".to_owned()),
+            ),
+            ("id".to_owned(), optional_string_value(output.id.as_deref())),
+            (
+                "status".to_owned(),
+                optional_string_value(output.status.as_deref()),
+            ),
+            ("call_id".to_owned(), Value::String(output.call_id.clone())),
+            ("output".to_owned(), tool_output_to_json(&output.output)),
+        ])),
+        ResponseItem::CustomToolCallOutput(output) => Value::Object(JsonObject::from_iter([
+            (
+                "type".to_owned(),
+                Value::String("custom_tool_call_output".to_owned()),
+            ),
+            ("id".to_owned(), optional_string_value(output.id.as_deref())),
+            (
+                "status".to_owned(),
+                optional_string_value(output.status.as_deref()),
+            ),
+            ("call_id".to_owned(), Value::String(output.call_id.clone())),
+            ("output".to_owned(), tool_output_to_json(&output.output)),
+        ])),
+        ResponseItem::Reasoning(reasoning) => {
+            let mut value = JsonObject::from_iter([
+                ("type".to_owned(), Value::String("reasoning".to_owned())),
+                (
+                    "id".to_owned(),
+                    optional_string_value(reasoning.id.as_deref()),
+                ),
+                (
+                    "status".to_owned(),
+                    optional_string_value(reasoning.status.as_deref()),
+                ),
+                ("summary".to_owned(), reasoning.summary.clone()),
+            ]);
+
+            if let Some(content) = &reasoning.content {
+                value.insert(
+                    "content".to_owned(),
+                    Value::Array(content.iter().map(content_item_to_json).collect()),
+                );
+            }
+
+            if let Some(encrypted_content) = reasoning.encrypted_content.as_ref() {
+                value.insert(
+                    "encrypted_content".to_owned(),
+                    Value::String(encrypted_content.clone()),
+                );
+            }
+
+            Value::Object(value)
+        }
+        ResponseItem::Opaque(opaque) => Value::Object(opaque.raw.clone()),
+    }
+}
+
+fn content_item_to_json(item: &ContentItem) -> Value {
+    match item {
+        ContentItem::InputText { text } => Value::Object(JsonObject::from_iter([
+            ("type".to_owned(), Value::String("input_text".to_owned())),
+            ("text".to_owned(), Value::String(text.clone())),
+        ])),
+        ContentItem::InputImage { image_url } => Value::Object(JsonObject::from_iter([
+            ("type".to_owned(), Value::String("input_image".to_owned())),
+            ("image_url".to_owned(), Value::String(image_url.clone())),
+        ])),
+        ContentItem::OutputText { text, raw } => {
+            let mut value = raw.clone();
+            value.insert("type".to_owned(), Value::String("output_text".to_owned()));
+            value.insert("text".to_owned(), Value::String(text.clone()));
+            Value::Object(value)
+        }
+        ContentItem::Other { raw } => Value::Object(raw.clone()),
+    }
+}
+
+fn tool_output_to_json(output: &ToolOutput) -> Value {
+    match output {
+        ToolOutput::Text(text) => Value::String(text.clone()),
+        ToolOutput::Content(content) => {
+            Value::Array(content.iter().map(content_item_to_json).collect())
+        }
+    }
+}
+
+fn optional_string_value(value: Option<&str>) -> Value {
+    value
+        .map(|value| Value::String(value.to_owned()))
+        .unwrap_or(Value::Null)
+}
+
+fn service_tier_to_wire(service_tier: ChatgptServiceTier) -> &'static str {
+    match service_tier {
+        ChatgptServiceTier::Default => "default",
+        ChatgptServiceTier::Flex => "flex",
+        ChatgptServiceTier::Fast => "priority",
+    }
+}
+
+fn text_verbosity_to_wire(verbosity: TextVerbosity) -> &'static str {
+    match verbosity {
+        TextVerbosity::Low => "low",
+        TextVerbosity::Medium => "medium",
+        TextVerbosity::High => "high",
+    }
+}
+
+pub struct ChatgptResponseStream {
+    effective_turn_state: Option<String>,
+    receiver: mpsc::Receiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    driver_task: Option<JoinHandle<()>>,
+}
+
+impl ChatgptResponseStream {
+    pub fn effective_turn_state(&self) -> Option<&str> {
+        self.effective_turn_state.as_deref()
+    }
+
+    fn empty(
+        effective_turn_state: Option<String>,
+        receiver: mpsc::Receiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+        driver_task: Option<JoinHandle<()>>,
+    ) -> Self {
+        Self {
+            effective_turn_state,
+            receiver,
+            driver_task,
+        }
+    }
+}
+
+impl Drop for ChatgptResponseStream {
+    fn drop(&mut self) {
+        if let Some(driver_task) = self.driver_task.take() {
+            driver_task.abort();
+        }
+    }
+}
+
+impl Stream for ChatgptResponseStream {
+    type Item = Result<ChatgptResponseEvent, ChatgptApiError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().receiver.poll_recv(cx)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptResponsesRequest {
+    pub model: String,
+    pub model_capabilities: ChatgptModelCapabilities,
+    pub context: ChatgptRequestContext,
+    pub instructions: Option<String>,
+    pub input: Vec<ResponseItem>,
+    pub tools: Vec<ToolDescriptor>,
+    pub parallel_tool_calls: bool,
+    pub reasoning: ChatgptReasoningOptions,
+    pub text: ChatgptTextOptions,
+    pub service_tier: Option<ChatgptServiceTier>,
+}
+
+impl ChatgptResponsesRequest {
+    pub fn validate(&self) -> Result<(), RequestValidationError> {
+        validate_non_blank("model", &self.model)?;
+        validate_non_blank("context.conversation_id", &self.context.conversation_id)?;
+        validate_non_blank("context.installation_id", &self.context.installation_id)?;
+
+        if self.context.conversation_id.contains(':') {
+            return Err(RequestValidationError::new(
+                "context.conversation_id",
+                "must not contain ':'",
+            ));
+        }
+
+        validate_header_value("context.conversation_id", &self.context.conversation_id)?;
+        validate_header_value("context.installation_id", &self.context.installation_id)?;
+        validate_optional_header_value("context.turn_state", self.context.turn_state.as_deref())?;
+        validate_optional_header_value(
+            "context.turn_metadata",
+            self.context.turn_metadata.as_deref(),
+        )?;
+        validate_optional_header_value("context.subagent", self.context.subagent.as_deref())?;
+        validate_optional_header_value(
+            "context.parent_thread_id",
+            self.context.parent_thread_id.as_deref(),
+        )?;
+
+        for beta_feature in &self.context.beta_features {
+            validate_non_blank("context.beta_features", beta_feature)?;
+            validate_header_value("context.beta_features", beta_feature)?;
+
+            if beta_feature.contains(',') {
+                return Err(RequestValidationError::new(
+                    "context.beta_features",
+                    "must not contain ','",
+                ));
+            }
+        }
+
+        if self.reasoning.summary.is_some() && !self.model_capabilities.supports_reasoning_summaries
+        {
+            return Err(RequestValidationError::new(
+                "reasoning.summary",
+                "is not supported by this model",
+            ));
+        }
+
+        if self.text.verbosity.is_some() && !self.model_capabilities.supports_text_verbosity {
+            return Err(RequestValidationError::new(
+                "text.verbosity",
+                "is not supported by this model",
+            ));
+        }
+
+        validate_json_objects("tools", &self.tools)?;
+
+        Ok(())
+    }
+}
+
+fn validate_non_blank(field: &'static str, value: &str) -> Result<(), RequestValidationError> {
+    if value.trim().is_empty() {
+        return Err(RequestValidationError::new(field, "must not be blank"));
+    }
+
+    Ok(())
+}
+
+fn validate_header_value(field: &'static str, value: &str) -> Result<(), RequestValidationError> {
+    HeaderValue::from_str(value)
+        .map_err(|_| RequestValidationError::new(field, "must be a valid HTTP header value"))?;
+
+    Ok(())
+}
+
+fn validate_optional_header_value(
+    field: &'static str,
+    value: Option<&str>,
+) -> Result<(), RequestValidationError> {
+    if let Some(value) = value {
+        validate_non_blank(field, value)?;
+        validate_header_value(field, value)?;
+    }
+
+    Ok(())
+}
+
+fn validate_json_objects(
+    field: &'static str,
+    tools: &[ToolDescriptor],
+) -> Result<(), RequestValidationError> {
+    if tools
+        .iter()
+        .any(|descriptor| serde_json::to_value(&descriptor.0).ok().is_none())
+    {
+        return Err(RequestValidationError::new(
+            field,
+            "must be valid JSON objects",
+        ));
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptModelCapabilities {
+    pub supports_reasoning_summaries: bool,
+    pub supports_text_verbosity: bool,
+    pub default_reasoning_effort: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptRequestContext {
+    pub conversation_id: String,
+    pub window_generation: u64,
+    pub installation_id: String,
+    pub turn_state: Option<String>,
+    pub turn_metadata: Option<String>,
+    pub beta_features: Vec<String>,
+    pub subagent: Option<String>,
+    pub parent_thread_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ChatgptReasoningOptions {
+    pub effort: Option<String>,
+    pub summary: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ChatgptTextOptions {
+    pub verbosity: Option<TextVerbosity>,
+    pub json_schema: Option<JsonObject>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TextVerbosity {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChatgptServiceTier {
+    Default,
+    Flex,
+    Fast,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ToolDescriptor(pub JsonObject);
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ChatgptResponseEvent {
+    Created(ChatgptResponseSnapshot),
+    OutputItemAdded {
+        output_index: u64,
+        item: ResponseItem,
+    },
+    OutputItemDone {
+        output_index: u64,
+        item: ResponseItem,
+    },
+    OutputTextDelta {
+        item_id: String,
+        output_index: u64,
+        content_index: u64,
+        delta: String,
+    },
+    OutputTextDone {
+        item_id: String,
+        output_index: u64,
+        content_index: u64,
+        text: String,
+    },
+    ReasoningSummaryTextDelta {
+        item_id: String,
+        output_index: u64,
+        summary_index: u64,
+        delta: String,
+    },
+    ReasoningSummaryTextDone {
+        item_id: String,
+        output_index: u64,
+        summary_index: u64,
+        text: String,
+    },
+    ReasoningTextDelta {
+        item_id: String,
+        output_index: u64,
+        content_index: u64,
+        delta: String,
+    },
+    ReasoningTextDone {
+        item_id: String,
+        output_index: u64,
+        content_index: u64,
+        text: String,
+    },
+    Completed(ChatgptResponseSnapshot),
+    Other(ChatgptRawEvent),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptResponseSnapshot {
+    pub id: Option<String>,
+    pub model: Option<String>,
+    pub usage: Option<ChatgptUsage>,
+    pub service_tier: Option<String>,
+    pub raw: JsonObject,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptRawEvent {
+    pub event_type: String,
+    pub payload: JsonObject,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptUsage {
+    pub input_tokens: Option<u64>,
+    pub cached_input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub reasoning_output_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ResponseItem {
+    Message(MessageItem),
+    FunctionCall(FunctionCallItem),
+    FunctionCallOutput(FunctionCallOutputItem),
+    CustomToolCallOutput(CustomToolCallOutputItem),
+    Reasoning(ReasoningItem),
+    Opaque(OpaqueResponseItem),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MessageItem {
+    pub id: Option<String>,
+    pub status: Option<String>,
+    pub role: String,
+    pub content: Vec<ContentItem>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FunctionCallItem {
+    pub id: Option<String>,
+    pub status: Option<String>,
+    pub name: String,
+    pub namespace: Option<String>,
+    pub arguments: String,
+    pub call_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FunctionCallOutputItem {
+    pub id: Option<String>,
+    pub status: Option<String>,
+    pub call_id: String,
+    pub output: ToolOutput,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CustomToolCallOutputItem {
+    pub id: Option<String>,
+    pub status: Option<String>,
+    pub call_id: String,
+    pub output: ToolOutput,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReasoningItem {
+    pub id: Option<String>,
+    pub status: Option<String>,
+    pub summary: Value,
+    pub content: Option<Vec<ContentItem>>,
+    pub encrypted_content: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OpaqueResponseItem {
+    pub raw: JsonObject,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ContentItem {
+    InputText { text: String },
+    InputImage { image_url: String },
+    OutputText { text: String, raw: JsonObject },
+    Other { raw: JsonObject },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ToolOutput {
+    Text(String),
+    Content(Vec<ContentItem>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RequestValidationError {
+    pub field: &'static str,
+    pub reason: String,
+}
+
+impl RequestValidationError {
+    fn new(field: &'static str, reason: impl Into<String>) -> Self {
+        Self {
+            field,
+            reason: reason.into(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ChatgptApiError {
+    #[error(transparent)]
+    LowerLayer(#[from] ChatgptApiLowerLayerError),
+    #[error(transparent)]
+    Endpoint(#[from] ChatgptApiEndpointError),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ChatgptApiLowerLayerError {
+    #[error("invalid request field {0:?}")]
+    InvalidInput(RequestValidationError),
+    #[error(transparent)]
+    Config(#[from] selvedge_config::ConfigError),
+    #[error("auth error: {0:?}")]
+    Auth(chatgpt_auth::ChatgptAuthError),
+    #[error(transparent)]
+    Client(#[from] selvedge_client::HttpError),
+    #[error("response stream exceeded completion timeout of {timeout:?}")]
+    StreamCompletionTimeout { timeout: Duration },
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ChatgptApiEndpointError {
+    #[error("response failed")]
+    Failed(ChatgptFailedEndpointError),
+    #[error("response incomplete")]
+    Incomplete(ChatgptIncompleteEndpointError),
+    #[error("response head was not a valid event stream")]
+    MalformedResponseHead { content_type: Option<String> },
+    #[error("malformed event: {reason}")]
+    MalformedEvent { reason: String, raw: Option<String> },
+    #[error("response stream closed before completion")]
+    PrematureClose,
+    #[error("unexpected endpoint event")]
+    Other(ChatgptOtherEndpointError),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChatgptFailedEndpointKind {
+    ContextLengthExceeded,
+    InsufficientQuota,
+    UsageNotIncluded,
+    InvalidPrompt,
+    ServerOverloaded,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptFailedEndpointError {
+    pub kind: ChatgptFailedEndpointKind,
+    pub response_id: Option<String>,
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub raw: JsonObject,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptIncompleteEndpointError {
+    pub response_id: Option<String>,
+    pub reason: Option<String>,
+    pub raw: JsonObject,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptOtherEndpointError {
+    pub event_type: Option<String>,
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub retry_after: Option<Duration>,
+    pub raw: JsonObject,
+}
+
+#[cfg(test)]
+mod tests {
+    use chatgpt_auth::ResolvedChatgptAuth;
+    use http::HeaderValue;
+    use selvedge_client::{HttpMethod, HttpRequestBody, RequestCompression};
+    use selvedge_config_model::ChatgptApiConfig;
+
+    use super::{
+        ChatgptModelCapabilities, ChatgptReasoningOptions, ChatgptRequestContext,
+        ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem, JsonObject,
+        MessageItem, ResponseItem, TextVerbosity, ToolDescriptor, build_http_request,
+    };
+
+    fn base_request() -> ChatgptResponsesRequest {
+        ChatgptResponsesRequest {
+            model: "gpt-5".to_owned(),
+            model_capabilities: ChatgptModelCapabilities {
+                supports_reasoning_summaries: true,
+                supports_text_verbosity: true,
+                default_reasoning_effort: Some("medium".to_owned()),
+            },
+            context: ChatgptRequestContext {
+                conversation_id: "conversation-123".to_owned(),
+                window_generation: 3,
+                installation_id: "install-123".to_owned(),
+                turn_state: Some("turn-state".to_owned()),
+                turn_metadata: Some("{\"k\":\"v\"}".to_owned()),
+                beta_features: vec!["beta-a".to_owned(), "beta-b".to_owned()],
+                subagent: Some("planner".to_owned()),
+                parent_thread_id: Some("thread-123".to_owned()),
+            },
+            instructions: Some("follow instructions".to_owned()),
+            input: vec![ResponseItem::Message(MessageItem {
+                id: Some("msg-1".to_owned()),
+                status: Some("completed".to_owned()),
+                role: "user".to_owned(),
+                content: vec![ContentItem::InputText {
+                    text: "hello".to_owned(),
+                }],
+            })],
+            tools: vec![ToolDescriptor(JsonObject::new())],
+            parallel_tool_calls: true,
+            reasoning: ChatgptReasoningOptions {
+                effort: Some("high".to_owned()),
+                summary: Some("detailed".to_owned()),
+            },
+            text: ChatgptTextOptions {
+                verbosity: Some(TextVerbosity::High),
+                json_schema: Some(JsonObject::from_iter([(
+                    "type".to_owned(),
+                    serde_json::json!("object"),
+                )])),
+            },
+            service_tier: Some(ChatgptServiceTier::Fast),
+        }
+    }
+
+    fn base_auth() -> ResolvedChatgptAuth {
+        ResolvedChatgptAuth {
+            access_token: "access-token".to_owned(),
+            access_token_expires_at: None,
+            account_id: "account-123".to_owned(),
+            user_id: Some("user-123".to_owned()),
+            email: Some("user@example.com".to_owned()),
+            plan_type: Some("plus".to_owned()),
+        }
+    }
+
+    fn base_api_config() -> ChatgptApiConfig {
+        ChatgptApiConfig {
+            base_url: "https://chatgpt.com/backend-api/codex".to_owned(),
+            stream_completion_timeout_ms: 1_800_000,
+        }
+    }
+
+    #[test]
+    fn build_http_request_derives_headers_and_body_for_supported_models() {
+        let request = base_request();
+        let auth = base_auth();
+        let api_config = base_api_config();
+
+        let http_request = build_http_request(&request, &auth, &api_config).expect("http request");
+
+        assert_eq!(http_request.method, HttpMethod::Post);
+        assert_eq!(
+            http_request.url,
+            "https://chatgpt.com/backend-api/codex/responses"
+        );
+        assert_eq!(http_request.compression, RequestCompression::None);
+        assert_eq!(
+            http_request
+                .headers
+                .get("authorization")
+                .and_then(|value: &HeaderValue| value.to_str().ok()),
+            Some("Bearer access-token")
+        );
+        assert_eq!(
+            http_request
+                .headers
+                .get("chatgpt-account-id")
+                .and_then(|value: &HeaderValue| value.to_str().ok()),
+            Some("account-123")
+        );
+        assert_eq!(
+            http_request
+                .headers
+                .get("x-codex-window-id")
+                .and_then(|value: &HeaderValue| value.to_str().ok()),
+            Some("conversation-123:3")
+        );
+
+        let HttpRequestBody::Json(body) = http_request.body else {
+            panic!("expected json body");
+        };
+
+        assert_eq!(body.get("model"), Some(&serde_json::json!("gpt-5")));
+        assert_eq!(body.get("tool_choice"), Some(&serde_json::json!("auto")));
+        assert_eq!(
+            body.get("parallel_tool_calls"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(body.get("store"), Some(&serde_json::json!(false)));
+        assert_eq!(body.get("stream"), Some(&serde_json::json!(true)));
+        assert_eq!(
+            body.get("prompt_cache_key"),
+            Some(&serde_json::json!("conversation-123"))
+        );
+        assert_eq!(
+            body.get("include"),
+            Some(&serde_json::json!(["reasoning.encrypted_content"]))
+        );
+        assert_eq!(
+            body.get("service_tier"),
+            Some(&serde_json::json!("priority"))
+        );
+        assert_eq!(
+            body.pointer("/client_metadata/x-codex-installation-id"),
+            Some(&serde_json::json!("install-123"))
+        );
+        assert_eq!(
+            body.pointer("/reasoning/effort"),
+            Some(&serde_json::json!("high"))
+        );
+        assert_eq!(
+            body.pointer("/reasoning/summary"),
+            Some(&serde_json::json!("detailed"))
+        );
+        assert_eq!(
+            body.pointer("/text/verbosity"),
+            Some(&serde_json::json!("high"))
+        );
+        assert_eq!(
+            body.pointer("/text/format/type"),
+            Some(&serde_json::json!("json_schema"))
+        );
+        assert_eq!(
+            body.pointer("/text/format/strict"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(
+            body.pointer("/text/format/name"),
+            Some(&serde_json::json!("codex_output_schema"))
+        );
+    }
+
+    #[test]
+    fn build_http_request_uses_null_reasoning_for_unsupported_models() {
+        let mut request = base_request();
+        request.instructions = None;
+        request.tools.clear();
+        request.service_tier = None;
+        request.text = ChatgptTextOptions::default();
+        request.reasoning = ChatgptReasoningOptions::default();
+        request.model_capabilities.supports_reasoning_summaries = false;
+        request.model_capabilities.supports_text_verbosity = false;
+        request.model_capabilities.default_reasoning_effort = None;
+        request.context.turn_state = None;
+        request.context.turn_metadata = None;
+        request.context.beta_features.clear();
+        request.context.subagent = None;
+        request.context.parent_thread_id = None;
+
+        let http_request =
+            build_http_request(&request, &base_auth(), &base_api_config()).expect("http request");
+
+        assert!(http_request.headers.get("x-codex-turn-state").is_none());
+        assert!(http_request.headers.get("x-codex-turn-metadata").is_none());
+        assert!(http_request.headers.get("x-codex-beta-features").is_none());
+
+        let HttpRequestBody::Json(body) = http_request.body else {
+            panic!("expected json body");
+        };
+
+        assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
+        assert_eq!(body.get("include"), Some(&serde_json::json!([])));
+        assert!(body.get("instructions").is_none());
+        assert!(body.get("service_tier").is_none());
+        assert!(body.get("text").is_none());
+        assert_eq!(body.get("tools"), Some(&serde_json::json!([])));
+    }
+}

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -11,7 +11,10 @@ use futures::StreamExt;
 use futures_core::Stream;
 use http::{HeaderMap, HeaderValue, StatusCode};
 use serde_json::Value;
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    task::JoinHandle,
+};
 
 pub type JsonObject = serde_json::Map<String, Value>;
 
@@ -34,7 +37,7 @@ pub async fn stream(
         .map(str::to_owned)
         .or_else(|| request.context.turn_state.clone());
 
-    let (sender, receiver) = mpsc::channel(32);
+    let (sender, receiver) = mpsc::unbounded_channel();
     let timeout = Duration::from_millis(api_config.stream_completion_timeout_ms);
     let driver_task = tokio::spawn(async move {
         drive_response_stream(response.body, sender, timeout).await;
@@ -156,7 +159,7 @@ fn retry_delay_for_attempt(retry_count: u8, error: &selvedge_client::HttpError) 
 
 async fn drive_response_stream(
     mut body: selvedge_client::ByteStream,
-    sender: mpsc::Sender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    sender: UnboundedSender<Result<ChatgptResponseEvent, ChatgptApiError>>,
     timeout: Duration,
 ) {
     let deadline = tokio::time::Instant::now() + timeout;
@@ -170,8 +173,7 @@ async fn drive_response_stream(
                 Err(ChatgptApiError::LowerLayer(
                     ChatgptApiLowerLayerError::StreamCompletionTimeout { timeout },
                 )),
-            )
-            .await;
+            );
             return;
         }
 
@@ -184,8 +186,7 @@ async fn drive_response_stream(
                     Err(ChatgptApiError::LowerLayer(
                         ChatgptApiLowerLayerError::StreamCompletionTimeout { timeout },
                     )),
-                )
-                .await;
+                );
                 return;
             }
         };
@@ -199,7 +200,7 @@ async fn drive_response_stream(
                     raw: Some(String::from_utf8_lossy(&buffer).into_owned()),
                 })
             };
-            send_stream_item(&sender, Err(error)).await;
+            send_stream_item(&sender, Err(error));
             return;
         };
 
@@ -211,8 +212,7 @@ async fn drive_response_stream(
                     Err(ChatgptApiError::LowerLayer(
                         ChatgptApiLowerLayerError::Client(error),
                     )),
-                )
-                .await;
+                );
                 return;
             }
         };
@@ -231,8 +231,7 @@ async fn drive_response_stream(
                                 raw: None,
                             },
                         )),
-                    )
-                    .await;
+                    );
                     return;
                 }
             };
@@ -245,25 +244,25 @@ async fn drive_response_stream(
                 Ok(Some(payload)) => payload,
                 Ok(None) => continue,
                 Err(error) => {
-                    send_stream_item(&sender, Err(error)).await;
+                    send_stream_item(&sender, Err(error));
                     return;
                 }
             };
 
             match map_stream_event(&payload) {
                 Ok(MappedEvent::Event(event)) => {
-                    send_stream_item(&sender, Ok(event)).await;
+                    send_stream_item(&sender, Ok(event));
                 }
                 Ok(MappedEvent::Completed(event)) => {
-                    send_stream_item(&sender, Ok(event)).await;
+                    send_stream_item(&sender, Ok(event));
                     return;
                 }
                 Ok(MappedEvent::EndpointError(error)) => {
-                    send_stream_item(&sender, Err(error)).await;
+                    send_stream_item(&sender, Err(error));
                     return;
                 }
                 Err(error) => {
-                    send_stream_item(&sender, Err(error)).await;
+                    send_stream_item(&sender, Err(error));
                     return;
                 }
             }
@@ -271,11 +270,11 @@ async fn drive_response_stream(
     }
 }
 
-async fn send_stream_item(
-    sender: &mpsc::Sender<Result<ChatgptResponseEvent, ChatgptApiError>>,
+fn send_stream_item(
+    sender: &UnboundedSender<Result<ChatgptResponseEvent, ChatgptApiError>>,
     item: Result<ChatgptResponseEvent, ChatgptApiError>,
 ) {
-    let _ = sender.send(item).await;
+    let _ = sender.send(item);
 }
 
 fn take_next_sse_frame(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
@@ -530,10 +529,7 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
         "reasoning" => Ok(ResponseItem::Reasoning(ReasoningItem {
             id: optional_string(item, "id")?,
             status: optional_string(item, "status")?,
-            summary: item
-                .get("summary")
-                .cloned()
-                .ok_or_else(|| malformed_event("summary", "must be present"))?,
+            summary: item.get("summary").cloned().unwrap_or(Value::Null),
             content: item
                 .get("content")
                 .map(|value| match value {
@@ -1187,7 +1183,7 @@ fn text_verbosity_to_wire(verbosity: TextVerbosity) -> &'static str {
 
 pub struct ChatgptResponseStream {
     effective_turn_state: Option<String>,
-    receiver: mpsc::Receiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+    receiver: UnboundedReceiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
     driver_task: Option<JoinHandle<()>>,
 }
 
@@ -1198,7 +1194,7 @@ impl ChatgptResponseStream {
 
     fn empty(
         effective_turn_state: Option<String>,
-        receiver: mpsc::Receiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
+        receiver: UnboundedReceiver<Result<ChatgptResponseEvent, ChatgptApiError>>,
         driver_task: Option<JoinHandle<()>>,
     ) -> Self {
         Self {
@@ -1932,6 +1928,25 @@ mod tests {
                 input,
                 ..
             }) if call_id == "call-1" && name == "apply_patch" && input == "*** Begin Patch"
+        ));
+    }
+
+    #[test]
+    fn response_item_parser_accepts_reasoning_items_without_summary() {
+        let item = response_item_from_object(&JsonObject::from_iter([
+            ("type".to_owned(), serde_json::json!("reasoning")),
+            ("id".to_owned(), serde_json::json!("reasoning-1")),
+            ("encrypted_content".to_owned(), serde_json::json!("cipher")),
+        ]))
+        .expect("reasoning item without summary");
+
+        assert!(matches!(
+            item,
+            ResponseItem::Reasoning(ReasoningItem {
+                encrypted_content: Some(encrypted_content),
+                summary,
+                ..
+            }) if encrypted_content == "cipher" && summary.is_null()
         ));
     }
 }

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -167,6 +167,7 @@ async fn drive_response_stream(
 ) {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut buffer = Vec::new();
+    let mut last_event_was_unknown = false;
 
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -204,14 +205,24 @@ async fn drive_response_stream(
 
         let Some(chunk) = maybe_chunk else {
             let final_result = if buffer.is_empty() {
-                Err(ChatgptApiError::Endpoint(
-                    ChatgptApiEndpointError::PrematureClose,
-                ))
+                if last_event_was_unknown {
+                    Ok(None)
+                } else {
+                    Err(ChatgptApiError::Endpoint(
+                        ChatgptApiEndpointError::PrematureClose,
+                    ))
+                }
             } else {
                 parse_final_sse_frame(&buffer).and_then(|maybe_payload| match maybe_payload {
-                    None => Err(ChatgptApiError::Endpoint(
-                        ChatgptApiEndpointError::PrematureClose,
-                    )),
+                    None => {
+                        if last_event_was_unknown {
+                            Ok(None)
+                        } else {
+                            Err(ChatgptApiError::Endpoint(
+                                ChatgptApiEndpointError::PrematureClose,
+                            ))
+                        }
+                    }
                     Some(payload) => match map_stream_event(&payload) {
                         Ok(MappedEvent::Event(event)) => Ok(Some(event)),
                         Ok(MappedEvent::Completed(event)) => Ok(Some(event)),
@@ -333,6 +344,7 @@ async fn drive_response_stream(
 
             match map_stream_event(&payload) {
                 Ok(MappedEvent::Event(event)) => {
+                    last_event_was_unknown = matches!(event, ChatgptResponseEvent::Other(_));
                     if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
                         .await
                     {

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -166,7 +166,6 @@ async fn drive_response_stream(
 ) {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut buffer = Vec::new();
-    let mut last_event_was_unknown = false;
 
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -204,24 +203,14 @@ async fn drive_response_stream(
 
         let Some(chunk) = maybe_chunk else {
             let final_result = if buffer.is_empty() {
-                if last_event_was_unknown {
-                    Ok(None)
-                } else {
-                    Err(ChatgptApiError::Endpoint(
-                        ChatgptApiEndpointError::PrematureClose,
-                    ))
-                }
+                Err(ChatgptApiError::Endpoint(
+                    ChatgptApiEndpointError::PrematureClose,
+                ))
             } else {
                 parse_final_sse_frame(&buffer).and_then(|maybe_payload| match maybe_payload {
-                    None => {
-                        if last_event_was_unknown {
-                            Ok(None)
-                        } else {
-                            Err(ChatgptApiError::Endpoint(
-                                ChatgptApiEndpointError::PrematureClose,
-                            ))
-                        }
-                    }
+                    None => Err(ChatgptApiError::Endpoint(
+                        ChatgptApiEndpointError::PrematureClose,
+                    )),
                     Some(payload) => match map_stream_event(&payload) {
                         Ok(MappedEvent::Event(event)) => Ok(Some(event)),
                         Ok(MappedEvent::Completed(event)) => Ok(Some(event)),
@@ -244,18 +233,7 @@ async fn drive_response_stream(
                         .await;
                         return;
                     }
-                    FinalEventDisposition::Unknown => {
-                        let _ = send_stream_item(
-                            &sender,
-                            &terminal_error,
-                            Ok(event),
-                            deadline,
-                            timeout,
-                        )
-                        .await;
-                        return;
-                    }
-                    FinalEventDisposition::NonTerminal => {
+                    FinalEventDisposition::Unknown | FinalEventDisposition::NonTerminal => {
                         if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
                             .await
                         {
@@ -343,7 +321,6 @@ async fn drive_response_stream(
 
             match map_stream_event(&payload) {
                 Ok(MappedEvent::Event(event)) => {
-                    last_event_was_unknown = matches!(event, ChatgptResponseEvent::Other(_));
                     if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
                         .await
                     {

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -157,8 +157,7 @@ async fn drive_response_stream(
     timeout: Duration,
 ) {
     let deadline = tokio::time::Instant::now() + timeout;
-    let completed = false;
-    let mut buffer = String::new();
+    let mut buffer = Vec::new();
 
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -189,16 +188,12 @@ async fn drive_response_stream(
         };
 
         let Some(chunk) = maybe_chunk else {
-            if completed {
-                return;
-            }
-
-            let error = if buffer.trim().is_empty() {
+            let error = if buffer.is_empty() {
                 ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
             } else {
                 ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent {
                     reason: "stream ended before the current SSE frame completed".to_owned(),
-                    raw: Some(buffer),
+                    raw: Some(String::from_utf8_lossy(&buffer).into_owned()),
                 })
             };
             send_stream_item(&sender, Err(error)).await;
@@ -219,25 +214,26 @@ async fn drive_response_stream(
             }
         };
 
-        let chunk = match std::str::from_utf8(&chunk) {
-            Ok(text) => text.replace("\r\n", "\n").replace('\r', "\n"),
-            Err(_) => {
-                send_stream_item(
-                    &sender,
-                    Err(ChatgptApiError::Endpoint(
-                        ChatgptApiEndpointError::MalformedEvent {
-                            reason: "event stream contained non-utf8 bytes".to_owned(),
-                            raw: None,
-                        },
-                    )),
-                )
-                .await;
-                return;
-            }
-        };
-        buffer.push_str(&chunk);
+        buffer.extend_from_slice(&chunk);
 
         while let Some(frame) = take_next_sse_frame(&mut buffer) {
+            let frame = match std::str::from_utf8(&frame) {
+                Ok(text) => text.replace("\r\n", "\n").replace('\r', "\n"),
+                Err(_) => {
+                    send_stream_item(
+                        &sender,
+                        Err(ChatgptApiError::Endpoint(
+                            ChatgptApiEndpointError::MalformedEvent {
+                                reason: "event stream contained non-utf8 bytes".to_owned(),
+                                raw: None,
+                            },
+                        )),
+                    )
+                    .await;
+                    return;
+                }
+            };
+
             if frame.trim().is_empty() {
                 continue;
             }
@@ -279,13 +275,36 @@ async fn send_stream_item(
     let _ = sender.send(item).await;
 }
 
-fn take_next_sse_frame(buffer: &mut String) -> Option<String> {
-    let frame_end = buffer.find("\n\n")?;
-    let frame = buffer[..frame_end].to_owned();
-    let remainder = buffer[frame_end + 2..].to_owned();
+fn take_next_sse_frame(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
+    let (frame_end, delimiter_len) = find_frame_delimiter(buffer)?;
+    let frame = buffer[..frame_end].to_vec();
+    let remainder = buffer[frame_end + delimiter_len..].to_vec();
     *buffer = remainder;
 
     Some(frame)
+}
+
+fn find_frame_delimiter(buffer: &[u8]) -> Option<(usize, usize)> {
+    let mut index = 0;
+
+    while index + 1 < buffer.len() {
+        if buffer[index] == b'\n' && buffer[index + 1] == b'\n' {
+            return Some((index, 2));
+        }
+
+        if index + 3 < buffer.len()
+            && buffer[index] == b'\r'
+            && buffer[index + 1] == b'\n'
+            && buffer[index + 2] == b'\r'
+            && buffer[index + 3] == b'\n'
+        {
+            return Some((index, 4));
+        }
+
+        index += 1;
+    }
+
+    None
 }
 
 fn parse_sse_frame(frame: &str) -> Result<Option<String>, ChatgptApiError> {
@@ -569,9 +588,13 @@ fn chatgpt_usage_from_value(value: &Value) -> Result<ChatgptUsage, ChatgptApiErr
 
     Ok(ChatgptUsage {
         input_tokens: optional_u64(usage, "input_tokens")?,
-        cached_input_tokens: optional_u64(usage, "cached_input_tokens")?,
+        cached_input_tokens: nested_optional_u64(usage, "input_tokens_details", "cached_tokens")?,
         output_tokens: optional_u64(usage, "output_tokens")?,
-        reasoning_output_tokens: optional_u64(usage, "reasoning_output_tokens")?,
+        reasoning_output_tokens: nested_optional_u64(
+            usage,
+            "output_tokens_details",
+            "reasoning_tokens",
+        )?,
         total_tokens: optional_u64(usage, "total_tokens")?,
     })
 }
@@ -738,6 +761,18 @@ fn optional_u64(object: &JsonObject, field: &'static str) -> Result<Option<u64>,
     }
 }
 
+fn nested_optional_u64(
+    object: &JsonObject,
+    parent_field: &'static str,
+    child_field: &'static str,
+) -> Result<Option<u64>, ChatgptApiError> {
+    let Some(Value::Object(child)) = object.get(parent_field) else {
+        return Ok(None);
+    };
+
+    optional_u64(child, child_field)
+}
+
 fn required_array<'a>(
     object: &'a JsonObject,
     field: &'static str,
@@ -885,18 +920,18 @@ fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
         );
     }
 
-    let reasoning_support = request.model_capabilities.supports_reasoning_summaries;
+    let reasoning = build_reasoning_body(request);
     body.insert(
         "reasoning".to_owned(),
-        if reasoning_support {
-            Value::Object(build_reasoning_body(request))
-        } else {
+        if reasoning.is_empty() {
             Value::Null
+        } else {
+            Value::Object(reasoning)
         },
     );
     body.insert(
         "include".to_owned(),
-        if reasoning_support {
+        if request.model_capabilities.supports_reasoning_summaries {
             serde_json::json!(["reasoning.encrypted_content"])
         } else {
             serde_json::json!([])
@@ -1567,6 +1602,7 @@ mod tests {
         ChatgptModelCapabilities, ChatgptReasoningOptions, ChatgptRequestContext,
         ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem, JsonObject,
         MessageItem, ResponseItem, TextVerbosity, ToolDescriptor, build_http_request,
+        chatgpt_usage_from_value,
     };
 
     fn base_request() -> ChatgptResponsesRequest {
@@ -1755,5 +1791,46 @@ mod tests {
         assert!(body.get("service_tier").is_none());
         assert!(body.get("text").is_none());
         assert_eq!(body.get("tools"), Some(&serde_json::json!([])));
+    }
+
+    #[test]
+    fn build_http_request_preserves_reasoning_effort_without_summary_support() {
+        let mut request = base_request();
+        request.reasoning.summary = None;
+        request.model_capabilities.supports_reasoning_summaries = false;
+
+        let http_request =
+            build_http_request(&request, &base_auth(), &base_api_config()).expect("http request");
+        let selvedge_client::HttpRequestBody::Json(body) = http_request.body else {
+            panic!("expected json body");
+        };
+
+        assert_eq!(
+            body.pointer("/reasoning/effort"),
+            Some(&serde_json::json!("high"))
+        );
+        assert_eq!(body.get("include"), Some(&serde_json::json!([])));
+    }
+
+    #[test]
+    fn chatgpt_usage_reads_nested_cache_and_reasoning_counts() {
+        let usage = chatgpt_usage_from_value(&serde_json::json!({
+            "input_tokens": 10,
+            "input_tokens_details": {
+                "cached_tokens": 4
+            },
+            "output_tokens": 7,
+            "output_tokens_details": {
+                "reasoning_tokens": 3
+            },
+            "total_tokens": 17
+        }))
+        .expect("usage");
+
+        assert_eq!(usage.input_tokens, Some(10));
+        assert_eq!(usage.cached_input_tokens, Some(4));
+        assert_eq!(usage.output_tokens, Some(7));
+        assert_eq!(usage.reasoning_output_tokens, Some(3));
+        assert_eq!(usage.total_tokens, Some(17));
     }
 }

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -392,6 +392,10 @@ fn find_frame_delimiter(buffer: &[u8]) -> Option<(usize, usize)> {
             return Some((index, 2));
         }
 
+        if buffer[index] == b'\r' && buffer[index + 1] == b'\r' {
+            return Some((index, 2));
+        }
+
         if index + 3 < buffer.len()
             && buffer[index] == b'\r'
             && buffer[index + 1] == b'\n'
@@ -978,15 +982,9 @@ fn build_http_request(
         url,
         headers,
         body: selvedge_client::HttpRequestBody::Json(body),
-        timeout: Some(response_transport_timeout(
-            api_config.stream_completion_timeout_ms,
-        )),
+        timeout: None,
         compression: selvedge_client::RequestCompression::None,
     })
-}
-
-fn response_transport_timeout(stream_completion_timeout_ms: u64) -> Duration {
-    Duration::from_millis(stream_completion_timeout_ms).saturating_add(Duration::from_secs(1))
 }
 
 enum FinalEventDisposition {
@@ -1863,6 +1861,7 @@ mod tests {
             "https://chatgpt.com/backend-api/codex/responses"
         );
         assert_eq!(http_request.compression, RequestCompression::None);
+        assert_eq!(http_request.timeout, None);
         assert_eq!(
             http_request
                 .headers
@@ -2227,5 +2226,15 @@ mod tests {
         assert_eq!(frame, b"data: first".to_vec());
         assert_eq!(buffer, b"data: second\n\n".to_vec());
         assert_eq!(buffer.capacity(), original_capacity);
+    }
+
+    #[test]
+    fn take_next_sse_frame_accepts_cr_only_delimiters() {
+        let mut buffer = b"data: first\r\rdata: second\r\r".to_vec();
+
+        let frame = take_next_sse_frame(&mut buffer).expect("first frame");
+
+        assert_eq!(frame, b"data: first".to_vec());
+        assert_eq!(buffer, b"data: second\r\r".to_vec());
     }
 }

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -119,9 +119,8 @@ fn ensure_event_stream_content_type(headers: &HeaderMap) -> Result<(), ChatgptAp
 
 fn is_retryable_client_error(error: &selvedge_client::HttpError) -> bool {
     match error {
-        selvedge_client::HttpError::Timeout
-        | selvedge_client::HttpError::Connect { .. }
-        | selvedge_client::HttpError::Io { .. } => true,
+        selvedge_client::HttpError::Timeout => false,
+        selvedge_client::HttpError::Connect { .. } | selvedge_client::HttpError::Io { .. } => true,
         selvedge_client::HttpError::Status(status) => matches!(
             status.status,
             StatusCode::REQUEST_TIMEOUT
@@ -403,8 +402,7 @@ fn parse_final_sse_frame(buffer: &[u8]) -> Result<Option<String>, ChatgptApiErro
 fn take_next_sse_frame(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
     let (frame_end, delimiter_len) = find_frame_delimiter(buffer)?;
     let frame = buffer[..frame_end].to_vec();
-    let remainder = buffer[frame_end + delimiter_len..].to_vec();
-    *buffer = remainder;
+    buffer.drain(..frame_end + delimiter_len);
 
     Some(frame)
 }
@@ -1774,7 +1772,8 @@ mod tests {
         ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem, JsonObject,
         MessageItem, ReasoningItem, ResponseItem, TextVerbosity, ToolDescriptor,
         build_http_request, chatgpt_usage_from_value, content_item_from_value,
-        failed_endpoint_event, response_item_from_object, retry_delay_for_attempt,
+        failed_endpoint_event, is_retryable_client_error, response_item_from_object,
+        retry_delay_for_attempt, take_next_sse_frame,
     };
 
     fn base_request() -> ChatgptResponsesRequest {
@@ -2013,6 +2012,13 @@ mod tests {
     }
 
     #[test]
+    fn request_timeouts_are_not_retryable() {
+        assert!(!is_retryable_client_error(
+            &selvedge_client::HttpError::Timeout
+        ));
+    }
+
+    #[test]
     fn build_http_request_uses_fixed_reasoning_contract_without_summary_support() {
         let mut request = base_request();
         request.reasoning.summary = None;
@@ -2175,5 +2181,18 @@ mod tests {
             ChatgptApiError::Endpoint(ChatgptApiEndpointError::Other(ChatgptOtherEndpointError { raw, .. }))
                 if raw.get("code") == Some(&serde_json::json!("server_busy"))
         ));
+    }
+
+    #[test]
+    fn take_next_sse_frame_keeps_buffer_allocation_for_remainder() {
+        let mut buffer = b"data: first\n\ndata: second\n\n".to_vec();
+        buffer.reserve(1024);
+        let original_capacity = buffer.capacity();
+
+        let frame = take_next_sse_frame(&mut buffer).expect("first frame");
+
+        assert_eq!(frame, b"data: first".to_vec());
+        assert_eq!(buffer, b"data: second\n\n".to_vec());
+        assert_eq!(buffer.capacity(), original_capacity);
     }
 }

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -584,6 +584,7 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
         "message" => Ok(ResponseItem::Message(MessageItem {
             id: optional_string(item, "id")?,
             status: optional_string(item, "status")?,
+            phase: optional_string(item, "phase")?,
             role: required_string(item, "role")?,
             content: required_array(item, "content")?
                 .iter()
@@ -628,7 +629,7 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
         "reasoning" => Ok(ResponseItem::Reasoning(ReasoningItem {
             id: optional_string(item, "id")?,
             status: optional_string(item, "status")?,
-            summary: item.get("summary").cloned().unwrap_or(Value::Null),
+            summary: item.get("summary").cloned(),
             content: item
                 .get("content")
                 .map(|value| match value {
@@ -658,7 +659,7 @@ fn content_item_from_value(value: &Value) -> Result<ContentItem, ChatgptApiError
             text: required_string(object, "text")?,
         }),
         "input_image" => Ok(ContentItem::InputImage {
-            image_url: required_string(object, "image_url")?,
+            raw: object.clone(),
         }),
         "output_text" => Ok(ContentItem::OutputText {
             text: required_string(object, "text")?,
@@ -1158,6 +1159,10 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
                 "status".to_owned(),
                 optional_string_value(message.status.as_deref()),
             ),
+            (
+                "phase".to_owned(),
+                optional_string_value(message.phase.as_deref()),
+            ),
             ("role".to_owned(), Value::String(message.role.clone())),
             (
                 "content".to_owned(),
@@ -1233,8 +1238,11 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
                     "status".to_owned(),
                     optional_string_value(reasoning.status.as_deref()),
                 ),
-                ("summary".to_owned(), reasoning.summary.clone()),
             ]);
+
+            if let Some(summary) = &reasoning.summary {
+                value.insert("summary".to_owned(), summary.clone());
+            }
 
             if let Some(content) = &reasoning.content {
                 value.insert(
@@ -1262,10 +1270,7 @@ fn content_item_to_json(item: &ContentItem) -> Value {
             ("type".to_owned(), Value::String("input_text".to_owned())),
             ("text".to_owned(), Value::String(text.clone())),
         ])),
-        ContentItem::InputImage { image_url } => Value::Object(JsonObject::from_iter([
-            ("type".to_owned(), Value::String("input_image".to_owned())),
-            ("image_url".to_owned(), Value::String(image_url.clone())),
-        ])),
+        ContentItem::InputImage { raw } => Value::Object(raw.clone()),
         ContentItem::OutputText { text, raw } => {
             let mut value = raw.clone();
             value.insert("type".to_owned(), Value::String("output_text".to_owned()));
@@ -1619,6 +1624,7 @@ pub enum ResponseItem {
 pub struct MessageItem {
     pub id: Option<String>,
     pub status: Option<String>,
+    pub phase: Option<String>,
     pub role: String,
     pub content: Vec<ContentItem>,
 }
@@ -1662,7 +1668,7 @@ pub struct CustomToolCallOutputItem {
 pub struct ReasoningItem {
     pub id: Option<String>,
     pub status: Option<String>,
-    pub summary: Value,
+    pub summary: Option<Value>,
     pub content: Option<Vec<ContentItem>>,
     pub encrypted_content: Option<String>,
 }
@@ -1676,7 +1682,7 @@ pub struct OpaqueResponseItem {
 #[non_exhaustive]
 pub enum ContentItem {
     InputText { text: String },
-    InputImage { image_url: String },
+    InputImage { raw: JsonObject },
     OutputText { text: String, raw: JsonObject },
     Other { raw: JsonObject },
 }
@@ -1788,7 +1794,8 @@ mod tests {
         ChatgptModelCapabilities, ChatgptReasoningOptions, ChatgptRequestContext,
         ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem,
         CustomToolCallItem, JsonObject, MessageItem, ReasoningItem, ResponseItem, TextVerbosity,
-        ToolDescriptor, build_http_request, chatgpt_usage_from_value, response_item_from_object,
+        ToolDescriptor, build_http_request, chatgpt_usage_from_value, content_item_from_value,
+        response_item_from_object,
     };
 
     fn base_request() -> ChatgptResponsesRequest {
@@ -1813,6 +1820,7 @@ mod tests {
             input: vec![ResponseItem::Message(MessageItem {
                 id: Some("msg-1".to_owned()),
                 status: Some("completed".to_owned()),
+                phase: Some("commentary".to_owned()),
                 role: "user".to_owned(),
                 content: vec![ContentItem::InputText {
                     text: "hello".to_owned(),
@@ -2009,7 +2017,7 @@ mod tests {
         request.input.push(ResponseItem::Reasoning(ReasoningItem {
             id: Some("reasoning-1".to_owned()),
             status: Some("completed".to_owned()),
-            summary: serde_json::json!([]),
+            summary: Some(serde_json::json!([])),
             content: None,
             encrypted_content: Some("encrypted".to_owned()),
         }));
@@ -2073,6 +2081,40 @@ mod tests {
     }
 
     #[test]
+    fn response_item_parser_preserves_message_phase() {
+        let item = response_item_from_object(&JsonObject::from_iter([
+            ("type".to_owned(), serde_json::json!("message")),
+            ("role".to_owned(), serde_json::json!("assistant")),
+            ("phase".to_owned(), serde_json::json!("final_answer")),
+            ("content".to_owned(), serde_json::json!([])),
+        ]))
+        .expect("message item");
+
+        assert!(matches!(
+            item,
+            ResponseItem::Message(MessageItem {
+                phase: Some(phase),
+                ..
+            }) if phase == "final_answer"
+        ));
+    }
+
+    #[test]
+    fn content_item_parser_accepts_file_backed_input_images() {
+        let item = content_item_from_value(&serde_json::json!({
+            "type": "input_image",
+            "file_id": "file-123",
+            "detail": "high"
+        }))
+        .expect("file-backed input image");
+
+        assert!(matches!(
+            item,
+            ContentItem::InputImage { raw } if raw.get("file_id") == Some(&serde_json::json!("file-123"))
+        ));
+    }
+
+    #[test]
     fn response_item_parser_accepts_reasoning_items_without_summary() {
         let item = response_item_from_object(&JsonObject::from_iter([
             ("type".to_owned(), serde_json::json!("reasoning")),
@@ -2087,7 +2129,7 @@ mod tests {
                 encrypted_content: Some(encrypted_content),
                 summary,
                 ..
-            }) if encrypted_content == "cipher" && summary.is_null()
+            }) if encrypted_content == "cipher" && summary.is_none()
         ));
     }
 }

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -221,8 +221,8 @@ async fn drive_response_stream(
             };
 
             match final_result {
-                Ok(Some(event)) => match map_event_finality(&event) {
-                    FinalEventDisposition::Completed => {
+                Ok(Some(event)) => {
+                    if event_is_completed(&event) {
                         let _ = send_stream_item(
                             &sender,
                             &terminal_error,
@@ -233,25 +233,24 @@ async fn drive_response_stream(
                         .await;
                         return;
                     }
-                    FinalEventDisposition::Unknown | FinalEventDisposition::NonTerminal => {
-                        if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
-                            .await
-                        {
-                            return;
-                        }
-                        send_stream_item(
-                            &sender,
-                            &terminal_error,
-                            Err(ChatgptApiError::Endpoint(
-                                ChatgptApiEndpointError::PrematureClose,
-                            )),
-                            deadline,
-                            timeout,
-                        )
-                        .await;
+
+                    if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
+                        .await
+                    {
                         return;
                     }
-                },
+                    send_stream_item(
+                        &sender,
+                        &terminal_error,
+                        Err(ChatgptApiError::Endpoint(
+                            ChatgptApiEndpointError::PrematureClose,
+                        )),
+                        deadline,
+                        timeout,
+                    )
+                    .await;
+                    return;
+                }
                 Ok(None) => {}
                 Err(error) => {
                     send_stream_item(&sender, &terminal_error, Err(error), deadline, timeout).await;
@@ -527,21 +526,25 @@ fn map_stream_event(payload: &str) -> Result<MappedEvent, ChatgptApiError> {
                 text: required_string(&raw_object, "text")?,
             },
         )),
-        "response.completed" | "response.done" => Ok(MappedEvent::Completed(
-            ChatgptResponseEvent::Completed(response_snapshot_from_field(&raw_object)?),
-        )),
-        "response.failed" | "error" => Ok(MappedEvent::EndpointError(failed_endpoint_event(
+        "response.completed" => Ok(MappedEvent::Completed(ChatgptResponseEvent::Completed(
+            response_snapshot_from_field(&raw_object)?,
+        ))),
+        "response.failed" => Ok(MappedEvent::EndpointError(failed_endpoint_event(
             &raw_object,
             &event_type,
         ))),
         "response.incomplete" => Ok(MappedEvent::EndpointError(ChatgptApiError::Endpoint(
             ChatgptApiEndpointError::Incomplete(incomplete_endpoint_error(&raw_object)),
         ))),
-        _ => Ok(MappedEvent::Event(ChatgptResponseEvent::Other(
-            ChatgptRawEvent {
+        _ if event_type.starts_with("response.") => Ok(MappedEvent::Event(
+            ChatgptResponseEvent::Other(ChatgptRawEvent {
                 event_type,
                 payload: raw_object,
-            },
+            }),
+        )),
+        _ => Ok(MappedEvent::EndpointError(unknown_endpoint_event(
+            &raw_object,
+            &event_type,
         ))),
     }
 }
@@ -624,7 +627,10 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
         "reasoning" => Ok(ResponseItem::Reasoning(ReasoningItem {
             id: optional_string(item, "id")?,
             status: optional_string(item, "status")?,
-            summary: item.get("summary").cloned(),
+            summary: item
+                .get("summary")
+                .cloned()
+                .ok_or_else(|| malformed_event("summary", "must be present"))?,
             content: item
                 .get("content")
                 .map(|value| match value {
@@ -763,6 +769,41 @@ fn failed_endpoint_event(object: &JsonObject, event_type: &str) -> ChatgptApiErr
             }))
         }
     }
+}
+
+fn unknown_endpoint_event(object: &JsonObject, event_type: &str) -> ChatgptApiError {
+    let code = object
+        .get("code")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            object
+                .get("error")
+                .and_then(Value::as_object)
+                .and_then(|error| error.get("code"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+    let message = object
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            object
+                .get("error")
+                .and_then(Value::as_object)
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+
+    ChatgptApiError::Endpoint(ChatgptApiEndpointError::Other(ChatgptOtherEndpointError {
+        event_type: Some(event_type.to_owned()),
+        code,
+        message: message.clone(),
+        retry_after: message.as_deref().and_then(parse_retry_after),
+        raw: object.clone(),
+    }))
 }
 
 fn incomplete_endpoint_error(object: &JsonObject) -> ChatgptIncompleteEndpointError {
@@ -987,26 +1028,8 @@ fn build_http_request(
     })
 }
 
-enum FinalEventDisposition {
-    Completed,
-    NonTerminal,
-    Unknown,
-}
-
-fn map_event_finality(event: &ChatgptResponseEvent) -> FinalEventDisposition {
-    match event {
-        ChatgptResponseEvent::Completed(_) => FinalEventDisposition::Completed,
-        ChatgptResponseEvent::Created(_)
-        | ChatgptResponseEvent::OutputItemAdded { .. }
-        | ChatgptResponseEvent::OutputItemDone { .. }
-        | ChatgptResponseEvent::OutputTextDelta { .. }
-        | ChatgptResponseEvent::OutputTextDone { .. }
-        | ChatgptResponseEvent::ReasoningSummaryTextDelta { .. }
-        | ChatgptResponseEvent::ReasoningSummaryTextDone { .. }
-        | ChatgptResponseEvent::ReasoningTextDelta { .. }
-        | ChatgptResponseEvent::ReasoningTextDone { .. } => FinalEventDisposition::NonTerminal,
-        ChatgptResponseEvent::Other(_) => FinalEventDisposition::Unknown,
-    }
+fn event_is_completed(event: &ChatgptResponseEvent) -> bool {
+    matches!(event, ChatgptResponseEvent::Completed(_))
 }
 
 fn insert_header(
@@ -1075,21 +1098,17 @@ fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
         );
     }
 
-    let reasoning = build_reasoning_body(request);
-    let reasoning_enabled = !reasoning.is_empty();
-    let needs_encrypted_reasoning_content =
-        reasoning_enabled || request_replays_reasoning_state(&request.input);
     body.insert(
         "reasoning".to_owned(),
-        if reasoning_enabled {
-            Value::Object(reasoning)
+        if request.model_capabilities.supports_reasoning_summaries {
+            Value::Object(build_reasoning_body(request))
         } else {
             Value::Null
         },
     );
     body.insert(
         "include".to_owned(),
-        if needs_encrypted_reasoning_content {
+        if request.model_capabilities.supports_reasoning_summaries {
             serde_json::json!(["reasoning.encrypted_content"])
         } else {
             serde_json::json!([])
@@ -1127,18 +1146,6 @@ fn build_reasoning_body(request: &ChatgptResponsesRequest) -> JsonObject {
     }
 
     reasoning
-}
-
-fn request_replays_reasoning_state(input: &[ResponseItem]) -> bool {
-    input.iter().any(|item| {
-        matches!(
-            item,
-            ResponseItem::Reasoning(ReasoningItem {
-                encrypted_content: Some(_),
-                ..
-            })
-        )
-    })
 }
 
 fn build_text_body(text: &ChatgptTextOptions) -> Option<JsonObject> {
@@ -1231,9 +1238,7 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
             insert_optional_string(&mut value, "id", reasoning.id.as_deref());
             insert_optional_string(&mut value, "status", reasoning.status.as_deref());
 
-            if let Some(summary) = &reasoning.summary {
-                value.insert("summary".to_owned(), summary.clone());
-            }
+            value.insert("summary".to_owned(), reasoning.summary.clone());
 
             if let Some(content) = &reasoning.content {
                 value.insert(
@@ -1651,7 +1656,7 @@ pub struct CustomToolCallOutputItem {
 pub struct ReasoningItem {
     pub id: Option<String>,
     pub status: Option<String>,
-    pub summary: Option<Value>,
+    pub summary: Value,
     pub content: Option<Vec<ContentItem>>,
     pub encrypted_content: Option<String>,
 }
@@ -2029,10 +2034,11 @@ mod tests {
     }
 
     #[test]
-    fn build_http_request_uses_fixed_reasoning_contract_without_summary_support() {
+    fn build_http_request_uses_null_reasoning_and_empty_include_without_summary_support() {
         let mut request = base_request();
         request.reasoning.summary = None;
         request.model_capabilities.supports_reasoning_summaries = false;
+        request.model_capabilities.default_reasoning_effort = Some("high".to_owned());
 
         let http_request =
             build_http_request(&request, &base_auth(), &base_api_config()).expect("http request");
@@ -2040,18 +2046,12 @@ mod tests {
             panic!("expected json body");
         };
 
-        assert_eq!(
-            body.pointer("/reasoning/effort"),
-            Some(&serde_json::json!("high"))
-        );
-        assert_eq!(
-            body.get("include"),
-            Some(&serde_json::json!(["reasoning.encrypted_content"]))
-        );
+        assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
+        assert_eq!(body.get("include"), Some(&serde_json::json!([])));
     }
 
     #[test]
-    fn build_http_request_keeps_encrypted_reasoning_content_for_stateless_replay() {
+    fn build_http_request_does_not_change_reasoning_contract_for_replay() {
         let mut request = base_request();
         request.reasoning = ChatgptReasoningOptions::default();
         request.model_capabilities.default_reasoning_effort = None;
@@ -2059,7 +2059,7 @@ mod tests {
         request.input.push(ResponseItem::Reasoning(ReasoningItem {
             id: Some("reasoning-1".to_owned()),
             status: Some("completed".to_owned()),
-            summary: None,
+            summary: serde_json::json!([{ "type": "summary_text", "text": "thinking" }]),
             content: None,
             encrypted_content: Some("encrypted".to_owned()),
         }));
@@ -2070,11 +2070,8 @@ mod tests {
             panic!("expected json body");
         };
 
-        assert_eq!(
-            body.get("include"),
-            Some(&serde_json::json!(["reasoning.encrypted_content"]))
-        );
         assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
+        assert_eq!(body.get("include"), Some(&serde_json::json!([])));
     }
 
     #[test]
@@ -2163,21 +2160,17 @@ mod tests {
     }
 
     #[test]
-    fn response_item_parser_accepts_reasoning_items_without_summary() {
+    fn response_item_parser_rejects_reasoning_items_without_summary() {
         let item = response_item_from_object(&JsonObject::from_iter([
             ("type".to_owned(), serde_json::json!("reasoning")),
             ("id".to_owned(), serde_json::json!("reasoning-1")),
             ("encrypted_content".to_owned(), serde_json::json!("cipher")),
         ]))
-        .expect("reasoning item without summary");
+        .expect_err("reasoning item without summary must fail");
 
         assert!(matches!(
             item,
-            ResponseItem::Reasoning(ReasoningItem {
-                encrypted_content: Some(encrypted_content),
-                summary,
-                ..
-            }) if encrypted_content == "cipher" && summary.is_none()
+            ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent { .. })
         ));
     }
 
@@ -2202,7 +2195,7 @@ mod tests {
     }
 
     #[test]
-    fn response_done_maps_to_completed_terminal_event() {
+    fn response_done_maps_to_other_nonterminal_event() {
         let event = map_stream_event(
             r#"{"type":"response.done","response":{"id":"resp-1","model":"gpt-5"}}"#,
         )
@@ -2210,8 +2203,23 @@ mod tests {
 
         assert!(matches!(
             event,
-            super::MappedEvent::Completed(ChatgptResponseEvent::Completed(snapshot))
-                if snapshot.id.as_deref() == Some("resp-1")
+            super::MappedEvent::Event(ChatgptResponseEvent::Other(raw))
+                if raw.event_type == "response.done"
+        ));
+    }
+
+    #[test]
+    fn unknown_non_response_event_maps_to_endpoint_other_error() {
+        let event = map_stream_event(
+            r#"{"type":"server.notice","code":"server_busy","message":"retry later"}"#,
+        )
+        .expect("mapped event");
+
+        assert!(matches!(
+            event,
+            super::MappedEvent::EndpointError(ChatgptApiError::Endpoint(
+                ChatgptApiEndpointError::Other(ChatgptOtherEndpointError { event_type, .. })
+            )) if event_type.as_deref() == Some("server.notice")
         ));
     }
 

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -922,6 +922,8 @@ fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
 
     let reasoning = build_reasoning_body(request);
     let reasoning_enabled = !reasoning.is_empty();
+    let needs_encrypted_reasoning_content =
+        reasoning_enabled || request_replays_reasoning_state(&request.input);
     body.insert(
         "reasoning".to_owned(),
         if reasoning_enabled {
@@ -932,7 +934,7 @@ fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
     );
     body.insert(
         "include".to_owned(),
-        if reasoning_enabled {
+        if needs_encrypted_reasoning_content {
             serde_json::json!(["reasoning.encrypted_content"])
         } else {
             serde_json::json!([])
@@ -998,6 +1000,18 @@ fn build_text_body(text: &ChatgptTextOptions) -> Option<JsonObject> {
     }
 
     (!body.is_empty()).then_some(body)
+}
+
+fn request_replays_reasoning_state(input: &[ResponseItem]) -> bool {
+    input.iter().any(|item| {
+        matches!(
+            item,
+            ResponseItem::Reasoning(ReasoningItem {
+                encrypted_content: Some(_),
+                ..
+            })
+        )
+    })
 }
 
 fn response_item_to_json(item: &ResponseItem) -> Value {
@@ -1602,8 +1616,8 @@ mod tests {
     use super::{
         ChatgptModelCapabilities, ChatgptReasoningOptions, ChatgptRequestContext,
         ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem, JsonObject,
-        MessageItem, ResponseItem, TextVerbosity, ToolDescriptor, build_http_request,
-        chatgpt_usage_from_value,
+        MessageItem, ReasoningItem, ResponseItem, TextVerbosity, ToolDescriptor,
+        build_http_request, chatgpt_usage_from_value,
     };
 
     fn base_request() -> ChatgptResponsesRequest {
@@ -1814,6 +1828,32 @@ mod tests {
             body.get("include"),
             Some(&serde_json::json!(["reasoning.encrypted_content"]))
         );
+    }
+
+    #[test]
+    fn build_http_request_keeps_encrypted_reasoning_content_for_stateless_replay() {
+        let mut request = base_request();
+        request.reasoning = ChatgptReasoningOptions::default();
+        request.model_capabilities.default_reasoning_effort = None;
+        request.input.push(ResponseItem::Reasoning(ReasoningItem {
+            id: Some("reasoning-1".to_owned()),
+            status: Some("completed".to_owned()),
+            summary: serde_json::json!([]),
+            content: None,
+            encrypted_content: Some("encrypted".to_owned()),
+        }));
+
+        let http_request =
+            build_http_request(&request, &base_auth(), &base_api_config()).expect("http request");
+        let selvedge_client::HttpRequestBody::Json(body) = http_request.body else {
+            panic!("expected json body");
+        };
+
+        assert_eq!(
+            body.get("include"),
+            Some(&serde_json::json!(["reasoning.encrypted_content"]))
+        );
+        assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
     }
 
     #[test]

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -233,6 +233,17 @@ async fn drive_response_stream(
                         .await;
                         return;
                     }
+                    FinalEventDisposition::Unknown => {
+                        let _ = send_stream_item(
+                            &sender,
+                            &terminal_error,
+                            Ok(event),
+                            deadline,
+                            timeout,
+                        )
+                        .await;
+                        return;
+                    }
                     FinalEventDisposition::NonTerminal => {
                         if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
                             .await
@@ -969,6 +980,7 @@ fn response_transport_timeout(stream_completion_timeout_ms: u64) -> Duration {
 enum FinalEventDisposition {
     Completed,
     NonTerminal,
+    Unknown,
 }
 
 fn map_event_finality(event: &ChatgptResponseEvent) -> FinalEventDisposition {
@@ -982,8 +994,8 @@ fn map_event_finality(event: &ChatgptResponseEvent) -> FinalEventDisposition {
         | ChatgptResponseEvent::ReasoningSummaryTextDelta { .. }
         | ChatgptResponseEvent::ReasoningSummaryTextDone { .. }
         | ChatgptResponseEvent::ReasoningTextDelta { .. }
-        | ChatgptResponseEvent::ReasoningTextDone { .. }
-        | ChatgptResponseEvent::Other(_) => FinalEventDisposition::NonTerminal,
+        | ChatgptResponseEvent::ReasoningTextDone { .. } => FinalEventDisposition::NonTerminal,
+        ChatgptResponseEvent::Other(_) => FinalEventDisposition::Unknown,
     }
 }
 
@@ -1149,96 +1161,80 @@ fn request_replays_reasoning_state(input: &[ResponseItem]) -> bool {
 
 fn response_item_to_json(item: &ResponseItem) -> Value {
     match item {
-        ResponseItem::Message(message) => Value::Object(JsonObject::from_iter([
-            ("type".to_owned(), Value::String("message".to_owned())),
-            (
-                "id".to_owned(),
-                optional_string_value(message.id.as_deref()),
-            ),
-            (
-                "status".to_owned(),
-                optional_string_value(message.status.as_deref()),
-            ),
-            (
-                "phase".to_owned(),
-                optional_string_value(message.phase.as_deref()),
-            ),
-            ("role".to_owned(), Value::String(message.role.clone())),
-            (
-                "content".to_owned(),
-                Value::Array(message.content.iter().map(content_item_to_json).collect()),
-            ),
-        ])),
-        ResponseItem::FunctionCall(call) => Value::Object(JsonObject::from_iter([
-            ("type".to_owned(), Value::String("function_call".to_owned())),
-            ("id".to_owned(), optional_string_value(call.id.as_deref())),
-            (
-                "status".to_owned(),
-                optional_string_value(call.status.as_deref()),
-            ),
-            ("name".to_owned(), Value::String(call.name.clone())),
-            (
-                "namespace".to_owned(),
-                optional_string_value(call.namespace.as_deref()),
-            ),
-            (
-                "arguments".to_owned(),
-                Value::String(call.arguments.clone()),
-            ),
-            ("call_id".to_owned(), Value::String(call.call_id.clone())),
-        ])),
-        ResponseItem::CustomToolCall(call) => Value::Object(JsonObject::from_iter([
-            (
-                "type".to_owned(),
-                Value::String("custom_tool_call".to_owned()),
-            ),
-            ("id".to_owned(), optional_string_value(call.id.as_deref())),
-            (
-                "status".to_owned(),
-                optional_string_value(call.status.as_deref()),
-            ),
-            ("call_id".to_owned(), Value::String(call.call_id.clone())),
-            ("name".to_owned(), Value::String(call.name.clone())),
-            ("input".to_owned(), Value::String(call.input.clone())),
-        ])),
-        ResponseItem::FunctionCallOutput(output) => Value::Object(JsonObject::from_iter([
-            (
-                "type".to_owned(),
-                Value::String("function_call_output".to_owned()),
-            ),
-            ("id".to_owned(), optional_string_value(output.id.as_deref())),
-            (
-                "status".to_owned(),
-                optional_string_value(output.status.as_deref()),
-            ),
-            ("call_id".to_owned(), Value::String(output.call_id.clone())),
-            ("output".to_owned(), tool_output_to_json(&output.output)),
-        ])),
-        ResponseItem::CustomToolCallOutput(output) => Value::Object(JsonObject::from_iter([
-            (
-                "type".to_owned(),
-                Value::String("custom_tool_call_output".to_owned()),
-            ),
-            ("id".to_owned(), optional_string_value(output.id.as_deref())),
-            (
-                "status".to_owned(),
-                optional_string_value(output.status.as_deref()),
-            ),
-            ("call_id".to_owned(), Value::String(output.call_id.clone())),
-            ("output".to_owned(), tool_output_to_json(&output.output)),
-        ])),
-        ResponseItem::Reasoning(reasoning) => {
+        ResponseItem::Message(message) => {
             let mut value = JsonObject::from_iter([
-                ("type".to_owned(), Value::String("reasoning".to_owned())),
+                ("type".to_owned(), Value::String("message".to_owned())),
+                ("role".to_owned(), Value::String(message.role.clone())),
                 (
-                    "id".to_owned(),
-                    optional_string_value(reasoning.id.as_deref()),
-                ),
-                (
-                    "status".to_owned(),
-                    optional_string_value(reasoning.status.as_deref()),
+                    "content".to_owned(),
+                    Value::Array(message.content.iter().map(content_item_to_json).collect()),
                 ),
             ]);
+            insert_optional_string(&mut value, "id", message.id.as_deref());
+            insert_optional_string(&mut value, "status", message.status.as_deref());
+            insert_optional_string(&mut value, "phase", message.phase.as_deref());
+            Value::Object(value)
+        }
+        ResponseItem::FunctionCall(call) => {
+            let mut value = JsonObject::from_iter([
+                ("type".to_owned(), Value::String("function_call".to_owned())),
+                ("name".to_owned(), Value::String(call.name.clone())),
+                (
+                    "arguments".to_owned(),
+                    Value::String(call.arguments.clone()),
+                ),
+                ("call_id".to_owned(), Value::String(call.call_id.clone())),
+            ]);
+            insert_optional_string(&mut value, "id", call.id.as_deref());
+            insert_optional_string(&mut value, "status", call.status.as_deref());
+            insert_optional_string(&mut value, "namespace", call.namespace.as_deref());
+            Value::Object(value)
+        }
+        ResponseItem::CustomToolCall(call) => {
+            let mut value = JsonObject::from_iter([
+                (
+                    "type".to_owned(),
+                    Value::String("custom_tool_call".to_owned()),
+                ),
+                ("call_id".to_owned(), Value::String(call.call_id.clone())),
+                ("name".to_owned(), Value::String(call.name.clone())),
+                ("input".to_owned(), Value::String(call.input.clone())),
+            ]);
+            insert_optional_string(&mut value, "id", call.id.as_deref());
+            insert_optional_string(&mut value, "status", call.status.as_deref());
+            Value::Object(value)
+        }
+        ResponseItem::FunctionCallOutput(output) => {
+            let mut value = JsonObject::from_iter([
+                (
+                    "type".to_owned(),
+                    Value::String("function_call_output".to_owned()),
+                ),
+                ("call_id".to_owned(), Value::String(output.call_id.clone())),
+                ("output".to_owned(), tool_output_to_json(&output.output)),
+            ]);
+            insert_optional_string(&mut value, "id", output.id.as_deref());
+            insert_optional_string(&mut value, "status", output.status.as_deref());
+            Value::Object(value)
+        }
+        ResponseItem::CustomToolCallOutput(output) => {
+            let mut value = JsonObject::from_iter([
+                (
+                    "type".to_owned(),
+                    Value::String("custom_tool_call_output".to_owned()),
+                ),
+                ("call_id".to_owned(), Value::String(output.call_id.clone())),
+                ("output".to_owned(), tool_output_to_json(&output.output)),
+            ]);
+            insert_optional_string(&mut value, "id", output.id.as_deref());
+            insert_optional_string(&mut value, "status", output.status.as_deref());
+            Value::Object(value)
+        }
+        ResponseItem::Reasoning(reasoning) => {
+            let mut value =
+                JsonObject::from_iter([("type".to_owned(), Value::String("reasoning".to_owned()))]);
+            insert_optional_string(&mut value, "id", reasoning.id.as_deref());
+            insert_optional_string(&mut value, "status", reasoning.status.as_deref());
 
             if let Some(summary) = &reasoning.summary {
                 value.insert("summary".to_owned(), summary.clone());
@@ -1290,10 +1286,10 @@ fn tool_output_to_json(output: &ToolOutput) -> Value {
     }
 }
 
-fn optional_string_value(value: Option<&str>) -> Value {
-    value
-        .map(|value| Value::String(value.to_owned()))
-        .unwrap_or(Value::Null)
+fn insert_optional_string(object: &mut JsonObject, key: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        object.insert(key.to_owned(), Value::String(value.to_owned()));
+    }
 }
 
 fn service_tier_to_wire(service_tier: ChatgptServiceTier) -> &'static str {
@@ -1985,6 +1981,36 @@ mod tests {
         assert!(body.get("service_tier").is_none());
         assert!(body.get("text").is_none());
         assert_eq!(body.get("tools"), Some(&serde_json::json!([])));
+    }
+
+    #[test]
+    fn build_http_request_omits_missing_optional_request_item_fields() {
+        let mut request = base_request();
+        request.input = vec![ResponseItem::Message(MessageItem {
+            id: None,
+            status: None,
+            phase: None,
+            role: "user".to_owned(),
+            content: vec![ContentItem::InputText {
+                text: "hello".to_owned(),
+            }],
+        })];
+
+        let http_request =
+            build_http_request(&request, &base_auth(), &base_api_config()).expect("http request");
+        let selvedge_client::HttpRequestBody::Json(body) = http_request.body else {
+            panic!("expected json body");
+        };
+        let input_item = body
+            .get("input")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|items| items.first())
+            .and_then(serde_json::Value::as_object)
+            .expect("first input item");
+
+        assert!(!input_item.contains_key("id"));
+        assert!(!input_item.contains_key("status"));
+        assert!(!input_item.contains_key("phase"));
     }
 
     #[test]

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -608,7 +608,6 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
         "message" => Ok(ResponseItem::Message(MessageItem {
             id: optional_string(item, "id")?,
             status: optional_string(item, "status")?,
-            phase: optional_string(item, "phase")?,
             role: required_string(item, "role")?,
             content: required_array(item, "content")?
                 .iter()
@@ -622,13 +621,6 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
             namespace: optional_string(item, "namespace")?,
             arguments: required_string(item, "arguments")?,
             call_id: required_string(item, "call_id")?,
-        })),
-        "custom_tool_call" => Ok(ResponseItem::CustomToolCall(CustomToolCallItem {
-            id: optional_string(item, "id")?,
-            status: optional_string(item, "status")?,
-            call_id: required_string(item, "call_id")?,
-            name: required_string(item, "name")?,
-            input: required_string(item, "input")?,
         })),
         "function_call_output" => Ok(ResponseItem::FunctionCallOutput(FunctionCallOutputItem {
             id: optional_string(item, "id")?,
@@ -653,7 +645,10 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
         "reasoning" => Ok(ResponseItem::Reasoning(ReasoningItem {
             id: optional_string(item, "id")?,
             status: optional_string(item, "status")?,
-            summary: item.get("summary").cloned(),
+            summary: item
+                .get("summary")
+                .cloned()
+                .ok_or_else(|| malformed_event("summary", "must be present"))?,
             content: item
                 .get("content")
                 .map(|value| match value {
@@ -683,7 +678,7 @@ fn content_item_from_value(value: &Value) -> Result<ContentItem, ChatgptApiError
             text: required_string(object, "text")?,
         }),
         "input_image" => Ok(ContentItem::InputImage {
-            raw: object.clone(),
+            image_url: required_string(object, "image_url")?,
         }),
         "output_text" => Ok(ContentItem::OutputText {
             text: required_string(object, "text")?,
@@ -1092,21 +1087,17 @@ fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
         );
     }
 
-    let reasoning = build_reasoning_body(request);
-    let reasoning_enabled = !reasoning.is_empty();
-    let needs_encrypted_reasoning_content =
-        reasoning_enabled || request_replays_reasoning_state(&request.input);
     body.insert(
         "reasoning".to_owned(),
-        if reasoning_enabled {
-            Value::Object(reasoning)
+        if request.model_capabilities.supports_reasoning_summaries {
+            Value::Object(build_reasoning_body(request))
         } else {
             Value::Null
         },
     );
     body.insert(
         "include".to_owned(),
-        if needs_encrypted_reasoning_content {
+        if request.model_capabilities.supports_reasoning_summaries {
             serde_json::json!(["reasoning.encrypted_content"])
         } else {
             serde_json::json!([])
@@ -1174,18 +1165,6 @@ fn build_text_body(text: &ChatgptTextOptions) -> Option<JsonObject> {
     (!body.is_empty()).then_some(body)
 }
 
-fn request_replays_reasoning_state(input: &[ResponseItem]) -> bool {
-    input.iter().any(|item| {
-        matches!(
-            item,
-            ResponseItem::Reasoning(ReasoningItem {
-                encrypted_content: Some(_),
-                ..
-            })
-        )
-    })
-}
-
 fn response_item_to_json(item: &ResponseItem) -> Value {
     match item {
         ResponseItem::Message(message) => {
@@ -1199,7 +1178,6 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
             ]);
             insert_optional_string(&mut value, "id", message.id.as_deref());
             insert_optional_string(&mut value, "status", message.status.as_deref());
-            insert_optional_string(&mut value, "phase", message.phase.as_deref());
             Value::Object(value)
         }
         ResponseItem::FunctionCall(call) => {
@@ -1215,20 +1193,6 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
             insert_optional_string(&mut value, "id", call.id.as_deref());
             insert_optional_string(&mut value, "status", call.status.as_deref());
             insert_optional_string(&mut value, "namespace", call.namespace.as_deref());
-            Value::Object(value)
-        }
-        ResponseItem::CustomToolCall(call) => {
-            let mut value = JsonObject::from_iter([
-                (
-                    "type".to_owned(),
-                    Value::String("custom_tool_call".to_owned()),
-                ),
-                ("call_id".to_owned(), Value::String(call.call_id.clone())),
-                ("name".to_owned(), Value::String(call.name.clone())),
-                ("input".to_owned(), Value::String(call.input.clone())),
-            ]);
-            insert_optional_string(&mut value, "id", call.id.as_deref());
-            insert_optional_string(&mut value, "status", call.status.as_deref());
             Value::Object(value)
         }
         ResponseItem::FunctionCallOutput(output) => {
@@ -1262,10 +1226,7 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
                 JsonObject::from_iter([("type".to_owned(), Value::String("reasoning".to_owned()))]);
             insert_optional_string(&mut value, "id", reasoning.id.as_deref());
             insert_optional_string(&mut value, "status", reasoning.status.as_deref());
-
-            if let Some(summary) = &reasoning.summary {
-                value.insert("summary".to_owned(), summary.clone());
-            }
+            value.insert("summary".to_owned(), reasoning.summary.clone());
 
             if let Some(content) = &reasoning.content {
                 value.insert(
@@ -1293,7 +1254,10 @@ fn content_item_to_json(item: &ContentItem) -> Value {
             ("type".to_owned(), Value::String("input_text".to_owned())),
             ("text".to_owned(), Value::String(text.clone())),
         ])),
-        ContentItem::InputImage { raw } => Value::Object(raw.clone()),
+        ContentItem::InputImage { image_url } => Value::Object(JsonObject::from_iter([
+            ("type".to_owned(), Value::String("input_image".to_owned())),
+            ("image_url".to_owned(), Value::String(image_url.clone())),
+        ])),
         ContentItem::OutputText { text, raw } => {
             let mut value = raw.clone();
             value.insert("type".to_owned(), Value::String("output_text".to_owned()));
@@ -1636,7 +1600,6 @@ pub struct ChatgptUsage {
 pub enum ResponseItem {
     Message(MessageItem),
     FunctionCall(FunctionCallItem),
-    CustomToolCall(CustomToolCallItem),
     FunctionCallOutput(FunctionCallOutputItem),
     CustomToolCallOutput(CustomToolCallOutputItem),
     Reasoning(ReasoningItem),
@@ -1647,7 +1610,6 @@ pub enum ResponseItem {
 pub struct MessageItem {
     pub id: Option<String>,
     pub status: Option<String>,
-    pub phase: Option<String>,
     pub role: String,
     pub content: Vec<ContentItem>,
 }
@@ -1660,15 +1622,6 @@ pub struct FunctionCallItem {
     pub namespace: Option<String>,
     pub arguments: String,
     pub call_id: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CustomToolCallItem {
-    pub id: Option<String>,
-    pub status: Option<String>,
-    pub call_id: String,
-    pub name: String,
-    pub input: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1691,7 +1644,7 @@ pub struct CustomToolCallOutputItem {
 pub struct ReasoningItem {
     pub id: Option<String>,
     pub status: Option<String>,
-    pub summary: Option<Value>,
+    pub summary: Value,
     pub content: Option<Vec<ContentItem>>,
     pub encrypted_content: Option<String>,
 }
@@ -1705,7 +1658,7 @@ pub struct OpaqueResponseItem {
 #[non_exhaustive]
 pub enum ContentItem {
     InputText { text: String },
-    InputImage { raw: JsonObject },
+    InputImage { image_url: String },
     OutputText { text: String, raw: JsonObject },
     Other { raw: JsonObject },
 }
@@ -1818,9 +1771,9 @@ mod tests {
     use super::{
         ChatgptApiEndpointError, ChatgptApiError, ChatgptModelCapabilities,
         ChatgptOtherEndpointError, ChatgptReasoningOptions, ChatgptRequestContext,
-        ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem,
-        CustomToolCallItem, JsonObject, MessageItem, ReasoningItem, ResponseItem, TextVerbosity,
-        ToolDescriptor, build_http_request, chatgpt_usage_from_value, content_item_from_value,
+        ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem, JsonObject,
+        MessageItem, ReasoningItem, ResponseItem, TextVerbosity, ToolDescriptor,
+        build_http_request, chatgpt_usage_from_value, content_item_from_value,
         failed_endpoint_event, response_item_from_object, retry_delay_for_attempt,
     };
 
@@ -1846,7 +1799,6 @@ mod tests {
             input: vec![ResponseItem::Message(MessageItem {
                 id: Some("msg-1".to_owned()),
                 status: Some("completed".to_owned()),
-                phase: Some("commentary".to_owned()),
                 role: "user".to_owned(),
                 content: vec![ContentItem::InputText {
                     text: "hello".to_owned(),
@@ -2019,7 +1971,6 @@ mod tests {
         request.input = vec![ResponseItem::Message(MessageItem {
             id: None,
             status: None,
-            phase: None,
             role: "user".to_owned(),
             content: vec![ContentItem::InputText {
                 text: "hello".to_owned(),
@@ -2040,7 +1991,6 @@ mod tests {
 
         assert!(!input_item.contains_key("id"));
         assert!(!input_item.contains_key("status"));
-        assert!(!input_item.contains_key("phase"));
     }
 
     #[test]
@@ -2063,7 +2013,7 @@ mod tests {
     }
 
     #[test]
-    fn build_http_request_preserves_reasoning_effort_without_summary_support() {
+    fn build_http_request_uses_fixed_reasoning_contract_without_summary_support() {
         let mut request = base_request();
         request.reasoning.summary = None;
         request.model_capabilities.supports_reasoning_summaries = false;
@@ -2074,25 +2024,19 @@ mod tests {
             panic!("expected json body");
         };
 
-        assert_eq!(
-            body.pointer("/reasoning/effort"),
-            Some(&serde_json::json!("high"))
-        );
-        assert_eq!(
-            body.get("include"),
-            Some(&serde_json::json!(["reasoning.encrypted_content"]))
-        );
+        assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
+        assert_eq!(body.get("include"), Some(&serde_json::json!([])));
     }
 
     #[test]
-    fn build_http_request_keeps_encrypted_reasoning_content_for_stateless_replay() {
+    fn build_http_request_uses_fixed_reasoning_contract_with_summary_support() {
         let mut request = base_request();
         request.reasoning = ChatgptReasoningOptions::default();
         request.model_capabilities.default_reasoning_effort = None;
         request.input.push(ResponseItem::Reasoning(ReasoningItem {
             id: Some("reasoning-1".to_owned()),
             status: Some("completed".to_owned()),
-            summary: Some(serde_json::json!([])),
+            summary: serde_json::json!([]),
             content: None,
             encrypted_content: Some("encrypted".to_owned()),
         }));
@@ -2107,7 +2051,10 @@ mod tests {
             body.get("include"),
             Some(&serde_json::json!(["reasoning.encrypted_content"]))
         );
-        assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
+        assert_eq!(
+            body.get("reasoning"),
+            Some(&serde_json::Value::Object(JsonObject::new()))
+        );
     }
 
     #[test]
@@ -2147,7 +2094,7 @@ mod tests {
     }
 
     #[test]
-    fn response_item_parser_decodes_custom_tool_calls() {
+    fn response_item_parser_routes_custom_tool_calls_to_opaque() {
         let item = response_item_from_object(&JsonObject::from_iter([
             ("type".to_owned(), serde_json::json!("custom_tool_call")),
             ("id".to_owned(), serde_json::json!("custom-1")),
@@ -2158,19 +2105,11 @@ mod tests {
         ]))
         .expect("custom tool call");
 
-        assert!(matches!(
-            item,
-            ResponseItem::CustomToolCall(CustomToolCallItem {
-                call_id,
-                name,
-                input,
-                ..
-            }) if call_id == "call-1" && name == "apply_patch" && input == "*** Begin Patch"
-        ));
+        assert!(matches!(item, ResponseItem::Opaque(_)));
     }
 
     #[test]
-    fn response_item_parser_preserves_message_phase() {
+    fn response_item_parser_ignores_non_contract_message_fields() {
         let item = response_item_from_object(&JsonObject::from_iter([
             ("type".to_owned(), serde_json::json!("message")),
             ("role".to_owned(), serde_json::json!("assistant")),
@@ -2182,43 +2121,39 @@ mod tests {
         assert!(matches!(
             item,
             ResponseItem::Message(MessageItem {
-                phase: Some(phase),
+                role,
                 ..
-            }) if phase == "final_answer"
+            }) if role == "assistant"
         ));
     }
 
     #[test]
-    fn content_item_parser_accepts_file_backed_input_images() {
-        let item = content_item_from_value(&serde_json::json!({
+    fn content_item_parser_rejects_input_images_without_image_url() {
+        let error = content_item_from_value(&serde_json::json!({
             "type": "input_image",
             "file_id": "file-123",
             "detail": "high"
         }))
-        .expect("file-backed input image");
+        .expect_err("input images without image_url must fail");
 
         assert!(matches!(
-            item,
-            ContentItem::InputImage { raw } if raw.get("file_id") == Some(&serde_json::json!("file-123"))
+            error,
+            ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent { .. })
         ));
     }
 
     #[test]
-    fn response_item_parser_accepts_reasoning_items_without_summary() {
-        let item = response_item_from_object(&JsonObject::from_iter([
+    fn response_item_parser_rejects_reasoning_items_without_summary() {
+        let error = response_item_from_object(&JsonObject::from_iter([
             ("type".to_owned(), serde_json::json!("reasoning")),
             ("id".to_owned(), serde_json::json!("reasoning-1")),
             ("encrypted_content".to_owned(), serde_json::json!("cipher")),
         ]))
-        .expect("reasoning item without summary");
+        .expect_err("reasoning item without summary must fail");
 
         assert!(matches!(
-            item,
-            ResponseItem::Reasoning(ReasoningItem {
-                encrypted_content: Some(encrypted_content),
-                summary,
-                ..
-            }) if encrypted_content == "cipher" && summary.is_none()
+            error,
+            ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent { .. })
         ));
     }
 

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -643,10 +643,7 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
         "reasoning" => Ok(ResponseItem::Reasoning(ReasoningItem {
             id: optional_string(item, "id")?,
             status: optional_string(item, "status")?,
-            summary: item
-                .get("summary")
-                .cloned()
-                .ok_or_else(|| malformed_event("summary", "must be present"))?,
+            summary: item.get("summary").cloned(),
             content: item
                 .get("content")
                 .map(|value| match value {
@@ -1085,17 +1082,21 @@ fn build_request_body(request: &ChatgptResponsesRequest) -> Value {
         );
     }
 
+    let reasoning = build_reasoning_body(request);
+    let reasoning_enabled = !reasoning.is_empty();
+    let needs_encrypted_reasoning_content =
+        reasoning_enabled || request_replays_reasoning_state(&request.input);
     body.insert(
         "reasoning".to_owned(),
-        if request.model_capabilities.supports_reasoning_summaries {
-            Value::Object(build_reasoning_body(request))
+        if reasoning_enabled {
+            Value::Object(reasoning)
         } else {
             Value::Null
         },
     );
     body.insert(
         "include".to_owned(),
-        if request.model_capabilities.supports_reasoning_summaries {
+        if needs_encrypted_reasoning_content {
             serde_json::json!(["reasoning.encrypted_content"])
         } else {
             serde_json::json!([])
@@ -1133,6 +1134,18 @@ fn build_reasoning_body(request: &ChatgptResponsesRequest) -> JsonObject {
     }
 
     reasoning
+}
+
+fn request_replays_reasoning_state(input: &[ResponseItem]) -> bool {
+    input.iter().any(|item| {
+        matches!(
+            item,
+            ResponseItem::Reasoning(ReasoningItem {
+                encrypted_content: Some(_),
+                ..
+            })
+        )
+    })
 }
 
 fn build_text_body(text: &ChatgptTextOptions) -> Option<JsonObject> {
@@ -1224,7 +1237,10 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
                 JsonObject::from_iter([("type".to_owned(), Value::String("reasoning".to_owned()))]);
             insert_optional_string(&mut value, "id", reasoning.id.as_deref());
             insert_optional_string(&mut value, "status", reasoning.status.as_deref());
-            value.insert("summary".to_owned(), reasoning.summary.clone());
+
+            if let Some(summary) = &reasoning.summary {
+                value.insert("summary".to_owned(), summary.clone());
+            }
 
             if let Some(content) = &reasoning.content {
                 value.insert(
@@ -1642,7 +1658,7 @@ pub struct CustomToolCallOutputItem {
 pub struct ReasoningItem {
     pub id: Option<String>,
     pub status: Option<String>,
-    pub summary: Value,
+    pub summary: Option<Value>,
     pub content: Option<Vec<ContentItem>>,
     pub encrypted_content: Option<String>,
 }
@@ -2030,19 +2046,26 @@ mod tests {
             panic!("expected json body");
         };
 
-        assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
-        assert_eq!(body.get("include"), Some(&serde_json::json!([])));
+        assert_eq!(
+            body.pointer("/reasoning/effort"),
+            Some(&serde_json::json!("high"))
+        );
+        assert_eq!(
+            body.get("include"),
+            Some(&serde_json::json!(["reasoning.encrypted_content"]))
+        );
     }
 
     #[test]
-    fn build_http_request_uses_fixed_reasoning_contract_with_summary_support() {
+    fn build_http_request_keeps_encrypted_reasoning_content_for_stateless_replay() {
         let mut request = base_request();
         request.reasoning = ChatgptReasoningOptions::default();
         request.model_capabilities.default_reasoning_effort = None;
+        request.model_capabilities.supports_reasoning_summaries = false;
         request.input.push(ResponseItem::Reasoning(ReasoningItem {
             id: Some("reasoning-1".to_owned()),
             status: Some("completed".to_owned()),
-            summary: serde_json::json!([]),
+            summary: None,
             content: None,
             encrypted_content: Some("encrypted".to_owned()),
         }));
@@ -2057,10 +2080,7 @@ mod tests {
             body.get("include"),
             Some(&serde_json::json!(["reasoning.encrypted_content"]))
         );
-        assert_eq!(
-            body.get("reasoning"),
-            Some(&serde_json::Value::Object(JsonObject::new()))
-        );
+        assert_eq!(body.get("reasoning"), Some(&serde_json::Value::Null));
     }
 
     #[test]
@@ -2149,17 +2169,21 @@ mod tests {
     }
 
     #[test]
-    fn response_item_parser_rejects_reasoning_items_without_summary() {
-        let error = response_item_from_object(&JsonObject::from_iter([
+    fn response_item_parser_accepts_reasoning_items_without_summary() {
+        let item = response_item_from_object(&JsonObject::from_iter([
             ("type".to_owned(), serde_json::json!("reasoning")),
             ("id".to_owned(), serde_json::json!("reasoning-1")),
             ("encrypted_content".to_owned(), serde_json::json!("cipher")),
         ]))
-        .expect_err("reasoning item without summary must fail");
+        .expect("reasoning item without summary");
 
         assert!(matches!(
-            error,
-            ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent { .. })
+            item,
+            ResponseItem::Reasoning(ReasoningItem {
+                encrypted_content: Some(encrypted_content),
+                summary,
+                ..
+            }) if encrypted_content == "cipher" && summary.is_none()
         ));
     }
 

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -97,9 +97,12 @@ fn ensure_event_stream_content_type(headers: &HeaderMap) -> Result<(), ChatgptAp
         .and_then(|value| value.to_str().ok())
         .map(str::to_owned);
 
-    let is_event_stream = content_type
-        .as_deref()
-        .is_some_and(|value| value.starts_with("text/event-stream"));
+    let is_event_stream = content_type.as_deref().is_some_and(|value| {
+        value
+            .split(';')
+            .next()
+            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("text/event-stream"))
+    });
 
     if !is_event_stream {
         return Err(ChatgptApiError::Endpoint(
@@ -496,6 +499,13 @@ fn response_item_from_object(item: &JsonObject) -> Result<ResponseItem, ChatgptA
             namespace: optional_string(item, "namespace")?,
             arguments: required_string(item, "arguments")?,
             call_id: required_string(item, "call_id")?,
+        })),
+        "custom_tool_call" => Ok(ResponseItem::CustomToolCall(CustomToolCallItem {
+            id: optional_string(item, "id")?,
+            status: optional_string(item, "status")?,
+            call_id: required_string(item, "call_id")?,
+            name: required_string(item, "name")?,
+            input: required_string(item, "input")?,
         })),
         "function_call_output" => Ok(ResponseItem::FunctionCallOutput(FunctionCallOutputItem {
             id: optional_string(item, "id")?,
@@ -1050,6 +1060,20 @@ fn response_item_to_json(item: &ResponseItem) -> Value {
             ),
             ("call_id".to_owned(), Value::String(call.call_id.clone())),
         ])),
+        ResponseItem::CustomToolCall(call) => Value::Object(JsonObject::from_iter([
+            (
+                "type".to_owned(),
+                Value::String("custom_tool_call".to_owned()),
+            ),
+            ("id".to_owned(), optional_string_value(call.id.as_deref())),
+            (
+                "status".to_owned(),
+                optional_string_value(call.status.as_deref()),
+            ),
+            ("call_id".to_owned(), Value::String(call.call_id.clone())),
+            ("name".to_owned(), Value::String(call.name.clone())),
+            ("input".to_owned(), Value::String(call.input.clone())),
+        ])),
         ResponseItem::FunctionCallOutput(output) => Value::Object(JsonObject::from_iter([
             (
                 "type".to_owned(),
@@ -1447,6 +1471,7 @@ pub struct ChatgptUsage {
 pub enum ResponseItem {
     Message(MessageItem),
     FunctionCall(FunctionCallItem),
+    CustomToolCall(CustomToolCallItem),
     FunctionCallOutput(FunctionCallOutputItem),
     CustomToolCallOutput(CustomToolCallOutputItem),
     Reasoning(ReasoningItem),
@@ -1469,6 +1494,15 @@ pub struct FunctionCallItem {
     pub namespace: Option<String>,
     pub arguments: String,
     pub call_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CustomToolCallItem {
+    pub id: Option<String>,
+    pub status: Option<String>,
+    pub call_id: String,
+    pub name: String,
+    pub input: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1615,9 +1649,9 @@ mod tests {
 
     use super::{
         ChatgptModelCapabilities, ChatgptReasoningOptions, ChatgptRequestContext,
-        ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem, JsonObject,
-        MessageItem, ReasoningItem, ResponseItem, TextVerbosity, ToolDescriptor,
-        build_http_request, chatgpt_usage_from_value,
+        ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ContentItem,
+        CustomToolCallItem, JsonObject, MessageItem, ReasoningItem, ResponseItem, TextVerbosity,
+        ToolDescriptor, build_http_request, chatgpt_usage_from_value, response_item_from_object,
     };
 
     fn base_request() -> ChatgptResponsesRequest {
@@ -1876,5 +1910,28 @@ mod tests {
         assert_eq!(usage.output_tokens, Some(7));
         assert_eq!(usage.reasoning_output_tokens, Some(3));
         assert_eq!(usage.total_tokens, Some(17));
+    }
+
+    #[test]
+    fn response_item_parser_decodes_custom_tool_calls() {
+        let item = response_item_from_object(&JsonObject::from_iter([
+            ("type".to_owned(), serde_json::json!("custom_tool_call")),
+            ("id".to_owned(), serde_json::json!("custom-1")),
+            ("status".to_owned(), serde_json::json!("in_progress")),
+            ("call_id".to_owned(), serde_json::json!("call-1")),
+            ("name".to_owned(), serde_json::json!("apply_patch")),
+            ("input".to_owned(), serde_json::json!("*** Begin Patch")),
+        ]))
+        .expect("custom tool call");
+
+        assert!(matches!(
+            item,
+            ResponseItem::CustomToolCall(CustomToolCallItem {
+                call_id,
+                name,
+                input,
+                ..
+            }) if call_id == "call-1" && name == "apply_patch" && input == "*** Begin Patch"
+        ));
     }
 }

--- a/crates/chatgpt-api/src/lib.rs
+++ b/crates/chatgpt-api/src/lib.rs
@@ -221,13 +221,37 @@ async fn drive_response_stream(
             };
 
             match final_result {
-                Ok(Some(event)) => {
-                    if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
-                        .await
-                    {
+                Ok(Some(event)) => match map_event_finality(&event) {
+                    FinalEventDisposition::Completed => {
+                        let _ = send_stream_item(
+                            &sender,
+                            &terminal_error,
+                            Ok(event),
+                            deadline,
+                            timeout,
+                        )
+                        .await;
                         return;
                     }
-                }
+                    FinalEventDisposition::NonTerminal => {
+                        if !send_stream_item(&sender, &terminal_error, Ok(event), deadline, timeout)
+                            .await
+                        {
+                            return;
+                        }
+                        send_stream_item(
+                            &sender,
+                            &terminal_error,
+                            Err(ChatgptApiError::Endpoint(
+                                ChatgptApiEndpointError::PrematureClose,
+                            )),
+                            deadline,
+                            timeout,
+                        )
+                        .await;
+                        return;
+                    }
+                },
                 Ok(None) => {}
                 Err(error) => {
                     send_stream_item(&sender, &terminal_error, Err(error), deadline, timeout).await;
@@ -930,9 +954,36 @@ fn build_http_request(
         url,
         headers,
         body: selvedge_client::HttpRequestBody::Json(body),
-        timeout: None,
+        timeout: Some(response_transport_timeout(
+            api_config.stream_completion_timeout_ms,
+        )),
         compression: selvedge_client::RequestCompression::None,
     })
+}
+
+fn response_transport_timeout(stream_completion_timeout_ms: u64) -> Duration {
+    Duration::from_millis(stream_completion_timeout_ms).saturating_add(Duration::from_secs(1))
+}
+
+enum FinalEventDisposition {
+    Completed,
+    NonTerminal,
+}
+
+fn map_event_finality(event: &ChatgptResponseEvent) -> FinalEventDisposition {
+    match event {
+        ChatgptResponseEvent::Completed(_) => FinalEventDisposition::Completed,
+        ChatgptResponseEvent::Created(_)
+        | ChatgptResponseEvent::OutputItemAdded { .. }
+        | ChatgptResponseEvent::OutputItemDone { .. }
+        | ChatgptResponseEvent::OutputTextDelta { .. }
+        | ChatgptResponseEvent::OutputTextDone { .. }
+        | ChatgptResponseEvent::ReasoningSummaryTextDelta { .. }
+        | ChatgptResponseEvent::ReasoningSummaryTextDone { .. }
+        | ChatgptResponseEvent::ReasoningTextDelta { .. }
+        | ChatgptResponseEvent::ReasoningTextDone { .. }
+        | ChatgptResponseEvent::Other(_) => FinalEventDisposition::NonTerminal,
+    }
 }
 
 fn insert_header(

--- a/crates/chatgpt-api/tests/public_api.rs
+++ b/crates/chatgpt-api/tests/public_api.rs
@@ -35,6 +35,7 @@ fn public_api_exposes_chatgpt_response_stream_types() {
         input: vec![ResponseItem::Message(MessageItem {
             id: Some("msg-1".to_owned()),
             status: Some("completed".to_owned()),
+            phase: Some("commentary".to_owned()),
             role: "user".to_owned(),
             content: vec![ContentItem::InputText {
                 text: "hello".to_owned(),
@@ -118,7 +119,7 @@ fn public_api_exposes_chatgpt_response_stream_types() {
     let reasoning_item = ResponseItem::Reasoning(ReasoningItem {
         id: Some("reasoning-1".to_owned()),
         status: Some("completed".to_owned()),
-        summary: serde_json::json!([{ "type": "summary_text", "text": "thinking" }]),
+        summary: Some(serde_json::json!([{ "type": "summary_text", "text": "thinking" }])),
         content: None,
         encrypted_content: Some("cipher".to_owned()),
     });

--- a/crates/chatgpt-api/tests/public_api.rs
+++ b/crates/chatgpt-api/tests/public_api.rs
@@ -1,0 +1,142 @@
+use std::time::Duration;
+
+use chatgpt_api::{
+    ChatgptApiEndpointError, ChatgptApiError, ChatgptApiLowerLayerError,
+    ChatgptFailedEndpointError, ChatgptFailedEndpointKind, ChatgptIncompleteEndpointError,
+    ChatgptModelCapabilities, ChatgptOtherEndpointError, ChatgptReasoningOptions,
+    ChatgptRequestContext, ChatgptResponseEvent, ChatgptResponseSnapshot, ChatgptResponseStream,
+    ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ChatgptUsage, ContentItem,
+    FunctionCallItem, FunctionCallOutputItem, JsonObject, MessageItem, OpaqueResponseItem,
+    ReasoningItem, RequestValidationError, ResponseItem, TextVerbosity, ToolDescriptor, ToolOutput,
+    stream,
+};
+
+#[test]
+fn public_api_exposes_chatgpt_response_stream_types() {
+    let json_object = JsonObject::new();
+    let request = ChatgptResponsesRequest {
+        model: "gpt-5".to_owned(),
+        model_capabilities: ChatgptModelCapabilities {
+            supports_reasoning_summaries: true,
+            supports_text_verbosity: true,
+            default_reasoning_effort: Some("medium".to_owned()),
+        },
+        context: ChatgptRequestContext {
+            conversation_id: "conversation-123".to_owned(),
+            window_generation: 2,
+            installation_id: "install-123".to_owned(),
+            turn_state: Some("turn-state".to_owned()),
+            turn_metadata: Some("{\"k\":\"v\"}".to_owned()),
+            beta_features: vec!["beta-a".to_owned()],
+            subagent: Some("planner".to_owned()),
+            parent_thread_id: Some("thread-123".to_owned()),
+        },
+        instructions: Some("follow instructions".to_owned()),
+        input: vec![ResponseItem::Message(MessageItem {
+            id: Some("msg-1".to_owned()),
+            status: Some("completed".to_owned()),
+            role: "user".to_owned(),
+            content: vec![ContentItem::InputText {
+                text: "hello".to_owned(),
+            }],
+        })],
+        tools: vec![ToolDescriptor(JsonObject::new())],
+        parallel_tool_calls: true,
+        reasoning: ChatgptReasoningOptions {
+            effort: Some("high".to_owned()),
+            summary: Some("detailed".to_owned()),
+        },
+        text: ChatgptTextOptions {
+            verbosity: Some(TextVerbosity::High),
+            json_schema: Some(JsonObject::new()),
+        },
+        service_tier: Some(ChatgptServiceTier::Fast),
+    };
+    let usage = ChatgptUsage {
+        input_tokens: Some(1),
+        cached_input_tokens: Some(2),
+        output_tokens: Some(3),
+        reasoning_output_tokens: Some(4),
+        total_tokens: Some(10),
+    };
+    let snapshot = ChatgptResponseSnapshot {
+        id: Some("resp-1".to_owned()),
+        model: Some("gpt-5".to_owned()),
+        usage: Some(usage),
+        service_tier: Some("priority".to_owned()),
+        raw: json_object.clone(),
+    };
+    let validation_error = RequestValidationError {
+        field: "model",
+        reason: "must not be blank".to_owned(),
+    };
+    let lower_error = ChatgptApiLowerLayerError::StreamCompletionTimeout {
+        timeout: Duration::from_secs(30),
+    };
+    let endpoint_error = ChatgptApiEndpointError::Failed(ChatgptFailedEndpointError {
+        kind: ChatgptFailedEndpointKind::InvalidPrompt,
+        response_id: Some("resp-1".to_owned()),
+        code: Some("invalid_prompt".to_owned()),
+        message: Some("bad prompt".to_owned()),
+        raw: json_object.clone(),
+    });
+    let other_endpoint_error =
+        ChatgptApiEndpointError::Incomplete(ChatgptIncompleteEndpointError {
+            response_id: Some("resp-1".to_owned()),
+            reason: Some("max_output_tokens".to_owned()),
+            raw: json_object.clone(),
+        });
+    let other = ChatgptApiEndpointError::Other(ChatgptOtherEndpointError {
+        event_type: Some("response.failed".to_owned()),
+        code: Some("server_overloaded".to_owned()),
+        message: Some("retry later".to_owned()),
+        retry_after: Some(Duration::from_secs(5)),
+        raw: json_object.clone(),
+    });
+    let event = ChatgptResponseEvent::Completed(snapshot);
+    let item = ResponseItem::FunctionCall(FunctionCallItem {
+        id: Some("call-item".to_owned()),
+        status: Some("completed".to_owned()),
+        name: "do_work".to_owned(),
+        namespace: Some("tools".to_owned()),
+        arguments: "{\"x\":1}".to_owned(),
+        call_id: "call-1".to_owned(),
+    });
+    let output_item = ResponseItem::FunctionCallOutput(FunctionCallOutputItem {
+        id: Some("call-output".to_owned()),
+        status: Some("completed".to_owned()),
+        call_id: "call-1".to_owned(),
+        output: ToolOutput::Text("done".to_owned()),
+    });
+    let reasoning_item = ResponseItem::Reasoning(ReasoningItem {
+        id: Some("reasoning-1".to_owned()),
+        status: Some("completed".to_owned()),
+        summary: serde_json::json!([{ "type": "summary_text", "text": "thinking" }]),
+        content: None,
+        encrypted_content: Some("cipher".to_owned()),
+    });
+    let opaque = ResponseItem::Opaque(OpaqueResponseItem { raw: json_object });
+
+    assert_eq!(request.model, "gpt-5");
+    assert!(matches!(
+        lower_error,
+        ChatgptApiLowerLayerError::StreamCompletionTimeout { .. }
+    ));
+    assert!(matches!(endpoint_error, ChatgptApiEndpointError::Failed(_)));
+    assert!(matches!(
+        other_endpoint_error,
+        ChatgptApiEndpointError::Incomplete(_)
+    ));
+    assert!(matches!(other, ChatgptApiEndpointError::Other(_)));
+    assert!(matches!(event, ChatgptResponseEvent::Completed(_)));
+    assert!(matches!(item, ResponseItem::FunctionCall(_)));
+    assert!(matches!(output_item, ResponseItem::FunctionCallOutput(_)));
+    assert!(matches!(reasoning_item, ResponseItem::Reasoning(_)));
+    assert!(matches!(opaque, ResponseItem::Opaque(_)));
+    assert_eq!(validation_error.field, "model");
+
+    let _ = ChatgptResponseStream::effective_turn_state;
+    let _ = ChatgptResponsesRequest::validate;
+    let _ = ChatgptApiError::LowerLayer(lower_error);
+    let _ = stream;
+}

--- a/crates/chatgpt-api/tests/public_api.rs
+++ b/crates/chatgpt-api/tests/public_api.rs
@@ -111,7 +111,7 @@ fn public_api_exposes_chatgpt_response_stream_types() {
     let reasoning_item = ResponseItem::Reasoning(ReasoningItem {
         id: Some("reasoning-1".to_owned()),
         status: Some("completed".to_owned()),
-        summary: serde_json::json!([{ "type": "summary_text", "text": "thinking" }]),
+        summary: Some(serde_json::json!([{ "type": "summary_text", "text": "thinking" }])),
         content: None,
         encrypted_content: Some("cipher".to_owned()),
     });

--- a/crates/chatgpt-api/tests/public_api.rs
+++ b/crates/chatgpt-api/tests/public_api.rs
@@ -6,9 +6,9 @@ use chatgpt_api::{
     ChatgptModelCapabilities, ChatgptOtherEndpointError, ChatgptReasoningOptions,
     ChatgptRequestContext, ChatgptResponseEvent, ChatgptResponseSnapshot, ChatgptResponseStream,
     ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ChatgptUsage, ContentItem,
-    CustomToolCallItem, FunctionCallItem, FunctionCallOutputItem, JsonObject, MessageItem,
-    OpaqueResponseItem, ReasoningItem, RequestValidationError, ResponseItem, TextVerbosity,
-    ToolDescriptor, ToolOutput, stream,
+    FunctionCallItem, FunctionCallOutputItem, JsonObject, MessageItem, OpaqueResponseItem,
+    ReasoningItem, RequestValidationError, ResponseItem, TextVerbosity, ToolDescriptor, ToolOutput,
+    stream,
 };
 
 #[test]
@@ -35,7 +35,6 @@ fn public_api_exposes_chatgpt_response_stream_types() {
         input: vec![ResponseItem::Message(MessageItem {
             id: Some("msg-1".to_owned()),
             status: Some("completed".to_owned()),
-            phase: Some("commentary".to_owned()),
             role: "user".to_owned(),
             content: vec![ContentItem::InputText {
                 text: "hello".to_owned(),
@@ -109,17 +108,10 @@ fn public_api_exposes_chatgpt_response_stream_types() {
         call_id: "call-1".to_owned(),
         output: ToolOutput::Text("done".to_owned()),
     });
-    let custom_tool_call = ResponseItem::CustomToolCall(CustomToolCallItem {
-        id: Some("custom-call".to_owned()),
-        status: Some("completed".to_owned()),
-        call_id: "custom-1".to_owned(),
-        name: "apply_patch".to_owned(),
-        input: "*** Begin Patch".to_owned(),
-    });
     let reasoning_item = ResponseItem::Reasoning(ReasoningItem {
         id: Some("reasoning-1".to_owned()),
         status: Some("completed".to_owned()),
-        summary: Some(serde_json::json!([{ "type": "summary_text", "text": "thinking" }])),
+        summary: serde_json::json!([{ "type": "summary_text", "text": "thinking" }]),
         content: None,
         encrypted_content: Some("cipher".to_owned()),
     });
@@ -139,7 +131,6 @@ fn public_api_exposes_chatgpt_response_stream_types() {
     assert!(matches!(event, ChatgptResponseEvent::Completed(_)));
     assert!(matches!(item, ResponseItem::FunctionCall(_)));
     assert!(matches!(output_item, ResponseItem::FunctionCallOutput(_)));
-    assert!(matches!(custom_tool_call, ResponseItem::CustomToolCall(_)));
     assert!(matches!(reasoning_item, ResponseItem::Reasoning(_)));
     assert!(matches!(opaque, ResponseItem::Opaque(_)));
     assert_eq!(validation_error.field, "model");

--- a/crates/chatgpt-api/tests/public_api.rs
+++ b/crates/chatgpt-api/tests/public_api.rs
@@ -6,9 +6,9 @@ use chatgpt_api::{
     ChatgptModelCapabilities, ChatgptOtherEndpointError, ChatgptReasoningOptions,
     ChatgptRequestContext, ChatgptResponseEvent, ChatgptResponseSnapshot, ChatgptResponseStream,
     ChatgptResponsesRequest, ChatgptServiceTier, ChatgptTextOptions, ChatgptUsage, ContentItem,
-    FunctionCallItem, FunctionCallOutputItem, JsonObject, MessageItem, OpaqueResponseItem,
-    ReasoningItem, RequestValidationError, ResponseItem, TextVerbosity, ToolDescriptor, ToolOutput,
-    stream,
+    CustomToolCallItem, FunctionCallItem, FunctionCallOutputItem, JsonObject, MessageItem,
+    OpaqueResponseItem, ReasoningItem, RequestValidationError, ResponseItem, TextVerbosity,
+    ToolDescriptor, ToolOutput, stream,
 };
 
 #[test]
@@ -108,6 +108,13 @@ fn public_api_exposes_chatgpt_response_stream_types() {
         call_id: "call-1".to_owned(),
         output: ToolOutput::Text("done".to_owned()),
     });
+    let custom_tool_call = ResponseItem::CustomToolCall(CustomToolCallItem {
+        id: Some("custom-call".to_owned()),
+        status: Some("completed".to_owned()),
+        call_id: "custom-1".to_owned(),
+        name: "apply_patch".to_owned(),
+        input: "*** Begin Patch".to_owned(),
+    });
     let reasoning_item = ResponseItem::Reasoning(ReasoningItem {
         id: Some("reasoning-1".to_owned()),
         status: Some("completed".to_owned()),
@@ -131,6 +138,7 @@ fn public_api_exposes_chatgpt_response_stream_types() {
     assert!(matches!(event, ChatgptResponseEvent::Completed(_)));
     assert!(matches!(item, ResponseItem::FunctionCall(_)));
     assert!(matches!(output_item, ResponseItem::FunctionCallOutput(_)));
+    assert!(matches!(custom_tool_call, ResponseItem::CustomToolCall(_)));
     assert!(matches!(reasoning_item, ResponseItem::Reasoning(_)));
     assert!(matches!(opaque, ResponseItem::Opaque(_)));
     assert_eq!(validation_error.field, "model");

--- a/crates/chatgpt-api/tests/public_api.rs
+++ b/crates/chatgpt-api/tests/public_api.rs
@@ -111,7 +111,7 @@ fn public_api_exposes_chatgpt_response_stream_types() {
     let reasoning_item = ResponseItem::Reasoning(ReasoningItem {
         id: Some("reasoning-1".to_owned()),
         status: Some("completed".to_owned()),
-        summary: Some(serde_json::json!([{ "type": "summary_text", "text": "thinking" }])),
+        summary: serde_json::json!([{ "type": "summary_text", "text": "thinking" }]),
         content: None,
         encrypted_content: Some("cipher".to_owned()),
     });

--- a/crates/chatgpt-api/tests/request_contract.rs
+++ b/crates/chatgpt-api/tests/request_contract.rs
@@ -26,7 +26,6 @@ fn base_request() -> ChatgptResponsesRequest {
         input: vec![ResponseItem::Message(MessageItem {
             id: Some("msg-1".to_owned()),
             status: Some("completed".to_owned()),
-            phase: Some("commentary".to_owned()),
             role: "user".to_owned(),
             content: vec![ContentItem::InputText {
                 text: "hello".to_owned(),

--- a/crates/chatgpt-api/tests/request_contract.rs
+++ b/crates/chatgpt-api/tests/request_contract.rs
@@ -1,0 +1,101 @@
+use chatgpt_api::{
+    ChatgptModelCapabilities, ChatgptReasoningOptions, ChatgptRequestContext,
+    ChatgptResponsesRequest, ChatgptTextOptions, ContentItem, JsonObject, MessageItem,
+    ResponseItem, TextVerbosity, ToolDescriptor,
+};
+
+fn base_request() -> ChatgptResponsesRequest {
+    ChatgptResponsesRequest {
+        model: "gpt-5".to_owned(),
+        model_capabilities: ChatgptModelCapabilities {
+            supports_reasoning_summaries: true,
+            supports_text_verbosity: true,
+            default_reasoning_effort: Some("medium".to_owned()),
+        },
+        context: ChatgptRequestContext {
+            conversation_id: "conversation-123".to_owned(),
+            window_generation: 1,
+            installation_id: "install-123".to_owned(),
+            turn_state: Some("turn-state".to_owned()),
+            turn_metadata: Some("{\"k\":\"v\"}".to_owned()),
+            beta_features: vec!["beta-a".to_owned()],
+            subagent: Some("planner".to_owned()),
+            parent_thread_id: Some("thread-123".to_owned()),
+        },
+        instructions: Some("follow instructions".to_owned()),
+        input: vec![ResponseItem::Message(MessageItem {
+            id: Some("msg-1".to_owned()),
+            status: Some("completed".to_owned()),
+            role: "user".to_owned(),
+            content: vec![ContentItem::InputText {
+                text: "hello".to_owned(),
+            }],
+        })],
+        tools: vec![ToolDescriptor(JsonObject::new())],
+        parallel_tool_calls: true,
+        reasoning: ChatgptReasoningOptions {
+            effort: Some("high".to_owned()),
+            summary: Some("detailed".to_owned()),
+        },
+        text: ChatgptTextOptions {
+            verbosity: Some(TextVerbosity::High),
+            json_schema: Some(JsonObject::new()),
+        },
+        service_tier: None,
+    }
+}
+
+#[test]
+fn request_validation_accepts_a_complete_request() {
+    let request = base_request();
+
+    request.validate().expect("valid request");
+}
+
+#[test]
+fn request_validation_rejects_reasoning_summary_for_unsupported_models() {
+    let mut request = base_request();
+    request.model_capabilities.supports_reasoning_summaries = false;
+
+    let error = request
+        .validate()
+        .expect_err("reasoning summary should be rejected");
+
+    assert_eq!(error.field, "reasoning.summary");
+}
+
+#[test]
+fn request_validation_rejects_verbosity_for_unsupported_models() {
+    let mut request = base_request();
+    request.model_capabilities.supports_text_verbosity = false;
+
+    let error = request
+        .validate()
+        .expect_err("verbosity should be rejected");
+
+    assert_eq!(error.field, "text.verbosity");
+}
+
+#[test]
+fn request_validation_rejects_header_unsafe_values() {
+    let mut request = base_request();
+    request.context.turn_metadata = Some("bad\r\nvalue".to_owned());
+
+    let error = request
+        .validate()
+        .expect_err("header unsafe values should be rejected");
+
+    assert_eq!(error.field, "context.turn_metadata");
+}
+
+#[test]
+fn request_validation_rejects_conversation_ids_with_colons() {
+    let mut request = base_request();
+    request.context.conversation_id = "conversation:123".to_owned();
+
+    let error = request
+        .validate()
+        .expect_err("conversation ids with colons should be rejected");
+
+    assert_eq!(error.field, "context.conversation_id");
+}

--- a/crates/chatgpt-api/tests/request_contract.rs
+++ b/crates/chatgpt-api/tests/request_contract.rs
@@ -26,6 +26,7 @@ fn base_request() -> ChatgptResponsesRequest {
         input: vec![ResponseItem::Message(MessageItem {
             id: Some("msg-1".to_owned()),
             status: Some("completed".to_owned()),
+            phase: Some("commentary".to_owned()),
             role: "user".to_owned(),
             content: vec![ContentItem::InputText {
                 text: "hello".to_owned(),

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -92,7 +92,7 @@ async fn stream_yields_events_and_updates_effective_turn_state() {
                     "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"text\":\"hello\"}\n\n",
                 ));
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
-                    "data: {\"type\":\"response.done\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"output_tokens\":2,\"output_token_details\":{\"reasoning_tokens\":3}}}}\n\n",
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"output_tokens\":2,\"output_token_details\":{\"reasoning_tokens\":3}}}}\n\n",
                 ));
             });
 
@@ -714,12 +714,12 @@ stream_completion_timeout_ms = 10
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn stream_accepts_done_event_at_eof_without_trailing_blank_line() {
+async fn stream_reports_premature_close_for_done_event_at_eof_without_trailing_blank_line() {
     const FLAG: &str = "CHATGPT_API_EOF_COMPLETED_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "stream_accepts_done_event_at_eof_without_trailing_blank_line",
+            "stream_reports_premature_close_for_done_event_at_eof_without_trailing_blank_line",
             FLAG,
         ));
         return;
@@ -775,11 +775,20 @@ base_url = "{}"
     let event = response_stream
         .next()
         .await
-        .expect("completed item")
-        .expect("completed event");
+        .expect("other item")
+        .expect("other event");
 
-    assert!(matches!(event, ChatgptResponseEvent::Completed(_)));
-    assert!(response_stream.next().await.is_none());
+    let error = response_stream
+        .next()
+        .await
+        .expect("premature close item")
+        .expect_err("done without completed must fail");
+
+    assert!(matches!(event, ChatgptResponseEvent::Other(_)));
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -483,12 +483,12 @@ base_url = "{}"
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn stream_allows_unknown_final_event_at_eof_without_premature_close() {
+async fn stream_reports_premature_close_for_unknown_final_event_at_eof() {
     const FLAG: &str = "CHATGPT_API_UNKNOWN_EOF_EVENT_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "stream_allows_unknown_final_event_at_eof_without_premature_close",
+            "stream_reports_premature_close_for_unknown_final_event_at_eof",
             FLAG,
         ));
         return;
@@ -541,23 +541,29 @@ base_url = "{}"
     );
 
     let mut response_stream = stream(base_request()).await.expect("open stream");
-    let event = response_stream
+    let event = response_stream.next().await.expect("other event");
+
+    assert!(matches!(event, Ok(ChatgptResponseEvent::Other(_))));
+
+    let error = response_stream
         .next()
         .await
-        .expect("other event")
-        .expect("other event value");
+        .expect("premature close item")
+        .expect_err("unknown trailing event must still fail at eof");
 
-    assert!(matches!(event, ChatgptResponseEvent::Other(_)));
-    assert!(response_stream.next().await.is_none());
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn stream_allows_delimited_unknown_final_event_without_premature_close() {
+async fn stream_reports_premature_close_for_delimited_unknown_final_event() {
     const FLAG: &str = "CHATGPT_API_DELIMITED_UNKNOWN_EOF_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "stream_allows_delimited_unknown_final_event_without_premature_close",
+            "stream_reports_premature_close_for_delimited_unknown_final_event",
             FLAG,
         ));
         return;
@@ -610,14 +616,20 @@ base_url = "{}"
     );
 
     let mut response_stream = stream(base_request()).await.expect("open stream");
-    let event = response_stream
+    let event = response_stream.next().await.expect("other event");
+
+    assert!(matches!(event, Ok(ChatgptResponseEvent::Other(_))));
+
+    let error = response_stream
         .next()
         .await
-        .expect("other event")
-        .expect("other event value");
+        .expect("premature close item")
+        .expect_err("unknown trailing event must still fail after delimiter");
 
-    assert!(matches!(event, ChatgptResponseEvent::Other(_)));
-    assert!(response_stream.next().await.is_none());
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -563,6 +563,162 @@ stream_completion_timeout_ms = 10
     ));
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_accepts_completed_event_at_eof_without_trailing_blank_line() {
+    const FLAG: &str = "CHATGPT_API_EOF_COMPLETED_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_accepts_completed_event_at_eof_without_trailing_blank_line",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let event = response_stream
+        .next()
+        .await
+        .expect("completed item")
+        .expect("completed event");
+
+    assert!(matches!(event, ChatgptResponseEvent::Completed(_)));
+    assert!(response_stream.next().await.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_reports_timeout_after_channel_backpressure() {
+    const FLAG: &str = "CHATGPT_API_BACKPRESSURE_TIMEOUT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_reports_timeout_after_channel_backpressure",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                for index in 0..40_u64 {
+                    yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(format!(
+                        "data: {{\"type\":\"response.output_text.delta\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":{},\"delta\":\"x\"}}\n\n",
+                        index
+                    )));
+                }
+                sleep(Duration::from_millis(50)).await;
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+stream_completion_timeout_ms = 10
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    sleep(Duration::from_millis(30)).await;
+
+    let mut received = 0_u64;
+    let mut timeout_seen = false;
+    while let Some(item) = response_stream.next().await {
+        match item {
+            Ok(ChatgptResponseEvent::OutputTextDelta { .. }) => {
+                received += 1;
+            }
+            Err(ChatgptApiError::LowerLayer(
+                chatgpt_api::ChatgptApiLowerLayerError::StreamCompletionTimeout { .. },
+            )) => {
+                timeout_seen = true;
+                break;
+            }
+            other => panic!("unexpected stream item: {other:?}"),
+        }
+    }
+
+    assert!(received >= 32);
+    assert!(timeout_seen);
+}
+
 fn auth_file_json(id_token: &str, access_token: &str, refresh_token: &str) -> String {
     json!({
         "schema_version": 1,

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -412,6 +412,77 @@ base_url = "{}"
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_maps_top_level_error_events_to_endpoint_errors() {
+    const FLAG: &str = "CHATGPT_API_TOP_LEVEL_ERROR_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_maps_top_level_error_events_to_endpoint_errors",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"error\",\"code\":\"server_busy\",\"message\":\"try again in 7 seconds\"}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let error = response_stream
+        .next()
+        .await
+        .expect("error item")
+        .expect_err("top-level error must fail");
+
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::Other(_))
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_reports_completion_timeout() {
     const FLAG: &str = "CHATGPT_API_COMPLETION_TIMEOUT_CHILD";
 

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -80,7 +80,7 @@ async fn stream_yields_events_and_updates_effective_turn_state() {
         post(|| async {
             let body = Body::from_stream(async_stream::stream! {
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
-                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"input_tokens\":1,\"input_tokens_details\":{\"cached_tokens\":2}}}}\n\n",
+                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"input_tokens\":1,\"input_token_details\":{\"cached_tokens\":2}}}}\n\n",
                 ));
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from_static(
                     b"data: {\"type\":\"response.output_text.delta\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"delta\":\"\xE4",
@@ -92,7 +92,7 @@ async fn stream_yields_events_and_updates_effective_turn_state() {
                     "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"text\":\"hello\"}\n\n",
                 ));
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
-                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"output_tokens\":2,\"output_tokens_details\":{\"reasoning_tokens\":3}}}}\n\n",
+                    "data: {\"type\":\"response.done\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"output_tokens\":2,\"output_token_details\":{\"reasoning_tokens\":3}}}}\n\n",
                 ));
             });
 
@@ -702,12 +702,12 @@ stream_completion_timeout_ms = 10
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn stream_accepts_completed_event_at_eof_without_trailing_blank_line() {
+async fn stream_accepts_done_event_at_eof_without_trailing_blank_line() {
     const FLAG: &str = "CHATGPT_API_EOF_COMPLETED_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "stream_accepts_completed_event_at_eof_without_trailing_blank_line",
+            "stream_accepts_done_event_at_eof_without_trailing_blank_line",
             FLAG,
         ));
         return;
@@ -718,7 +718,7 @@ async fn stream_accepts_completed_event_at_eof_without_trailing_blank_line() {
         post(|| async {
             let body = Body::from_stream(async_stream::stream! {
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
-                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}",
+                    "data: {\"type\":\"response.done\",\"response\":{\"id\":\"resp-1\"}}",
                 ));
             });
 

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -47,7 +47,6 @@ fn base_request() -> ChatgptResponsesRequest {
         input: vec![ResponseItem::Message(MessageItem {
             id: Some("msg-1".to_owned()),
             status: Some("completed".to_owned()),
-            phase: Some("commentary".to_owned()),
             role: "user".to_owned(),
             content: vec![ContentItem::InputText {
                 text: "hello".to_owned(),

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -633,6 +633,86 @@ base_url = "{}"
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_reports_premature_close_after_non_terminal_final_frame_at_eof() {
+    const FLAG: &str = "CHATGPT_API_EOF_NON_TERMINAL_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_reports_premature_close_after_non_terminal_final_frame_at_eof",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"delta\":\"x\"}",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let event = response_stream
+        .next()
+        .await
+        .expect("delta item")
+        .expect("delta event");
+    let error = response_stream
+        .next()
+        .await
+        .expect("premature close item")
+        .expect_err("non-terminal EOF must fail");
+
+    assert!(matches!(
+        event,
+        ChatgptResponseEvent::OutputTextDelta { .. }
+    ));
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_reports_timeout_after_channel_backpressure() {
     const FLAG: &str = "CHATGPT_API_BACKPRESSURE_TIMEOUT_CHILD";
 
@@ -717,6 +797,88 @@ stream_completion_timeout_ms = 10
 
     assert!(received >= 32);
     assert!(timeout_seen);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_overrides_short_global_request_timeout() {
+    const FLAG: &str = "CHATGPT_API_OVERRIDE_GLOBAL_TIMEOUT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_overrides_short_global_request_timeout",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+                ));
+                sleep(Duration::from_millis(25)).await;
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[network]
+request_timeout_ms = 5
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+stream_completion_timeout_ms = 100
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let first = response_stream
+        .next()
+        .await
+        .expect("created item")
+        .expect("created event");
+    let second = response_stream
+        .next()
+        .await
+        .expect("completed item")
+        .expect("completed event");
+
+    assert!(matches!(first, ChatgptResponseEvent::Created(_)));
+    assert!(matches!(second, ChatgptResponseEvent::Completed(_)));
 }
 
 fn auth_file_json(id_token: &str, access_token: &str, refresh_token: &str) -> String {

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -217,7 +217,7 @@ async fn stream_reauthenticates_once_after_unauthorized() {
 
                         (
                             StatusCode::OK,
-                            [(http::header::CONTENT_TYPE, HeaderValue::from_static("text/event-stream"))],
+                            [(http::header::CONTENT_TYPE, HeaderValue::from_static("Text/Event-Stream"))],
                             body,
                         )
                     },

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -950,12 +950,12 @@ stream_completion_timeout_ms = 10
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn stream_overrides_short_global_request_timeout() {
+async fn stream_preserves_short_global_request_timeout_before_open() {
     const FLAG: &str = "CHATGPT_API_OVERRIDE_GLOBAL_TIMEOUT_CHILD";
 
     if !child_mode(FLAG) {
         assert_child_success(&run_child(
-            "stream_overrides_short_global_request_timeout",
+            "stream_preserves_short_global_request_timeout_before_open",
             FLAG,
         ));
         return;
@@ -964,11 +964,11 @@ async fn stream_overrides_short_global_request_timeout() {
     let api_server = spawn_http_server(Router::new().route(
         "/responses",
         post(|| async {
+            sleep(Duration::from_millis(25)).await;
             let body = Body::from_stream(async_stream::stream! {
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
                     "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n",
                 ));
-                sleep(Duration::from_millis(25)).await;
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
                     "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
                 ));
@@ -1015,20 +1015,17 @@ stream_completion_timeout_ms = 100
         ),
     );
 
-    let mut response_stream = stream(base_request()).await.expect("open stream");
-    let first = response_stream
-        .next()
-        .await
-        .expect("created item")
-        .expect("created event");
-    let second = response_stream
-        .next()
-        .await
-        .expect("completed item")
-        .expect("completed event");
+    let error = match stream(base_request()).await {
+        Ok(_) => panic!("short global request timeout must still apply before open"),
+        Err(error) => error,
+    };
 
-    assert!(matches!(first, ChatgptResponseEvent::Created(_)));
-    assert!(matches!(second, ChatgptResponseEvent::Completed(_)));
+    assert!(matches!(
+        error,
+        ChatgptApiError::LowerLayer(chatgpt_api::ChatgptApiLowerLayerError::Client(
+            selvedge_client::HttpError::Timeout
+        ))
+    ));
 }
 
 fn auth_file_json(id_token: &str, access_token: &str, refresh_token: &str) -> String {

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -553,6 +553,75 @@ base_url = "{}"
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_allows_delimited_unknown_final_event_without_premature_close() {
+    const FLAG: &str = "CHATGPT_API_DELIMITED_UNKNOWN_EOF_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_allows_delimited_unknown_final_event_without_premature_close",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.future_terminal\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let event = response_stream
+        .next()
+        .await
+        .expect("other event")
+        .expect("other event value");
+
+    assert!(matches!(event, ChatgptResponseEvent::Other(_)));
+    assert!(response_stream.next().await.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_reports_completion_timeout() {
     const FLAG: &str = "CHATGPT_API_COMPLETION_TIMEOUT_CHILD";
 

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -1,0 +1,506 @@
+mod support;
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode},
+    routing::post,
+};
+use base64::Engine;
+use chatgpt_api::{
+    ChatgptApiEndpointError, ChatgptApiError, ChatgptModelCapabilities, ChatgptReasoningOptions,
+    ChatgptRequestContext, ChatgptResponseEvent, ChatgptResponsesRequest, ChatgptTextOptions,
+    ContentItem, MessageItem, ResponseItem, stream,
+};
+use futures::StreamExt;
+use serde_json::json;
+use support::{
+    assert_child_success, child_mode, init_api_test, run_child, spawn_http_server, write_auth_file,
+};
+use tokio::time::{Duration, sleep};
+
+fn base_request() -> ChatgptResponsesRequest {
+    ChatgptResponsesRequest {
+        model: "gpt-5".to_owned(),
+        model_capabilities: ChatgptModelCapabilities {
+            supports_reasoning_summaries: true,
+            supports_text_verbosity: true,
+            default_reasoning_effort: Some("medium".to_owned()),
+        },
+        context: ChatgptRequestContext {
+            conversation_id: "conversation-123".to_owned(),
+            window_generation: 1,
+            installation_id: "install-123".to_owned(),
+            turn_state: Some("turn-state".to_owned()),
+            turn_metadata: None,
+            beta_features: vec![],
+            subagent: None,
+            parent_thread_id: None,
+        },
+        instructions: Some("follow instructions".to_owned()),
+        input: vec![ResponseItem::Message(MessageItem {
+            id: Some("msg-1".to_owned()),
+            status: Some("completed".to_owned()),
+            role: "user".to_owned(),
+            content: vec![ContentItem::InputText {
+                text: "hello".to_owned(),
+            }],
+        })],
+        tools: vec![],
+        parallel_tool_calls: true,
+        reasoning: ChatgptReasoningOptions {
+            effort: Some("high".to_owned()),
+            summary: Some("detailed".to_owned()),
+        },
+        text: ChatgptTextOptions::default(),
+        service_tier: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_yields_events_and_updates_effective_turn_state() {
+    const FLAG: &str = "CHATGPT_API_STREAM_SUCCESS_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_yields_events_and_updates_effective_turn_state",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"input_tokens\":1}}}\n\n",
+                ));
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"delta\":\"hel\"}\n\n",
+                ));
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"text\":\"hello\"}\n\n",
+                ));
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"output_tokens\":2}}}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [
+                    (
+                        http::header::CONTENT_TYPE,
+                        HeaderValue::from_static("text/event-stream"),
+                    ),
+                    (
+                        http::header::HeaderName::from_static("x-codex-turn-state"),
+                        HeaderValue::from_static("turn-state-next"),
+                    ),
+                ],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    assert_eq!(
+        response_stream.effective_turn_state(),
+        Some("turn-state-next")
+    );
+
+    let mut events = Vec::new();
+    while let Some(item) = response_stream.next().await {
+        events.push(item.expect("event should be ok"));
+    }
+
+    assert!(matches!(
+        events.first(),
+        Some(ChatgptResponseEvent::Created(_))
+    ));
+    assert!(matches!(
+        events.get(1),
+        Some(ChatgptResponseEvent::OutputTextDelta { delta, .. }) if delta == "hel"
+    ));
+    assert!(matches!(
+        events.get(2),
+        Some(ChatgptResponseEvent::OutputTextDone { text, .. }) if text == "hello"
+    ));
+    assert!(matches!(
+        events.last(),
+        Some(ChatgptResponseEvent::Completed(_))
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_reauthenticates_once_after_unauthorized() {
+    const FLAG: &str = "CHATGPT_API_STREAM_REAUTH_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_reauthenticates_once_after_unauthorized",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_hits = Arc::new(AtomicUsize::new(0));
+    let api_hits_for_state = Arc::clone(&api_hits);
+    let api_server = spawn_http_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(
+                    |State(hits): State<Arc<AtomicUsize>>, headers: HeaderMap| async move {
+                        let hit_number = hits.fetch_add(1, Ordering::SeqCst);
+                        let auth_header = headers
+                            .get(http::header::AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_owned();
+
+                        if hit_number == 0 && auth_header == "Bearer stale-access-token" {
+                            return (
+                                StatusCode::UNAUTHORIZED,
+                                [(http::header::CONTENT_TYPE, HeaderValue::from_static("application/json"))],
+                                Body::from("{\"error\":\"expired\"}"),
+                            );
+                        }
+
+                        let body = Body::from_stream(async_stream::stream! {
+                            yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                                "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+                            ));
+                        });
+
+                        (
+                            StatusCode::OK,
+                            [(http::header::CONTENT_TYPE, HeaderValue::from_static("text/event-stream"))],
+                            body,
+                        )
+                    },
+                ),
+            )
+            .with_state(api_hits_for_state),
+    )
+    .await;
+
+    let refresh_hits = Arc::new(AtomicUsize::new(0));
+    let refresh_hits_for_state = Arc::clone(&refresh_hits);
+    let auth_server = spawn_http_server(
+        Router::new()
+            .route(
+                "/oauth/token",
+                post(|State(hits): State<Arc<AtomicUsize>>| async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    Json(json!({
+                        "id_token": build_jwt(json!({
+                            "sub": "subject",
+                            "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+                        })),
+                        "access_token": "fresh-access-token"
+                    }))
+                }),
+            )
+            .with_state(refresh_hits_for_state),
+    )
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "{}"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        auth_server.url(""),
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "stale-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let event = response_stream
+        .next()
+        .await
+        .expect("completed item")
+        .expect("completed event");
+
+    assert!(matches!(event, ChatgptResponseEvent::Completed(_)));
+    assert_eq!(api_hits.load(Ordering::SeqCst), 2);
+    assert_eq!(refresh_hits.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_rejects_non_sse_response_heads() {
+    const FLAG: &str = "CHATGPT_API_BAD_HEAD_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("stream_rejects_non_sse_response_heads", FLAG));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            (
+                StatusCode::OK,
+                [(http::header::CONTENT_TYPE, "application/json")],
+                "{}",
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let error = match stream(base_request()).await {
+        Ok(_) => panic!("bad head must fail"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedResponseHead { .. })
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_reports_malformed_events() {
+    const FLAG: &str = "CHATGPT_API_MALFORMED_EVENT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("stream_reports_malformed_events", FLAG));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"item-1\"}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let error = response_stream
+        .next()
+        .await
+        .expect("error item")
+        .expect_err("malformed event must fail");
+
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::MalformedEvent { .. })
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_reports_completion_timeout() {
+    const FLAG: &str = "CHATGPT_API_COMPLETION_TIMEOUT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child("stream_reports_completion_timeout", FLAG));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+                ));
+                sleep(Duration::from_millis(50)).await;
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+stream_completion_timeout_ms = 10
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let _created = response_stream
+        .next()
+        .await
+        .expect("created item")
+        .expect("created event");
+
+    let error = response_stream
+        .next()
+        .await
+        .expect("timeout item")
+        .expect_err("completion timeout must fail");
+
+    assert!(matches!(
+        error,
+        ChatgptApiError::LowerLayer(
+            chatgpt_api::ChatgptApiLowerLayerError::StreamCompletionTimeout { .. }
+        )
+    ));
+}
+
+fn auth_file_json(id_token: &str, access_token: &str, refresh_token: &str) -> String {
+    json!({
+        "schema_version": 1,
+        "provider": "chatgpt",
+        "login_method": "device_code",
+        "tokens": {
+            "id_token": id_token,
+            "access_token": access_token,
+            "refresh_token": refresh_token
+        }
+    })
+    .to_string()
+}
+
+fn build_jwt(payload: serde_json::Value) -> String {
+    let engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = engine.encode(r#"{"alg":"none","typ":"JWT"}"#);
+    let payload = engine.encode(payload.to_string());
+
+    format!("{header}.{payload}.signature")
+}

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -934,7 +934,7 @@ stream_completion_timeout_ms = 10
         }
     }
 
-    assert!(received >= 32);
+    assert!(received > 0);
     assert!(timeout_seen);
 }
 

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -80,16 +80,19 @@ async fn stream_yields_events_and_updates_effective_turn_state() {
         post(|| async {
             let body = Body::from_stream(async_stream::stream! {
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
-                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"input_tokens\":1}}}\n\n",
+                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"input_tokens\":1,\"input_tokens_details\":{\"cached_tokens\":2}}}}\n\n",
                 ));
-                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
-                    "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"delta\":\"hel\"}\n\n",
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from_static(
+                    b"data: {\"type\":\"response.output_text.delta\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"delta\":\"\xE4",
+                ));
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from_static(
+                    b"\xBD\xA0\xE5\xA5\xBD\"}\n\n",
                 ));
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
                     "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"text\":\"hello\"}\n\n",
                 ));
                 yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
-                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"output_tokens\":2}}}\n\n",
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"service_tier\":\"default\",\"usage\":{\"output_tokens\":2,\"output_tokens_details\":{\"reasoning_tokens\":3}}}}\n\n",
                 ));
             });
 
@@ -152,8 +155,13 @@ base_url = "{}"
         Some(ChatgptResponseEvent::Created(_))
     ));
     assert!(matches!(
+        events.first(),
+        Some(ChatgptResponseEvent::Created(snapshot))
+            if snapshot.usage.as_ref().is_some_and(|usage| usage.cached_input_tokens == Some(2))
+    ));
+    assert!(matches!(
         events.get(1),
-        Some(ChatgptResponseEvent::OutputTextDelta { delta, .. }) if delta == "hel"
+        Some(ChatgptResponseEvent::OutputTextDelta { delta, .. }) if delta == "你好"
     ));
     assert!(matches!(
         events.get(2),
@@ -161,7 +169,8 @@ base_url = "{}"
     ));
     assert!(matches!(
         events.last(),
-        Some(ChatgptResponseEvent::Completed(_))
+        Some(ChatgptResponseEvent::Completed(snapshot))
+            if snapshot.usage.as_ref().is_some_and(|usage| usage.reasoning_output_tokens == Some(3))
     ));
 }
 

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -783,6 +783,87 @@ base_url = "{}"
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_reports_premature_close_after_comment_only_final_frame_at_eof() {
+    const FLAG: &str = "CHATGPT_API_EOF_COMMENT_ONLY_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_reports_premature_close_after_comment_only_final_frame_at_eof",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+                ));
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    ": keepalive",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let event = response_stream
+        .next()
+        .await
+        .expect("created item")
+        .expect("created event");
+    assert!(matches!(event, ChatgptResponseEvent::Created(_)));
+
+    let error = response_stream
+        .next()
+        .await
+        .expect("premature close item")
+        .expect_err("comment-only eof must fail");
+
+    assert!(matches!(
+        error,
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::PrematureClose)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_reports_premature_close_after_non_terminal_final_frame_at_eof() {
     const FLAG: &str = "CHATGPT_API_EOF_NON_TERMINAL_CHILD";
 

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -484,6 +484,75 @@ base_url = "{}"
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_allows_unknown_final_event_at_eof_without_premature_close() {
+    const FLAG: &str = "CHATGPT_API_UNKNOWN_EOF_EVENT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "stream_allows_unknown_final_event_at_eof_without_premature_close",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.future_terminal\",\"response\":{\"id\":\"resp-1\"}}",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[logging]
+level = "debug"
+
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut response_stream = stream(base_request()).await.expect("open stream");
+    let event = response_stream
+        .next()
+        .await
+        .expect("other event")
+        .expect("other event value");
+
+    assert!(matches!(event, ChatgptResponseEvent::Other(_)));
+    assert!(response_stream.next().await.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_reports_completion_timeout() {
     const FLAG: &str = "CHATGPT_API_COMPLETION_TIMEOUT_CHILD";
 

--- a/crates/chatgpt-api/tests/stream_integration.rs
+++ b/crates/chatgpt-api/tests/stream_integration.rs
@@ -47,6 +47,7 @@ fn base_request() -> ChatgptResponsesRequest {
         input: vec![ResponseItem::Message(MessageItem {
             id: Some("msg-1".to_owned()),
             status: Some("completed".to_owned()),
+            phase: Some("commentary".to_owned()),
             role: "user".to_owned(),
             content: vec![ContentItem::InputText {
                 text: "hello".to_owned(),

--- a/crates/chatgpt-api/tests/support/mod.rs
+++ b/crates/chatgpt-api/tests/support/mod.rs
@@ -1,0 +1,83 @@
+use std::{
+    net::SocketAddr,
+    process::{Command, Output},
+};
+
+use axum::Router;
+use tempfile::TempDir;
+use tokio::{net::TcpListener, task::JoinHandle};
+
+pub fn child_mode(flag: &str) -> bool {
+    std::env::var_os(flag).is_some()
+}
+
+pub fn run_child(test_name: &str, flag: &str) -> Output {
+    let current_executable = std::env::current_exe().expect("current test executable");
+
+    Command::new(current_executable)
+        .arg("--exact")
+        .arg(test_name)
+        .env(flag, "1")
+        .output()
+        .expect("run child test")
+}
+
+pub fn assert_child_success(output: &Output) {
+    assert!(output.status.success(), "child test failed: {output:?}");
+}
+
+pub fn init_api_test(config_body: &str) -> TempDir {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_home = tempdir.path().join(".selvedge");
+    let config_path = config_home.join("config.toml");
+
+    std::fs::create_dir_all(&config_home).expect("create config home");
+    std::fs::write(&config_path, config_body).expect("write config");
+
+    selvedge_config::init_with_home(&config_home).expect("init config");
+    selvedge_logging::init().expect("init logging");
+
+    tempdir
+}
+
+pub fn write_auth_file(tempdir: &TempDir, auth_file_body: &str) -> std::path::PathBuf {
+    let auth_file_path = tempdir.path().join(".selvedge/auth/chatgpt-auth.json");
+    std::fs::create_dir_all(
+        auth_file_path
+            .parent()
+            .expect("auth file path must have parent"),
+    )
+    .expect("create auth dir");
+    std::fs::write(&auth_file_path, auth_file_body).expect("write auth file");
+
+    auth_file_path
+}
+
+pub struct TestServer {
+    pub addr: SocketAddr,
+    handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    pub fn url(&self, path: &str) -> String {
+        format!("http://{}{}", self.addr, path)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+pub async fn spawn_http_server(router: Router) -> TestServer {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve test app");
+    });
+
+    TestServer { addr, handle }
+}

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -307,7 +307,7 @@ fn ensure_explicit_authority(
         return Err(invalid_url_error);
     };
 
-    if !matches!(scheme, "http" | "https") {
+    if !matches!(scheme.to_ascii_lowercase().as_str(), "http" | "https") {
         return Err(invalid_url_error);
     }
 

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -209,6 +209,7 @@ impl ChatgptAuthConfig {
     pub fn validate(&self) -> Result<(), ValidationError> {
         let issuer =
             url::Url::parse(&self.issuer).map_err(|_| ValidationError::InvalidChatgptIssuer)?;
+        ensure_explicit_authority(&self.issuer, &issuer, ValidationError::InvalidChatgptIssuer)?;
 
         validate_base_url_scheme_and_authority(
             &issuer,
@@ -251,6 +252,11 @@ impl ChatgptApiConfig {
     pub fn validate(&self) -> Result<(), ValidationError> {
         let base_url = url::Url::parse(&self.base_url)
             .map_err(|_| ValidationError::InvalidChatgptApiBaseUrl)?;
+        ensure_explicit_authority(
+            &self.base_url,
+            &base_url,
+            ValidationError::InvalidChatgptApiBaseUrl,
+        )?;
 
         validate_base_url_scheme_and_authority(
             &base_url,
@@ -287,6 +293,28 @@ fn validate_base_url_scheme_and_authority(
 
     if url.scheme() == "http" && !issuer_host_is_loopback(url) {
         return Err(https_required_error);
+    }
+
+    Ok(())
+}
+
+fn ensure_explicit_authority(
+    raw: &str,
+    url: &url::Url,
+    invalid_url_error: ValidationError,
+) -> Result<(), ValidationError> {
+    let Some((scheme, remainder)) = raw.split_once("://") else {
+        return Err(invalid_url_error);
+    };
+
+    if !matches!(scheme, "http" | "https") {
+        return Err(invalid_url_error);
+    }
+
+    let authority = remainder.split(['/', '?', '#']).next().unwrap_or_default();
+
+    if authority.is_empty() || authority.starts_with('/') || url.host().is_none() {
+        return Err(invalid_url_error);
     }
 
     Ok(())

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -186,11 +186,12 @@ impl LlmProvidersConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ChatgptConfig {
     pub auth: ChatgptAuthConfig,
+    pub api: ChatgptApiConfig,
 }
 
 impl ChatgptConfig {
     pub fn validate(&self) -> Result<(), ValidationError> {
-        self.auth.validate()
+        self.auth.validate().and_then(|_| self.api.validate())
     }
 }
 
@@ -209,17 +210,12 @@ impl ChatgptAuthConfig {
         let issuer =
             url::Url::parse(&self.issuer).map_err(|_| ValidationError::InvalidChatgptIssuer)?;
 
-        if !matches!(issuer.scheme(), "http" | "https") {
-            return Err(ValidationError::InvalidChatgptIssuer);
-        }
-
-        if !issuer.username().is_empty() || issuer.password().is_some() {
-            return Err(ValidationError::ChatgptIssuerMustNotContainUserinfo);
-        }
-
-        if issuer.scheme() == "http" && !issuer_host_is_loopback(&issuer) {
-            return Err(ValidationError::ChatgptIssuerMustUseHttps);
-        }
+        validate_base_url_scheme_and_authority(
+            &issuer,
+            ValidationError::InvalidChatgptIssuer,
+            ValidationError::ChatgptIssuerMustNotContainUserinfo,
+            ValidationError::ChatgptIssuerMustUseHttps,
+        )?;
 
         let clean_path = issuer.path().is_empty() || issuer.path() == "/";
         if !clean_path || issuer.query().is_some() || issuer.fragment().is_some() {
@@ -240,6 +236,60 @@ impl ChatgptAuthConfig {
 
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChatgptApiConfig {
+    pub base_url: String,
+    pub stream_completion_timeout_ms: u64,
+}
+
+impl ChatgptApiConfig {
+    const DEFAULT_BASE_URL: &'static str = "https://chatgpt.com/backend-api/codex";
+    const DEFAULT_STREAM_COMPLETION_TIMEOUT_MS: u64 = 1_800_000;
+
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        let base_url = url::Url::parse(&self.base_url)
+            .map_err(|_| ValidationError::InvalidChatgptApiBaseUrl)?;
+
+        validate_base_url_scheme_and_authority(
+            &base_url,
+            ValidationError::InvalidChatgptApiBaseUrl,
+            ValidationError::ChatgptApiBaseUrlMustNotContainUserinfo,
+            ValidationError::ChatgptApiBaseUrlMustUseHttps,
+        )?;
+
+        if base_url.query().is_some() || base_url.fragment().is_some() {
+            return Err(ValidationError::ChatgptApiBaseUrlMustBeBaseUrl);
+        }
+
+        if self.stream_completion_timeout_ms == 0 {
+            return Err(ValidationError::InvalidChatgptApiStreamCompletionTimeout);
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_base_url_scheme_and_authority(
+    url: &url::Url,
+    invalid_url_error: ValidationError,
+    userinfo_error: ValidationError,
+    https_required_error: ValidationError,
+) -> Result<(), ValidationError> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(invalid_url_error);
+    }
+
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(userinfo_error);
+    }
+
+    if url.scheme() == "http" && !issuer_host_is_loopback(url) {
+        return Err(https_required_error);
+    }
+
+    Ok(())
 }
 
 fn issuer_host_is_loopback(issuer: &url::Url) -> bool {
@@ -289,6 +339,16 @@ pub enum ValidationError {
     BlankChatgptClientId,
     #[error("llm.providers.chatgpt.auth.expected_workspace_id must not be blank")]
     BlankExpectedWorkspaceId,
+    #[error("llm.providers.chatgpt.api.base_url must be an absolute http or https URL")]
+    InvalidChatgptApiBaseUrl,
+    #[error("llm.providers.chatgpt.api.base_url must use https unless it targets a loopback host")]
+    ChatgptApiBaseUrlMustUseHttps,
+    #[error("llm.providers.chatgpt.api.base_url must not contain userinfo")]
+    ChatgptApiBaseUrlMustNotContainUserinfo,
+    #[error("llm.providers.chatgpt.api.base_url must be a clean base URL")]
+    ChatgptApiBaseUrlMustBeBaseUrl,
+    #[error("llm.providers.chatgpt.api.stream_completion_timeout_ms must be greater than zero")]
+    InvalidChatgptApiStreamCompletionTimeout,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -426,12 +486,14 @@ impl LlmProvidersConfigInput {
 #[serde(default, deny_unknown_fields)]
 struct ChatgptConfigInput {
     auth: ChatgptAuthConfigInput,
+    api: ChatgptApiConfigInput,
 }
 
 impl ChatgptConfigInput {
     fn materialize(self) -> ChatgptConfig {
         ChatgptConfig {
             auth: self.auth.materialize(),
+            api: self.api.materialize(),
         }
     }
 }
@@ -454,6 +516,26 @@ impl ChatgptAuthConfigInput {
                 .client_id
                 .unwrap_or_else(|| ChatgptAuthConfig::DEFAULT_CLIENT_ID.to_owned()),
             expected_workspace_id: self.expected_workspace_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct ChatgptApiConfigInput {
+    base_url: Option<String>,
+    stream_completion_timeout_ms: Option<u64>,
+}
+
+impl ChatgptApiConfigInput {
+    fn materialize(self) -> ChatgptApiConfig {
+        ChatgptApiConfig {
+            base_url: self
+                .base_url
+                .unwrap_or_else(|| ChatgptApiConfig::DEFAULT_BASE_URL.to_owned()),
+            stream_completion_timeout_ms: self
+                .stream_completion_timeout_ms
+                .unwrap_or(ChatgptApiConfig::DEFAULT_STREAM_COMPLETION_TIMEOUT_MS),
         }
     }
 }

--- a/crates/config-model/src/lib.rs
+++ b/crates/config-model/src/lib.rs
@@ -269,6 +269,14 @@ impl ChatgptApiConfig {
             return Err(ValidationError::ChatgptApiBaseUrlMustBeBaseUrl);
         }
 
+        if base_url
+            .path()
+            .trim_end_matches('/')
+            .ends_with("/responses")
+        {
+            return Err(ValidationError::ChatgptApiBaseUrlMustBeBaseUrl);
+        }
+
         if self.stream_completion_timeout_ms == 0 {
             return Err(ValidationError::InvalidChatgptApiStreamCompletionTimeout);
         }

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -266,6 +266,22 @@ fn chatgpt_api_rejects_base_url_with_query_or_fragment() {
 }
 
 #[test]
+fn chatgpt_api_rejects_base_url_that_already_includes_responses_path() {
+    let config_table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "https://chatgpt.com/backend-api/codex/responses"
+    };
+
+    let error =
+        AppConfig::try_from(config_table).expect_err("base url ending in /responses must fail");
+
+    assert_eq!(
+        error.to_string(),
+        "llm.providers.chatgpt.api.base_url must be a clean base URL"
+    );
+}
+
+#[test]
 fn chatgpt_api_rejects_blank_or_zero_timeout() {
     let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
     config

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -193,6 +193,32 @@ fn chatgpt_api_rejects_non_loopback_http_base_url() {
 }
 
 #[test]
+fn chatgpt_api_rejects_base_url_without_authority() {
+    let missing_authority_table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "https:///backend-api/codex"
+    };
+    let relative_authority_table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "https:backend-api/codex"
+    };
+
+    let missing_authority_error = AppConfig::try_from(missing_authority_table)
+        .expect_err("base url without authority must fail");
+    let relative_authority_error = AppConfig::try_from(relative_authority_table)
+        .expect_err("base url with relative authority must fail");
+
+    assert_eq!(
+        missing_authority_error.to_string(),
+        "llm.providers.chatgpt.api.base_url must be an absolute http or https URL"
+    );
+    assert_eq!(
+        relative_authority_error.to_string(),
+        "llm.providers.chatgpt.api.base_url must be an absolute http or https URL"
+    );
+}
+
+#[test]
 fn chatgpt_api_rejects_base_url_with_query_or_fragment() {
     let query_table = toml::toml! {
         [llm.providers.chatgpt.api]

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -119,6 +119,121 @@ fn chatgpt_auth_accepts_explicit_values() {
 }
 
 #[test]
+fn chatgpt_api_defaults_materialize_from_empty_config() {
+    let config = AppConfig::try_from(Table::new()).expect("materialize config");
+
+    assert_eq!(
+        config.llm.providers.chatgpt.api.base_url,
+        "https://chatgpt.com/backend-api/codex"
+    );
+    assert_eq!(
+        config
+            .llm
+            .providers
+            .chatgpt
+            .api
+            .stream_completion_timeout_ms,
+        1_800_000
+    );
+}
+
+#[test]
+fn chatgpt_api_accepts_explicit_values() {
+    let table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "https://example.com/backend-api/codex"
+        stream_completion_timeout_ms = 15_000
+    };
+
+    let config = AppConfig::try_from(table).expect("materialize config");
+
+    assert_eq!(
+        config.llm.providers.chatgpt.api.base_url,
+        "https://example.com/backend-api/codex"
+    );
+    assert_eq!(
+        config
+            .llm
+            .providers
+            .chatgpt
+            .api
+            .stream_completion_timeout_ms,
+        15_000
+    );
+}
+
+#[test]
+fn chatgpt_api_rejects_non_absolute_base_url() {
+    let table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "/backend-api/codex"
+    };
+
+    let error = AppConfig::try_from(table).expect_err("relative base url must fail");
+
+    assert_eq!(
+        error.to_string(),
+        "llm.providers.chatgpt.api.base_url must be an absolute http or https URL"
+    );
+}
+
+#[test]
+fn chatgpt_api_rejects_non_loopback_http_base_url() {
+    let table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "http://example.com/backend-api/codex"
+    };
+
+    let error = AppConfig::try_from(table).expect_err("non-loopback http base url must fail");
+
+    assert_eq!(
+        error.to_string(),
+        "llm.providers.chatgpt.api.base_url must use https unless it targets a loopback host"
+    );
+}
+
+#[test]
+fn chatgpt_api_rejects_base_url_with_query_or_fragment() {
+    let query_table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "https://chatgpt.com/backend-api/codex?x=1"
+    };
+    let fragment_table = toml::toml! {
+        [llm.providers.chatgpt.api]
+        base_url = "https://chatgpt.com/backend-api/codex#frag"
+    };
+
+    let query_error = AppConfig::try_from(query_table).expect_err("base url with query must fail");
+    let fragment_error =
+        AppConfig::try_from(fragment_table).expect_err("base url with fragment must fail");
+
+    assert_eq!(
+        query_error.to_string(),
+        "llm.providers.chatgpt.api.base_url must be a clean base URL"
+    );
+    assert_eq!(
+        fragment_error.to_string(),
+        "llm.providers.chatgpt.api.base_url must be a clean base URL"
+    );
+}
+
+#[test]
+fn chatgpt_api_rejects_blank_or_zero_timeout() {
+    let mut config = AppConfig::try_from(Table::new()).expect("materialize config");
+    config
+        .llm
+        .providers
+        .chatgpt
+        .api
+        .stream_completion_timeout_ms = 0;
+
+    assert_eq!(
+        config.validate(),
+        Err(ValidationError::InvalidChatgptApiStreamCompletionTimeout)
+    );
+}
+
+#[test]
 fn chatgpt_auth_rejects_blank_expected_workspace_id() {
     let table = toml::toml! {
         [llm.providers.chatgpt.auth]

--- a/crates/config-model/tests/model_contract.rs
+++ b/crates/config-model/tests/model_contract.rs
@@ -119,6 +119,28 @@ fn chatgpt_auth_accepts_explicit_values() {
 }
 
 #[test]
+fn chatgpt_auth_and_api_accept_uppercase_schemes() {
+    let table = toml::toml! {
+        [llm.providers.chatgpt.auth]
+        issuer = "HTTPS://auth.openai.com"
+
+        [llm.providers.chatgpt.api]
+        base_url = "HTTPS://chatgpt.com/backend-api/codex"
+    };
+
+    let config = AppConfig::try_from(table).expect("uppercase schemes should be accepted");
+
+    assert_eq!(
+        config.llm.providers.chatgpt.auth.issuer,
+        "HTTPS://auth.openai.com"
+    );
+    assert_eq!(
+        config.llm.providers.chatgpt.api.base_url,
+        "HTTPS://chatgpt.com/backend-api/codex"
+    );
+}
+
+#[test]
 fn chatgpt_api_defaults_materialize_from_empty_config() {
     let config = AppConfig::try_from(Table::new()).expect("materialize config");
 

--- a/xtask/src/agents_index.rs
+++ b/xtask/src/agents_index.rs
@@ -408,7 +408,7 @@ mod tests {
         }
 
         fn git_add(&self, paths: &[&str]) {
-            let mut command = Command::new("git");
+            let mut command = isolated_git_command();
             command.current_dir(self.path());
             command.arg("add");
             for path in paths {
@@ -424,7 +424,7 @@ mod tests {
     }
 
     fn run_git(root: &Path, args: &[&str]) {
-        let output = Command::new("git")
+        let output = isolated_git_command()
             .current_dir(root)
             .args(args)
             .output()
@@ -435,5 +435,33 @@ mod tests {
             args,
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn isolated_git_command() -> Command {
+        let mut command = Command::new("git");
+
+        for (key, _) in std::env::vars_os() {
+            if key.to_string_lossy().starts_with("GIT_") {
+                command.env_remove(&key);
+            }
+        }
+
+        let isolated_home = std::env::temp_dir().join(format!(
+            "xtask-git-home-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock should be valid")
+                .as_nanos()
+        ));
+        let isolated_git_config = isolated_home.join("gitconfig");
+
+        fs::create_dir_all(isolated_home.join(".config")).expect("isolated git home should exist");
+        fs::write(&isolated_git_config, "").expect("isolated git config should exist");
+        command.env("HOME", &isolated_home);
+        command.env("XDG_CONFIG_HOME", isolated_home.join(".config"));
+        command.env("GIT_CONFIG_GLOBAL", &isolated_git_config);
+
+        command
     }
 }

--- a/xtask/src/agents_index.rs
+++ b/xtask/src/agents_index.rs
@@ -95,7 +95,7 @@ fn prepare(root: &Path, warning_threshold: usize) -> Result<PreparedIndex, Strin
 }
 
 fn git_tracked_files(root: &Path) -> Result<Vec<PathBuf>, String> {
-    let output = Command::new("git")
+    let output = isolated_git_command()
         .current_dir(root)
         .args(["ls-files", "-z"])
         .output()
@@ -115,6 +115,18 @@ fn git_tracked_files(root: &Path) -> Result<Vec<PathBuf>, String> {
         .collect::<Vec<_>>();
     paths.sort();
     Ok(paths)
+}
+
+fn isolated_git_command() -> Command {
+    let mut command = Command::new("git");
+
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("GIT_") {
+            command.env_remove(&key);
+        }
+    }
+
+    command
 }
 
 fn render_index_block(tracked_files: &[PathBuf], line_ending: &str) -> String {


### PR DESCRIPTION
## Summary
- add the new `chatgpt-api` crate for ChatGPT `/responses` streaming
- extend config-model with `llm.providers.chatgpt.api` and wire the crate into the workspace
- align the public contract and request body rules with the `.workpad` specification, backed by tests

## Verification
- cargo test -p chatgpt-api
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- just hooks
- codex-review-final main
