### PR TITLE
[codex] Implement selvedge core runtime and database persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,domain-model/,logging/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,logging/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -91,6 +91,12 @@ This file is for coding agents working in this repository.
 |crates/config/examples:{README.md,layered_sources.rs,load_defaults.rs,runtime_updates.rs}
 |crates/config/src:{lib.rs}
 |crates/config/tests:{public_api.rs}
+|crates/core:{src/,tests/,Cargo.toml,README.md}
+|crates/core/src:{lib.rs}
+|crates/core/tests:{runtime_contract.rs}
+|crates/db:{src/,tests/,Cargo.toml,README.md}
+|crates/db/src:{lib.rs,schema.sql}
+|crates/db/tests:{db_contract.rs}
 |crates/domain-model:{src/,tests/,Cargo.toml,README.md}
 |crates/domain-model/src:{lib.rs}
 |crates/domain-model/tests:{domain_contract.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "selvedge-db",
  "selvedge-domain-model",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1940,6 +1941,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +384,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +568,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -556,6 +589,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -875,6 +917,17 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1240,6 +1293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1465,25 @@ dependencies = [
  "thiserror",
  "toml",
  "url",
+]
+
+[[package]]
+name = "selvedge-core"
+version = "0.0.0"
+dependencies = [
+ "selvedge-command-model",
+ "selvedge-db",
+ "selvedge-domain-model",
+ "tokio",
+]
+
+[[package]]
+name = "selvedge-db"
+version = "0.0.0"
+dependencies = [
+ "rusqlite",
+ "selvedge-domain-model",
+ "tempfile",
 ]
 
 [[package]]
@@ -1854,6 +1940,18 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ members = [
     "crates/command-model",
     "crates/config",
     "crates/config-model",
+    "crates/core",
+    "crates/db",
     "crates/domain-model",
     "crates/logging",
     "xtask",

--- a/crates/api/tests/api_contract.rs
+++ b/crates/api/tests/api_contract.rs
@@ -130,6 +130,7 @@ async fn invalid_correlation_sends_validation_failure_that_satisfies_output_vali
                 ApiOutputEnvelope::Success { .. } => panic!("unexpected success"),
             }
         }
+        _ => panic!("unexpected router message"),
     }
 }
 

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -5,3 +5,5 @@ This crate defines the Selvedge command model API slice used to dispatch model c
 Use it to define model-call request correlation, dispatch request, output envelope, call error, and router ingress API message types.
 
 This crate is not for network access, database access, filesystem access, provider execution, or task runtime mutation.
+
+`RuntimeReady` is only a readiness signal. The task runtime sender is returned by `selvedge-core::spawn_task_runtime` to the creator that owns router registration.

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -116,7 +116,7 @@ pub enum CoreOutputMessage {
     RequestModelCall(ModelCallRequest),
     RequestToolExecution(ToolExecutionRequest),
     PublishDomainEvent(DomainEventPublishRequest),
-    RuntimeReady { sender: TaskRuntimeSender },
+    RuntimeReady,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -1,21 +1,23 @@
 #![doc = include_str!("../README.md")]
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use selvedge_domain_model::{
-    ApiDomainValidationError, ConversationPath, ModelProviderProfile, ModelReply,
-    ResponsePreference, ToolManifest, validate_conversation_path, validate_model_provider_profile,
-    validate_model_reply, validate_tool_manifest,
+    ApiDomainValidationError, ConversationPath, FunctionCallId, HistoryNodeId,
+    ModelProviderProfile, ModelReply, ResponsePreference, ToolCallArgument, ToolManifest, ToolName,
+    validate_conversation_path, validate_model_provider_profile, validate_model_reply,
+    validate_tool_manifest,
 };
+
+pub use selvedge_domain_model::TaskId;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ApiEffectId(pub String);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TaskId(pub String);
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ModelRunId(pub String);
+
+pub type ModelCallId = ModelRunId;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ApiCallCorrelation {
@@ -61,12 +63,111 @@ pub enum ModelCallErrorKind {
     Cancelled,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum RouterIngressApiMessage {
+#[derive(Debug)]
+pub enum RouterIngressMessage {
     ApiOutput(ApiOutputEnvelope),
+    Core(CoreOutputEnvelope),
+    Tool(ToolExecutionResult),
+    RuntimeExit(TaskRuntimeExitNotice),
+    QueryRuntimeInventory(RuntimeInventoryQuery),
+    PublishToEvents(DomainEventPublishRequest),
 }
 
-pub type RouterIngressSender = mpsc::Sender<RouterIngressApiMessage>;
+pub type RouterIngressApiMessage = RouterIngressMessage;
+pub type RouterIngressSender = mpsc::Sender<RouterIngressMessage>;
+pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
+pub type ModelCallRequest = ModelCallDispatchRequest;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ToolExecutionRunId(pub String);
+
+#[derive(Debug)]
+pub enum TaskRuntimeCommand {
+    Start,
+    UserInput { message_text: String },
+    ApiModelReply(ApiOutputEnvelope),
+    ToolResult(ToolExecutionResult),
+    Archive,
+    Stop,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskRuntimeExitNotice {
+    pub task_id: TaskId,
+    pub reason: TaskRuntimeExitReason,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TaskRuntimeExitReason {
+    Stopped,
+    Archived,
+    DbError(String),
+    InternalError(String),
+}
+
+#[derive(Debug)]
+pub struct CoreOutputEnvelope {
+    pub task_id: TaskId,
+    pub message: CoreOutputMessage,
+}
+
+#[derive(Debug)]
+pub enum CoreOutputMessage {
+    RequestModelCall(ModelCallRequest),
+    RequestToolExecution(ToolExecutionRequest),
+    PublishDomainEvent(DomainEventPublishRequest),
+    RuntimeReady { sender: TaskRuntimeSender },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ToolExecutionRequest {
+    pub task_id: TaskId,
+    pub tool_execution_run_id: ToolExecutionRunId,
+    pub function_call_node_id: HistoryNodeId,
+    pub function_call_id: FunctionCallId,
+    pub tool_name: ToolName,
+    pub arguments: Vec<ToolCallArgument>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ToolExecutionResult {
+    pub task_id: TaskId,
+    pub tool_execution_run_id: ToolExecutionRunId,
+    pub function_call_node_id: HistoryNodeId,
+    pub function_call_id: FunctionCallId,
+    pub tool_name: ToolName,
+    pub output_text: String,
+    pub is_error: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DomainEventPublishRequest {
+    pub task_id: TaskId,
+    pub event: DomainEvent,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DomainEvent {
+    TaskRuntimeReady,
+    UserMessageCommitted { node_id: HistoryNodeId },
+    AssistantMessageCommitted { node_id: HistoryNodeId },
+    ReasoningCommitted { node_id: HistoryNodeId },
+    FunctionCallCommitted { node_id: HistoryNodeId },
+    FunctionOutputCommitted { node_id: HistoryNodeId },
+    TaskArchived,
+    ErrorNotice { message: String },
+}
+
+#[derive(Debug)]
+pub struct RuntimeInventoryQuery {
+    pub reply_to: oneshot::Sender<RuntimeInventoryResponse>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeInventoryResponse {
+    pub live_task_runtimes: Vec<TaskId>,
+    pub pending_task_runtime_effects: Vec<TaskId>,
+}
 
 pub fn validate_dispatch_request(request: &ModelCallDispatchRequest) -> Result<(), ModelCallError> {
     validate_correlation(&request.correlation)?;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "selvedge-core"
+edition = "2024"
+publish = false
+
+[dependencies]
+selvedge-command-model = { path = "../command-model" }
+selvedge-db = { path = "../db" }
+selvedge-domain-model = { path = "../domain-model" }
+tokio = { version = "1.42.0", features = ["rt", "sync"] }
+
+[dev-dependencies]
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,7 @@ selvedge-command-model = { path = "../command-model" }
 selvedge-db = { path = "../db" }
 selvedge-domain-model = { path = "../domain-model" }
 tokio = { version = "1.42.0", features = ["rt", "sync"] }
+uuid = { version = "1.11.0", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -2,6 +2,8 @@
 
 This crate runs one task runtime actor per active task.
 
-Use it to spawn a task-local runtime that loads SQLite state through `selvedge-db`, appends history, queues input while busy, requests model calls through the router, requests tool execution through the router, and exits on archive or database errors.
+Use it to spawn a task-local runtime that loads SQLite state through `selvedge-db`, queues input while busy, requests model calls through the router, requests tool execution through the router, and exits on archive or database errors.
 
 This crate only talks to the router mailbox and the database package. Provider calls, tool execution, event fanout, runtime registry ownership, and direct client delivery live in other crates.
+
+On `Start`, the runtime reads the active task snapshot and classifies the concrete cursor tail. User/system/function-output tails request a model call; function-call tails request tool execution; assistant/developer tails await user input with an empty queue. The runtime keeps only in-flight correlation ids and pending tool-call identity in memory; the task cursor lives in SQLite.

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,0 +1,7 @@
+# core
+
+This crate runs one task runtime actor per active task.
+
+Use it to spawn a task-local runtime that loads SQLite state through `selvedge-db`, appends history, queues input while busy, requests model calls through the router, requests tool execution through the router, and exits on archive or database errors.
+
+This crate only talks to the router mailbox and the database package. Provider calls, tool execution, event fanout, runtime registry ownership, and direct client delivery live in other crates.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,8 +13,9 @@ use selvedge_db::{
     DbError, DbPool, HistoryNodeId, MessageRole, NewFunctionCallNodeContent,
     NewFunctionOutputNodeContent, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
     TaskId, ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
-    append_history_node_and_move_cursor, archive_task, consume_next_queued_user_input,
-    load_active_task, queue_user_input, read_conversation_for_task, read_tool_manifest_for_task,
+    append_history_node_and_move_cursor, append_next_queued_user_input_and_move_cursor,
+    archive_task, load_active_task, queue_user_input, read_conversation_for_task,
+    read_tool_manifest_for_task,
 };
 use selvedge_domain_model::{
     ConversationItem, ConversationMessage, ConversationPath, MessageContent, ModelProfileKey,
@@ -235,7 +236,10 @@ impl TaskRuntimeActor {
                 self.wait_state = wait_state;
                 return false;
             }
-            WaitState::Idle | WaitState::WaitingModelReply { .. } => return false,
+            wait_state @ (WaitState::Idle | WaitState::WaitingModelReply { .. }) => {
+                self.wait_state = wait_state;
+                return false;
+            }
         };
 
         let node = NewHistoryNode {
@@ -410,20 +414,15 @@ impl TaskRuntimeActor {
     }
 
     async fn drain_queue_or_idle(&mut self) -> bool {
-        match load_active_task(&self.db, &self.task_id) {
-            Ok(loaded) => {
-                let Some(input) = loaded.queued_inputs.into_iter().next() else {
-                    self.wait_state = WaitState::Idle;
-                    return false;
-                };
+        match append_next_queued_user_input_and_move_cursor(&self.db, &self.task_id, now()) {
+            Ok(Some(node_id)) => {
+                self.cursor_node_id = Some(node_id);
                 self.wait_state = WaitState::Idle;
-                if let Err(error) = self.append_user_message(input.message_text) {
-                    return self.stop_with_db_error(error).await;
-                }
-                if let Err(error) = consume_next_queued_user_input(&self.db, &self.task_id) {
-                    return self.stop_with_db_error(error).await;
-                }
                 self.request_model_call().await
+            }
+            Ok(None) => {
+                self.wait_state = WaitState::Idle;
+                false
             }
             Err(error) => self.stop_with_db_error(error).await,
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -96,6 +96,7 @@ enum WaitState {
     },
     WaitingToolResult {
         tool_run_id: ToolExecutionRunId,
+        active_tool_call: PendingToolCall,
         pending_tool_calls: VecDeque<PendingToolCall>,
     },
 }
@@ -282,8 +283,14 @@ impl TaskRuntimeActor {
         let pending_tool_calls = match std::mem::replace(&mut self.wait_state, WaitState::Idle) {
             WaitState::WaitingToolResult {
                 tool_run_id,
+                active_tool_call,
                 pending_tool_calls,
-            } if result.task_id == self.task_id && result.tool_execution_run_id == tool_run_id => {
+            } if result.task_id == self.task_id
+                && result.tool_execution_run_id == tool_run_id
+                && result.function_call_node_id == active_tool_call.function_call_node_id
+                && result.function_call_id == active_tool_call.function_call_id
+                && result.tool_name == active_tool_call.tool_name =>
+            {
                 pending_tool_calls
             }
             wait_state @ WaitState::WaitingToolResult { .. } => {
@@ -448,12 +455,13 @@ impl TaskRuntimeActor {
             task_id: self.task_id.clone(),
             tool_execution_run_id: tool_run_id.clone(),
             function_call_node_id: tool_call.function_call_node_id,
-            function_call_id: tool_call.function_call_id,
-            tool_name: tool_call.tool_name,
-            arguments: tool_call.arguments,
+            function_call_id: tool_call.function_call_id.clone(),
+            tool_name: tool_call.tool_name.clone(),
+            arguments: tool_call.arguments.clone(),
         };
         self.wait_state = WaitState::WaitingToolResult {
             tool_run_id,
+            active_tool_call: tool_call,
             pending_tool_calls,
         };
         self.send_core(CoreOutputMessage::RequestToolExecution(request))
@@ -563,7 +571,13 @@ fn validate_conversation_tool_pairs(
                     return Err("conversation contains tool output with mismatched tool".to_owned());
                 }
             }
-            ConversationItem::Message { .. } => {}
+            ConversationItem::Message { .. } => {
+                if !pending_tool_calls.is_empty() {
+                    return Err(
+                        "conversation contains message before tool outputs complete".to_owned()
+                    );
+                }
+            }
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -505,16 +505,27 @@ fn conversation_item_to_message(item: ConversationItem) -> ConversationMessage {
             source_node_id: None,
         },
         ConversationItem::FunctionOutput {
+            function_call_id,
+            tool_name,
             output_text,
             is_error,
-            ..
         } => ConversationMessage {
             role: MessageRole::Tool,
-            content: MessageContent::ToolResultSummary(if is_error {
-                format!("error: {output_text}")
-            } else {
-                output_text
-            }),
+            content: MessageContent::Structured(StructuredPayload::Object(BTreeMap::from([
+                (
+                    "function_call_id".to_owned(),
+                    StructuredPayload::String(function_call_id.0),
+                ),
+                (
+                    "tool_name".to_owned(),
+                    StructuredPayload::String(tool_name.0),
+                ),
+                (
+                    "output_text".to_owned(),
+                    StructuredPayload::String(output_text),
+                ),
+                ("is_error".to_owned(), StructuredPayload::Boolean(is_error)),
+            ]))),
             source_node_id: None,
         },
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -270,10 +270,15 @@ impl TaskRuntimeActor {
     }
 
     async fn commit_user_message_and_request_model(&mut self, message_text: String) -> bool {
+        match self.append_user_message(message_text) {
+            Ok(()) => self.request_model_call().await,
+            Err(error) => self.stop_with_db_error(error).await,
+        }
+    }
+
+    fn append_user_message(&mut self, message_text: String) -> Result<(), DbError> {
         let Some(parent_node_id) = self.cursor_node_id else {
-            return self
-                .stop_with_internal_error("task cursor is missing")
-                .await;
+            return Err(DbError::Storage("task cursor is missing".to_owned()));
         };
         match append_history_node_and_move_cursor(
             &self.db,
@@ -289,9 +294,9 @@ impl TaskRuntimeActor {
         ) {
             Ok(node_id) => {
                 self.cursor_node_id = Some(node_id);
-                self.request_model_call().await
+                Ok(())
             }
-            Err(error) => self.stop_with_db_error(error).await,
+            Err(error) => Err(error),
         }
     }
 
@@ -405,15 +410,20 @@ impl TaskRuntimeActor {
     }
 
     async fn drain_queue_or_idle(&mut self) -> bool {
-        match consume_next_queued_user_input(&self.db, &self.task_id) {
-            Ok(Some(input)) => {
+        match load_active_task(&self.db, &self.task_id) {
+            Ok(loaded) => {
+                let Some(input) = loaded.queued_inputs.into_iter().next() else {
+                    self.wait_state = WaitState::Idle;
+                    return false;
+                };
                 self.wait_state = WaitState::Idle;
-                self.commit_user_message_and_request_model(input.message_text)
-                    .await
-            }
-            Ok(None) => {
-                self.wait_state = WaitState::Idle;
-                false
+                if let Err(error) = self.append_user_message(input.message_text) {
+                    return self.stop_with_db_error(error).await;
+                }
+                if let Err(error) = consume_next_queued_user_input(&self.db, &self.task_id) {
+                    return self.stop_with_db_error(error).await;
+                }
+                self.request_model_call().await
             }
             Err(error) => self.stop_with_db_error(error).await,
         }
@@ -554,11 +564,17 @@ fn tool_call_arguments_from_payload(
 
     let mut converted = Vec::with_capacity(arguments.len());
     for (name, value) in arguments {
-        let parameter_type = tool_spec
+        let Some(parameter_type) = tool_spec
             .parameters
             .iter()
             .find(|parameter| parameter.name == name)
-            .map(|parameter| &parameter.parameter_type);
+            .map(|parameter| &parameter.parameter_type)
+        else {
+            return Err(format!(
+                "tool argument is not declared: {}.{}",
+                tool_name.0, name
+            ));
+        };
         let Some(value) = tool_argument_value_from_payload(value, parameter_type) else {
             return Err(format!(
                 "tool argument value cannot be converted: {}.{}",
@@ -575,24 +591,27 @@ fn tool_call_arguments_from_payload(
 
 fn tool_argument_value_from_payload(
     payload: StructuredPayload,
-    parameter_type: Option<&ToolParameterType>,
+    parameter_type: &ToolParameterType,
 ) -> Option<ToolArgumentValue> {
-    match payload {
-        StructuredPayload::String(value) => Some(ToolArgumentValue::String(value)),
-        StructuredPayload::Number(value)
-            if parameter_type == Some(&ToolParameterType::Integer)
-                && value.is_finite()
+    match (parameter_type, payload) {
+        (ToolParameterType::String, StructuredPayload::String(value)) => {
+            Some(ToolArgumentValue::String(value))
+        }
+        (ToolParameterType::Integer, StructuredPayload::Number(value))
+            if value.is_finite()
                 && value.fract() == 0.0
                 && value >= i64::MIN as f64
                 && value <= i64::MAX as f64 =>
         {
             Some(ToolArgumentValue::Integer(value as i64))
         }
-        StructuredPayload::Number(value) => Some(ToolArgumentValue::Number(value)),
-        StructuredPayload::Boolean(value) => Some(ToolArgumentValue::Boolean(value)),
-        StructuredPayload::Object(_) | StructuredPayload::Array(_) | StructuredPayload::Null => {
-            None
+        (ToolParameterType::Number, StructuredPayload::Number(value)) if value.is_finite() => {
+            Some(ToolArgumentValue::Number(value))
         }
+        (ToolParameterType::Boolean, StructuredPayload::Boolean(value)) => {
+            Some(ToolArgumentValue::Boolean(value))
+        }
+        _ => None,
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,10 +10,11 @@ use selvedge_command_model::{
     TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_db::{
-    DbError, DbPool, FunctionCallId, HistoryNodeId, MessageRole, NewFunctionCallNodeContent,
-    NewFunctionOutputNodeContent, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
-    TaskId, ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
-    append_history_node_and_move_cursor, append_next_queued_user_input_and_move_cursor,
+    DbError, DbPool, FunctionCallId, HistoryNode, HistoryNodeId, MessageRole,
+    NewFunctionCallNodeContent, NewFunctionOutputNodeContent, TaskId, ToolArgumentValue,
+    ToolCallArgument, ToolName, ToolParameterName, UnixTs,
+    append_assistant_message_and_drain_queue, append_function_output_and_drain_queue,
+    append_model_reply_with_tool_calls_and_move_cursor, append_user_message_and_move_cursor,
     archive_task, load_active_task, queue_user_input, read_conversation_for_task,
     read_tool_manifest_for_task,
 };
@@ -64,12 +65,10 @@ pub fn spawn_task_runtime(
         task_id: args.task_id,
         db: args.db,
         router_tx: args.router_tx,
-        self_tx: task_runtime_tx,
         rx: task_runtime_rx,
-        cursor_node_id: None,
         started: false,
         model_profiles: args.config.model_profiles,
-        wait_state: WaitState::Idle,
+        wait_state: WaitState::AwaitingUserInput,
     };
     tokio::spawn(actor.run());
 
@@ -80,9 +79,7 @@ struct TaskRuntimeActor {
     task_id: TaskId,
     db: DbPool,
     router_tx: RouterIngressSender,
-    self_tx: TaskRuntimeSender,
     rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
-    cursor_node_id: Option<HistoryNodeId>,
     started: bool,
     model_profiles: HashMap<ModelProfileKey, ModelProviderProfile>,
     wait_state: WaitState,
@@ -90,7 +87,7 @@ struct TaskRuntimeActor {
 
 #[derive(Clone, Debug, PartialEq)]
 enum WaitState {
-    Idle,
+    AwaitingUserInput,
     WaitingModelReply {
         model_run_id: ModelRunId,
     },
@@ -146,24 +143,67 @@ impl TaskRuntimeActor {
             return false;
         }
         match load_active_task(&self.db, &self.task_id) {
-            Ok(task) => {
+            Ok(loaded) => {
                 self.started = true;
-                self.cursor_node_id = Some(task.task.cursor_node_id);
                 if self
-                    .send_core(CoreOutputMessage::RuntimeReady {
-                        sender: self.self_tx.clone(),
-                    })
+                    .send_core(CoreOutputMessage::RuntimeReady)
                     .await
                     .is_err()
                 {
                     return true;
                 }
-                self.drain_queue_or_idle().await
+                self.start_from_cursor_tail(loaded).await
             }
             Err(error) => {
                 self.send_exit(TaskRuntimeExitReason::DbError(error.to_string()))
                     .await;
                 true
+            }
+        }
+    }
+
+    async fn start_from_cursor_tail(&mut self, loaded: selvedge_db::LoadedActiveTask) -> bool {
+        match loaded.cursor_node {
+            HistoryNode::Message { message_role, .. } => match message_role {
+                MessageRole::System | MessageRole::User => self.request_model_call().await,
+                MessageRole::Assistant | MessageRole::Developer => {
+                    if loaded.queued_inputs.is_empty() {
+                        self.wait_state = WaitState::AwaitingUserInput;
+                        false
+                    } else {
+                        self.stop_with_internal_error(
+                            "queued user input cannot exist while cursor awaits user input",
+                        )
+                        .await
+                    }
+                }
+                MessageRole::Tool => {
+                    self.stop_with_internal_error("tool message cannot be a task cursor tail")
+                        .await
+                }
+            },
+            HistoryNode::FunctionOutput { .. } => self.request_model_call().await,
+            HistoryNode::FunctionCall {
+                node_id,
+                function_call_id,
+                tool_name,
+                arguments,
+                ..
+            } => {
+                self.dispatch_tool_call(
+                    PendingToolCall {
+                        function_call_node_id: node_id,
+                        function_call_id,
+                        tool_name,
+                        arguments,
+                    },
+                    VecDeque::new(),
+                )
+                .await
+            }
+            HistoryNode::Reasoning { .. } => {
+                self.stop_with_internal_error("reasoning cannot be a task cursor tail")
+                    .await
             }
         }
     }
@@ -176,7 +216,7 @@ impl TaskRuntimeActor {
         }
 
         match self.wait_state {
-            WaitState::Idle => {
+            WaitState::AwaitingUserInput => {
                 self.commit_user_message_and_request_model(message_text)
                     .await
             }
@@ -192,7 +232,7 @@ impl TaskRuntimeActor {
     async fn handle_model_reply(&mut self, envelope: ApiOutputEnvelope) -> bool {
         let expected_model_run_id = match &self.wait_state {
             WaitState::WaitingModelReply { model_run_id } => model_run_id.clone(),
-            WaitState::Idle | WaitState::WaitingToolResult { .. } => return false,
+            WaitState::AwaitingUserInput | WaitState::WaitingToolResult { .. } => return false,
         };
 
         match envelope {
@@ -202,7 +242,7 @@ impl TaskRuntimeActor {
                 {
                     return false;
                 }
-                let pending_tool_calls = if reply.tool_calls.is_empty() {
+                let validated_tool_calls = if reply.tool_calls.is_empty() {
                     VecDeque::new()
                 } else {
                     let tool_manifest = match read_tool_manifest_for_task(&self.db, &self.task_id) {
@@ -215,39 +255,42 @@ impl TaskRuntimeActor {
                     }
                 };
 
-                if let Some(content) = reply.content.filter(|content| !content.trim().is_empty()) {
-                    let Some(parent_node_id) = self.cursor_node_id else {
+                if validated_tool_calls.is_empty() {
+                    let Some(content) = reply.content.filter(|content| !content.trim().is_empty())
+                    else {
                         return self
-                            .stop_with_internal_error("task cursor is missing")
+                            .stop_with_internal_error("model reply has no terminal history node")
                             .await;
                     };
-                    match append_history_node_and_move_cursor(
+                    let had_queued_inputs = match load_active_task(&self.db, &self.task_id) {
+                        Ok(loaded) => !loaded.queued_inputs.is_empty(),
+                        Err(error) => return self.stop_with_db_error(error).await,
+                    };
+                    match append_assistant_message_and_drain_queue(
                         &self.db,
                         &self.task_id,
-                        NewHistoryNode {
-                            parent_node_id: Some(parent_node_id),
-                            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                                message_role: MessageRole::Assistant,
-                                message_text: content,
-                            }),
-                            created_at: now(),
-                        },
+                        content,
+                        now(),
                     ) {
-                        Ok(node_id) => self.cursor_node_id = Some(node_id),
-                        Err(error) => return self.stop_with_db_error(error).await,
-                    }
-                }
-
-                match self.append_tool_calls(pending_tool_calls) {
-                    Ok(mut pending_tool_calls) => {
-                        if let Some(tool_call) = pending_tool_calls.pop_front() {
-                            self.dispatch_tool_call(tool_call, pending_tool_calls).await
-                        } else {
-                            self.wait_state = WaitState::Idle;
-                            self.drain_queue_or_idle().await
+                        Ok(_) if had_queued_inputs => self.request_model_call().await,
+                        Ok(_) => {
+                            self.wait_state = WaitState::AwaitingUserInput;
+                            false
                         }
+                        Err(error) => self.stop_with_db_error(error).await,
                     }
-                    Err(error) => self.stop_with_db_error(error).await,
+                } else {
+                    let assistant_message_text =
+                        reply.content.filter(|content| !content.trim().is_empty());
+                    match self.append_tool_calls(assistant_message_text, validated_tool_calls) {
+                        Ok(mut pending_tool_calls) => {
+                            let tool_call = pending_tool_calls
+                                .pop_front()
+                                .expect("validated tool calls cannot be empty here");
+                            self.dispatch_tool_call(tool_call, pending_tool_calls).await
+                        }
+                        Err(error) => self.stop_with_db_error(error).await,
+                    }
                 }
             }
             ApiOutputEnvelope::Failure { correlation, error } => {
@@ -256,7 +299,7 @@ impl TaskRuntimeActor {
                 {
                     return false;
                 }
-                self.wait_state = WaitState::Idle;
+                self.wait_state = WaitState::AwaitingUserInput;
                 if self
                     .send_core(CoreOutputMessage::PublishDomainEvent(
                         DomainEventPublishRequest {
@@ -274,49 +317,50 @@ impl TaskRuntimeActor {
                 {
                     return true;
                 }
-                self.drain_queue_or_idle().await
+                false
             }
         }
     }
 
     async fn handle_tool_result(&mut self, result: ToolExecutionResult) -> bool {
-        let pending_tool_calls = match std::mem::replace(&mut self.wait_state, WaitState::Idle) {
-            WaitState::WaitingToolResult {
-                tool_run_id,
-                active_tool_call,
-                pending_tool_calls,
-            } if result.task_id == self.task_id
-                && result.tool_execution_run_id == tool_run_id
-                && result.function_call_node_id == active_tool_call.function_call_node_id
-                && result.function_call_id == active_tool_call.function_call_id
-                && result.tool_name == active_tool_call.tool_name =>
-            {
-                pending_tool_calls
-            }
-            wait_state @ WaitState::WaitingToolResult { .. } => {
-                self.wait_state = wait_state;
-                return false;
-            }
-            wait_state @ (WaitState::Idle | WaitState::WaitingModelReply { .. }) => {
-                self.wait_state = wait_state;
-                return false;
-            }
-        };
+        let pending_tool_calls =
+            match std::mem::replace(&mut self.wait_state, WaitState::AwaitingUserInput) {
+                WaitState::WaitingToolResult {
+                    tool_run_id,
+                    active_tool_call,
+                    pending_tool_calls,
+                } if result.task_id == self.task_id
+                    && result.tool_execution_run_id == tool_run_id
+                    && result.function_call_node_id == active_tool_call.function_call_node_id
+                    && result.function_call_id == active_tool_call.function_call_id
+                    && result.tool_name == active_tool_call.tool_name =>
+                {
+                    pending_tool_calls
+                }
+                wait_state @ WaitState::WaitingToolResult { .. } => {
+                    self.wait_state = wait_state;
+                    return false;
+                }
+                wait_state @ (WaitState::AwaitingUserInput
+                | WaitState::WaitingModelReply { .. }) => {
+                    self.wait_state = wait_state;
+                    return false;
+                }
+            };
 
-        let node = NewHistoryNode {
-            parent_node_id: Some(result.function_call_node_id),
-            content: NewHistoryNodeContent::FunctionOutput(NewFunctionOutputNodeContent {
+        match append_function_output_and_drain_queue(
+            &self.db,
+            &self.task_id,
+            NewFunctionOutputNodeContent {
                 function_call_node_id: result.function_call_node_id,
                 function_call_id: result.function_call_id,
                 tool_name: result.tool_name,
                 output_text: result.output_text,
                 is_error: result.is_error,
-            }),
-            created_at: now(),
-        };
-        match append_history_node_and_move_cursor(&self.db, &self.task_id, node) {
-            Ok(node_id) => {
-                self.cursor_node_id = Some(node_id);
+            },
+            now(),
+        ) {
+            Ok(_) => {
                 self.dispatch_next_tool_or_request_model(pending_tool_calls)
                     .await
             }
@@ -342,27 +386,8 @@ impl TaskRuntimeActor {
     }
 
     fn append_user_message(&mut self, message_text: String) -> Result<(), DbError> {
-        let Some(parent_node_id) = self.cursor_node_id else {
-            return Err(DbError::Storage("task cursor is missing".to_owned()));
-        };
-        match append_history_node_and_move_cursor(
-            &self.db,
-            &self.task_id,
-            NewHistoryNode {
-                parent_node_id: Some(parent_node_id),
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text,
-                }),
-                created_at: now(),
-            },
-        ) {
-            Ok(node_id) => {
-                self.cursor_node_id = Some(node_id);
-                Ok(())
-            }
-            Err(error) => Err(error),
-        }
+        append_user_message_and_move_cursor(&self.db, &self.task_id, message_text, now())
+            .map(|_| ())
     }
 
     async fn request_model_call(&mut self) -> bool {
@@ -410,38 +435,37 @@ impl TaskRuntimeActor {
 
     fn append_tool_calls(
         &mut self,
+        assistant_message_text: Option<String>,
         tool_calls: VecDeque<ValidatedToolCall>,
     ) -> Result<VecDeque<PendingToolCall>, DbError> {
-        let mut pending_tool_calls = VecDeque::new();
-        for tool_call in tool_calls {
-            let Some(parent_node_id) = self.cursor_node_id else {
-                return Err(DbError::Storage("task cursor is missing".to_owned()));
-            };
-            // A model turn can emit several tool calls at once. Persist every
-            // call from that turn before any tool output so the provider path
-            // remains causal: calls describe requested work, outputs describe
-            // later observations correlated by call id.
-            let node_id = append_history_node_and_move_cursor(
-                &self.db,
-                &self.task_id,
-                NewHistoryNode {
-                    parent_node_id: Some(parent_node_id),
-                    content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
-                        function_call_id: tool_call.function_call_id.clone(),
-                        tool_name: tool_call.tool_name.clone(),
-                        arguments: tool_call.arguments.clone(),
-                    }),
-                    created_at: now(),
-                },
-            )?;
-            self.cursor_node_id = Some(node_id);
-            pending_tool_calls.push_back(PendingToolCall {
+        // A model turn can emit several tool calls at once. Persist every call
+        // from that turn in one DB transaction before any tool output so the
+        // provider path keeps the reply batch as durable history.
+        let tool_calls = tool_calls.into_iter().collect::<Vec<_>>();
+        let function_call_node_ids = append_model_reply_with_tool_calls_and_move_cursor(
+            &self.db,
+            &self.task_id,
+            assistant_message_text,
+            tool_calls
+                .iter()
+                .map(|tool_call| NewFunctionCallNodeContent {
+                    function_call_id: tool_call.function_call_id.clone(),
+                    tool_name: tool_call.tool_name.clone(),
+                    arguments: tool_call.arguments.clone(),
+                })
+                .collect(),
+            now(),
+        )?;
+        let pending_tool_calls = function_call_node_ids
+            .into_iter()
+            .zip(tool_calls)
+            .map(|(node_id, tool_call)| PendingToolCall {
                 function_call_node_id: node_id,
                 function_call_id: tool_call.function_call_id,
                 tool_name: tool_call.tool_name,
                 arguments: tool_call.arguments,
-            });
-        }
+            })
+            .collect();
         Ok(pending_tool_calls)
     }
 
@@ -477,21 +501,6 @@ impl TaskRuntimeActor {
             self.dispatch_tool_call(tool_call, pending_tool_calls).await
         } else {
             self.request_model_call().await
-        }
-    }
-
-    async fn drain_queue_or_idle(&mut self) -> bool {
-        match append_next_queued_user_input_and_move_cursor(&self.db, &self.task_id, now()) {
-            Ok(Some(node_id)) => {
-                self.cursor_node_id = Some(node_id);
-                self.wait_state = WaitState::Idle;
-                self.request_model_call().await
-            }
-            Ok(None) => {
-                self.wait_state = WaitState::Idle;
-                false
-            }
-            Err(error) => self.stop_with_db_error(error).await,
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -571,21 +571,15 @@ fn validate_conversation_tool_pairs(
                     return Err("conversation contains tool output with mismatched tool".to_owned());
                 }
             }
-            ConversationItem::Message { .. } => {
-                if !pending_tool_calls.is_empty() {
-                    return Err(
-                        "conversation contains message before tool outputs complete".to_owned()
-                    );
-                }
-            }
+            ConversationItem::Message { .. } => {}
         }
     }
 
-    // Model providers require each tool result in a request to correlate with
-    // a previous tool call, and each open tool call must receive its result
-    // before normal conversation continues. This check belongs at dispatch
-    // time: history is a graph, while API conversation path is a linear
-    // provider protocol with stricter call/output pairing rules.
+    // Provider APIs correlate tool outputs by call id. Core only checks that
+    // every output in the selected conversation path has a matching prior
+    // call, and that every call has one matching output before dispatch. The
+    // meaning of messages between those two nodes belongs to the persisted
+    // history path and provider adapter policy, not to task runtime state.
     if pending_tool_calls.is_empty() {
         Ok(())
     } else {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -307,6 +307,14 @@ impl TaskRuntimeActor {
             "{}-model-{}",
             self.task_id.0, self.model_run_sequence
         ));
+        let Some(provider) = model_provider_profile_from_key(&loaded.task.model_profile_key.0)
+        else {
+            return self
+                .stop_with_internal_error(
+                    "model profile key must be provider/model or provider:model",
+                )
+                .await;
+        };
         let request = ModelCallDispatchRequest {
             correlation: selvedge_command_model::ApiCallCorrelation {
                 api_effect_id: ApiEffectId(format!(
@@ -316,12 +324,7 @@ impl TaskRuntimeActor {
                 task_id: self.task_id.clone(),
                 model_run_id: model_run_id.clone(),
             },
-            provider: ModelProviderProfile {
-                provider_name: loaded.task.model_profile_key.0.clone(),
-                model_name: loaded.task.model_profile_key.0,
-                temperature: None,
-                max_output_tokens: None,
-            },
+            provider,
             conversation: conversation_to_path(conversation),
             tool_manifest: Some(tool_manifest),
             response_preference: ResponsePreference::PlainTextOrToolCalls,
@@ -349,7 +352,11 @@ impl TaskRuntimeActor {
             Err(error) => return self.stop_with_db_error(error).await,
         };
         let arguments =
-            tool_call_arguments_from_payload(tool_call.arguments, &tool_name, &tool_manifest);
+            match tool_call_arguments_from_payload(tool_call.arguments, &tool_name, &tool_manifest)
+            {
+                Ok(arguments) => arguments,
+                Err(message) => return self.stop_with_internal_error(&message).await,
+            };
         let node = NewHistoryNode {
             parent_node_id: Some(parent_node_id),
             content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
@@ -458,6 +465,23 @@ fn conversation_to_path(conversation: selvedge_db::Conversation) -> Conversation
     ConversationPath { messages }
 }
 
+fn model_provider_profile_from_key(model_profile_key: &str) -> Option<ModelProviderProfile> {
+    let (provider_name, model_name) = model_profile_key
+        .split_once('/')
+        .or_else(|| model_profile_key.split_once(':'))?;
+    let provider_name = provider_name.trim();
+    let model_name = model_name.trim();
+    if provider_name.is_empty() || model_name.is_empty() {
+        return None;
+    }
+    Some(ModelProviderProfile {
+        provider_name: provider_name.to_owned(),
+        model_name: model_name.to_owned(),
+        temperature: None,
+        max_output_tokens: None,
+    })
+}
+
 fn conversation_item_to_message(item: ConversationItem) -> ConversationMessage {
     match item {
         ConversationItem::Message { role, text } => ConversationMessage {
@@ -525,29 +549,45 @@ fn tool_call_arguments_from_payload(
     payload: StructuredPayload,
     tool_name: &ToolName,
     tool_manifest: &ToolManifest,
-) -> Vec<ToolCallArgument> {
-    let StructuredPayload::Object(arguments) = payload else {
-        return Vec::new();
+) -> Result<Vec<ToolCallArgument>, String> {
+    let Some(tool_spec) = tool_manifest
+        .tools
+        .iter()
+        .find(|tool| tool.name == tool_name.0)
+    else {
+        return Err(format!("tool is not enabled for task: {}", tool_name.0));
     };
-    arguments
+    let StructuredPayload::Object(arguments) = payload else {
+        return Err(format!("tool arguments must be an object: {}", tool_name.0));
+    };
+    for parameter in tool_spec
+        .parameters
+        .iter()
+        .filter(|parameter| parameter.required)
+    {
+        if !arguments.contains_key(&parameter.name) {
+            return Err(format!(
+                "required tool argument is missing: {}.{}",
+                tool_name.0, parameter.name
+            ));
+        }
+    }
+
+    let converted = arguments
         .into_iter()
         .filter_map(|(name, value)| {
-            let parameter_type = tool_manifest
-                .tools
+            let parameter_type = tool_spec
+                .parameters
                 .iter()
-                .find(|tool| tool.name == tool_name.0)
-                .and_then(|tool| {
-                    tool.parameters
-                        .iter()
-                        .find(|parameter| parameter.name == name)
-                })
+                .find(|parameter| parameter.name == name)
                 .map(|parameter| &parameter.parameter_type);
             Some(ToolCallArgument {
                 name: ToolParameterName(name),
                 value: tool_argument_value_from_payload(value, parameter_type)?,
             })
         })
-        .collect()
+        .collect();
+    Ok(converted)
 }
 
 fn tool_argument_value_from_payload(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -175,15 +175,7 @@ impl TaskRuntimeActor {
             HistoryNode::Message { message_role, .. } => match message_role {
                 MessageRole::System | MessageRole::User => self.request_model_call().await,
                 MessageRole::Assistant | MessageRole::Developer => {
-                    if loaded.queued_inputs.is_empty() {
-                        self.wait_state = WaitState::AwaitingUserInput;
-                        false
-                    } else {
-                        self.stop_with_internal_error(
-                            "queued user input cannot exist while cursor awaits user input",
-                        )
-                        .await
-                    }
+                    self.enter_awaiting_user_input_or_promote_queue().await
                 }
                 MessageRole::Tool => {
                     self.stop_with_internal_error("tool message cannot be a task cursor tail")
@@ -233,6 +225,17 @@ impl TaskRuntimeActor {
             return false;
         };
         self.dispatch_tool_call(tool_call, pending_tool_calls).await
+    }
+
+    async fn enter_awaiting_user_input_or_promote_queue(&mut self) -> bool {
+        match drain_queued_user_inputs_and_move_cursor(&self.db, &self.task_id, now()) {
+            Ok(Some(_)) => self.request_model_call().await,
+            Ok(None) => {
+                self.wait_state = WaitState::AwaitingUserInput;
+                false
+            }
+            Err(error) => self.stop_with_db_error(error).await,
+        }
     }
 
     async fn handle_user_input(&mut self, message_text: String) -> bool {
@@ -300,10 +303,7 @@ impl TaskRuntimeActor {
                         now(),
                     ) {
                         Ok(_) if had_queued_inputs => self.request_model_call().await,
-                        Ok(_) => {
-                            self.wait_state = WaitState::AwaitingUserInput;
-                            false
-                        }
+                        Ok(_) => self.enter_awaiting_user_input_or_promote_queue().await,
                         Err(error) => self.stop_with_db_error(error).await,
                     }
                 } else {
@@ -355,7 +355,7 @@ impl TaskRuntimeActor {
                 if promoted_queued_input {
                     self.request_model_call().await
                 } else {
-                    false
+                    self.enter_awaiting_user_input_or_promote_queue().await
                 }
             }
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,9 +5,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use selvedge_command_model::{
     ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage,
-    ModelCallDispatchRequest, ModelCallErrorKind, ModelRunId, RouterIngressMessage,
-    RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+    ModelCallDispatchRequest, ModelRunId, RouterIngressMessage, RouterIngressSender,
+    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskRuntimeSender,
+    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_db::{
     DbError, DbPool, HistoryNodeId, MessageRole, NewFunctionCallNodeContent,
@@ -204,9 +204,8 @@ impl TaskRuntimeActor {
                 }
             }
             ApiOutputEnvelope::Failure { correlation, error } => {
-                if error.kind != ModelCallErrorKind::Validation
-                    && (correlation.task_id != self.task_id
-                        || correlation.model_run_id != expected_model_run_id)
+                if correlation.task_id != self.task_id
+                    || correlation.model_run_id != expected_model_run_id
                 {
                     return false;
                 }
@@ -573,20 +572,24 @@ fn tool_call_arguments_from_payload(
         }
     }
 
-    let converted = arguments
-        .into_iter()
-        .filter_map(|(name, value)| {
-            let parameter_type = tool_spec
-                .parameters
-                .iter()
-                .find(|parameter| parameter.name == name)
-                .map(|parameter| &parameter.parameter_type);
-            Some(ToolCallArgument {
-                name: ToolParameterName(name),
-                value: tool_argument_value_from_payload(value, parameter_type)?,
-            })
-        })
-        .collect();
+    let mut converted = Vec::with_capacity(arguments.len());
+    for (name, value) in arguments {
+        let parameter_type = tool_spec
+            .parameters
+            .iter()
+            .find(|parameter| parameter.name == name)
+            .map(|parameter| &parameter.parameter_type);
+        let Some(value) = tool_argument_value_from_payload(value, parameter_type) else {
+            return Err(format!(
+                "tool argument value cannot be converted: {}.{}",
+                tool_name.0, name
+            ));
+        };
+        converted.push(ToolCallArgument {
+            name: ToolParameterName(name),
+            value,
+        });
+    }
     Ok(converted)
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,10 +4,10 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use selvedge_command_model::{
-    ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage,
-    ModelCallDispatchRequest, ModelRunId, RouterIngressMessage, RouterIngressSender,
-    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskRuntimeSender,
-    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+    ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DomainEvent,
+    DomainEventPublishRequest, ModelCallDispatchRequest, ModelRunId, RouterIngressMessage,
+    RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
+    TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_db::{
     DbError, DbPool, FunctionCallId, HistoryNodeId, MessageRole, NewFunctionCallNodeContent,
@@ -238,7 +238,23 @@ impl TaskRuntimeActor {
                     return false;
                 }
                 self.wait_state = WaitState::Idle;
-                let _ = error;
+                if self
+                    .send_core(CoreOutputMessage::PublishDomainEvent(
+                        DomainEventPublishRequest {
+                            task_id: self.task_id.clone(),
+                            event: DomainEvent::ErrorNotice {
+                                message: format!(
+                                    "model call failed: {:?}: {}",
+                                    error.kind, error.message
+                                ),
+                            },
+                        },
+                    ))
+                    .await
+                    .is_err()
+                {
+                    return true;
+                }
                 self.drain_queue_or_idle().await
             }
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use selvedge_command_model::{
@@ -309,6 +309,9 @@ impl TaskRuntimeActor {
             Ok(conversation) => conversation,
             Err(error) => return self.stop_with_db_error(error).await,
         };
+        if let Err(message) = validate_conversation_tool_pairs(&conversation) {
+            return self.stop_with_internal_error(&message).await;
+        }
         let tool_manifest = match read_tool_manifest_for_task(&self.db, &self.task_id) {
             Ok(tool_manifest) => tool_manifest,
             Err(error) => return self.stop_with_db_error(error).await,
@@ -468,6 +471,51 @@ fn conversation_to_path(conversation: selvedge_db::Conversation) -> Conversation
         .map(conversation_item_to_message)
         .collect();
     ConversationPath { messages }
+}
+
+fn validate_conversation_tool_pairs(
+    conversation: &selvedge_db::Conversation,
+) -> Result<(), String> {
+    let mut pending_tool_calls = HashSet::new();
+
+    for item in &conversation.items {
+        match item {
+            ConversationItem::FunctionCall {
+                function_call_id,
+                tool_name,
+                ..
+            } => {
+                let key = (function_call_id.0.clone(), tool_name.0.clone());
+                if !pending_tool_calls.insert(key) {
+                    return Err("conversation contains duplicate open tool call id".to_owned());
+                }
+            }
+            ConversationItem::FunctionOutput {
+                function_call_id,
+                tool_name,
+                ..
+            } => {
+                let key = (function_call_id.0.clone(), tool_name.0.clone());
+                if !pending_tool_calls.remove(&key) {
+                    return Err(
+                        "conversation contains tool output without matching call".to_owned()
+                    );
+                }
+            }
+            ConversationItem::Message { .. } => {}
+        }
+    }
+
+    // Model providers require each tool result in a request to correlate with
+    // a previous tool call, and each open tool call must receive its result
+    // before normal conversation continues. This check belongs at dispatch
+    // time: history is a graph, while API conversation path is a linear
+    // provider protocol with stricter call/output pairing rules.
+    if pending_tool_calls.is_empty() {
+        Ok(())
+    } else {
+        Err("conversation contains tool call without matching output".to_owned())
+    }
 }
 
 fn conversation_item_to_message(item: ConversationItem) -> ConversationMessage {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,0 +1,533 @@
+#![doc = include_str!("../README.md")]
+
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use selvedge_command_model::{
+    ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage,
+    ModelCallDispatchRequest, ModelCallErrorKind, ModelRunId, RouterIngressMessage,
+    RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
+    TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+};
+use selvedge_db::{
+    DbError, DbPool, HistoryNodeId, MessageRole, NewFunctionCallNodeContent,
+    NewFunctionOutputNodeContent, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
+    TaskId, ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
+    append_history_node_and_move_cursor, archive_task, consume_next_queued_user_input,
+    load_active_task, queue_user_input, read_conversation_for_task, read_tool_manifest_for_task,
+};
+use selvedge_domain_model::{
+    ConversationItem, ConversationMessage, ConversationPath, MessageContent, ModelProviderProfile,
+    ResponsePreference, StructuredPayload,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskRuntimeConfig {
+    pub mailbox_capacity: usize,
+}
+
+#[derive(Clone)]
+pub struct SpawnTaskRuntimeArgs {
+    pub task_id: TaskId,
+    pub db: DbPool,
+    pub router_tx: RouterIngressSender,
+    pub config: TaskRuntimeConfig,
+}
+
+#[derive(Debug)]
+pub struct SpawnedTaskRuntime {
+    pub task_id: TaskId,
+    pub task_runtime_tx: TaskRuntimeSender,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpawnTaskRuntimeError {
+    MailboxCreateFailed,
+    TokioSpawnFailed,
+}
+
+pub fn spawn_task_runtime(
+    args: SpawnTaskRuntimeArgs,
+) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
+    let capacity = args.config.mailbox_capacity.max(1);
+    let (task_runtime_tx, task_runtime_rx) = tokio::sync::mpsc::channel(capacity);
+    let spawned = SpawnedTaskRuntime {
+        task_id: args.task_id.clone(),
+        task_runtime_tx: task_runtime_tx.clone(),
+    };
+
+    let actor = TaskRuntimeActor {
+        task_id: args.task_id,
+        db: args.db,
+        router_tx: args.router_tx,
+        self_tx: task_runtime_tx,
+        rx: task_runtime_rx,
+        cursor_node_id: None,
+        model_run_sequence: 0,
+        tool_run_sequence: 0,
+        wait_state: WaitState::Idle,
+    };
+    tokio::spawn(actor.run());
+
+    Ok(spawned)
+}
+
+struct TaskRuntimeActor {
+    task_id: TaskId,
+    db: DbPool,
+    router_tx: RouterIngressSender,
+    self_tx: TaskRuntimeSender,
+    rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
+    cursor_node_id: Option<HistoryNodeId>,
+    model_run_sequence: u64,
+    tool_run_sequence: u64,
+    wait_state: WaitState,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum WaitState {
+    Idle,
+    WaitingModelReply { model_run_id: ModelRunId },
+    WaitingToolResult { tool_run_id: ToolExecutionRunId },
+}
+
+impl TaskRuntimeActor {
+    async fn run(mut self) {
+        while let Some(command) = self.rx.recv().await {
+            let should_stop = match command {
+                TaskRuntimeCommand::Start => self.handle_start().await,
+                TaskRuntimeCommand::UserInput { message_text } => {
+                    self.handle_user_input(message_text).await
+                }
+                TaskRuntimeCommand::ApiModelReply(envelope) => {
+                    self.handle_model_reply(envelope).await
+                }
+                TaskRuntimeCommand::ToolResult(result) => self.handle_tool_result(result).await,
+                TaskRuntimeCommand::Archive => self.handle_archive().await,
+                TaskRuntimeCommand::Stop => {
+                    self.send_exit(TaskRuntimeExitReason::Stopped).await;
+                    true
+                }
+            };
+
+            if should_stop {
+                break;
+            }
+        }
+    }
+
+    async fn handle_start(&mut self) -> bool {
+        match load_active_task(&self.db, &self.task_id) {
+            Ok(task) => {
+                self.cursor_node_id = Some(task.task.cursor_node_id);
+                if self
+                    .send_core(CoreOutputMessage::RuntimeReady {
+                        sender: self.self_tx.clone(),
+                    })
+                    .await
+                    .is_err()
+                {
+                    return true;
+                }
+                self.drain_queue_or_idle().await
+            }
+            Err(error) => {
+                self.send_exit(TaskRuntimeExitReason::DbError(error.to_string()))
+                    .await;
+                true
+            }
+        }
+    }
+
+    async fn handle_user_input(&mut self, message_text: String) -> bool {
+        match self.wait_state {
+            WaitState::Idle => {
+                self.commit_user_message_and_request_model(message_text)
+                    .await
+            }
+            WaitState::WaitingModelReply { .. } | WaitState::WaitingToolResult { .. } => {
+                match queue_user_input(&self.db, &self.task_id, message_text, now()) {
+                    Ok(_) => false,
+                    Err(error) => self.stop_with_db_error(error).await,
+                }
+            }
+        }
+    }
+
+    async fn handle_model_reply(&mut self, envelope: ApiOutputEnvelope) -> bool {
+        let expected_model_run_id = match &self.wait_state {
+            WaitState::WaitingModelReply { model_run_id } => model_run_id.clone(),
+            WaitState::Idle | WaitState::WaitingToolResult { .. } => return false,
+        };
+
+        match envelope {
+            ApiOutputEnvelope::Success { correlation, reply } => {
+                if correlation.task_id != self.task_id
+                    || correlation.model_run_id != expected_model_run_id
+                {
+                    return false;
+                }
+                if let Some(content) = reply.content.filter(|content| !content.trim().is_empty()) {
+                    let Some(parent_node_id) = self.cursor_node_id else {
+                        return self
+                            .stop_with_internal_error("task cursor is missing")
+                            .await;
+                    };
+                    match append_history_node_and_move_cursor(
+                        &self.db,
+                        &self.task_id,
+                        NewHistoryNode {
+                            parent_node_id: Some(parent_node_id),
+                            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                                message_role: MessageRole::Assistant,
+                                message_text: content,
+                            }),
+                            created_at: now(),
+                        },
+                    ) {
+                        Ok(node_id) => self.cursor_node_id = Some(node_id),
+                        Err(error) => return self.stop_with_db_error(error).await,
+                    }
+                }
+
+                if let Some(tool_call) = reply.tool_calls.into_iter().next() {
+                    self.dispatch_tool_call(tool_call).await
+                } else {
+                    self.wait_state = WaitState::Idle;
+                    self.drain_queue_or_idle().await
+                }
+            }
+            ApiOutputEnvelope::Failure { correlation, error } => {
+                if error.kind != ModelCallErrorKind::Validation
+                    && (correlation.task_id != self.task_id
+                        || correlation.model_run_id != expected_model_run_id)
+                {
+                    return false;
+                }
+                self.wait_state = WaitState::Idle;
+                let _ = error;
+                self.drain_queue_or_idle().await
+            }
+        }
+    }
+
+    async fn handle_tool_result(&mut self, result: ToolExecutionResult) -> bool {
+        let expected_tool_run_id = match &self.wait_state {
+            WaitState::WaitingToolResult { tool_run_id } => tool_run_id.clone(),
+            WaitState::Idle | WaitState::WaitingModelReply { .. } => return false,
+        };
+        if result.task_id != self.task_id || result.tool_execution_run_id != expected_tool_run_id {
+            return false;
+        }
+
+        let node = NewHistoryNode {
+            parent_node_id: Some(result.function_call_node_id),
+            content: NewHistoryNodeContent::FunctionOutput(NewFunctionOutputNodeContent {
+                function_call_node_id: result.function_call_node_id,
+                function_call_id: result.function_call_id,
+                tool_name: result.tool_name,
+                output_text: result.output_text,
+                is_error: result.is_error,
+            }),
+            created_at: now(),
+        };
+        match append_history_node_and_move_cursor(&self.db, &self.task_id, node) {
+            Ok(node_id) => {
+                self.cursor_node_id = Some(node_id);
+                self.request_model_call().await
+            }
+            Err(error) => self.stop_with_db_error(error).await,
+        }
+    }
+
+    async fn handle_archive(&mut self) -> bool {
+        match archive_task(&self.db, &self.task_id, now()) {
+            Ok(()) => {
+                self.send_exit(TaskRuntimeExitReason::Archived).await;
+                true
+            }
+            Err(error) => self.stop_with_db_error(error).await,
+        }
+    }
+
+    async fn commit_user_message_and_request_model(&mut self, message_text: String) -> bool {
+        let Some(parent_node_id) = self.cursor_node_id else {
+            return self
+                .stop_with_internal_error("task cursor is missing")
+                .await;
+        };
+        match append_history_node_and_move_cursor(
+            &self.db,
+            &self.task_id,
+            NewHistoryNode {
+                parent_node_id: Some(parent_node_id),
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text,
+                }),
+                created_at: now(),
+            },
+        ) {
+            Ok(node_id) => {
+                self.cursor_node_id = Some(node_id);
+                self.request_model_call().await
+            }
+            Err(error) => self.stop_with_db_error(error).await,
+        }
+    }
+
+    async fn request_model_call(&mut self) -> bool {
+        let conversation = match read_conversation_for_task(&self.db, &self.task_id) {
+            Ok(conversation) => conversation,
+            Err(error) => return self.stop_with_db_error(error).await,
+        };
+        let tool_manifest = match read_tool_manifest_for_task(&self.db, &self.task_id) {
+            Ok(tool_manifest) => tool_manifest,
+            Err(error) => return self.stop_with_db_error(error).await,
+        };
+        let loaded = match load_active_task(&self.db, &self.task_id) {
+            Ok(loaded) => loaded,
+            Err(error) => return self.stop_with_db_error(error).await,
+        };
+        self.model_run_sequence += 1;
+        let model_run_id = ModelRunId(format!(
+            "{}-model-{}",
+            self.task_id.0, self.model_run_sequence
+        ));
+        let request = ModelCallDispatchRequest {
+            correlation: selvedge_command_model::ApiCallCorrelation {
+                api_effect_id: ApiEffectId(format!(
+                    "{}-api-{}",
+                    self.task_id.0, self.model_run_sequence
+                )),
+                task_id: self.task_id.clone(),
+                model_run_id: model_run_id.clone(),
+            },
+            provider: ModelProviderProfile {
+                provider_name: loaded.task.model_profile_key.0.clone(),
+                model_name: loaded.task.model_profile_key.0,
+                temperature: None,
+                max_output_tokens: None,
+            },
+            conversation: conversation_to_path(conversation),
+            tool_manifest: Some(tool_manifest),
+            response_preference: ResponsePreference::PlainTextOrToolCalls,
+        };
+        self.wait_state = WaitState::WaitingModelReply { model_run_id };
+        self.send_core(CoreOutputMessage::RequestModelCall(request))
+            .await
+            .is_err()
+    }
+
+    async fn dispatch_tool_call(
+        &mut self,
+        tool_call: selvedge_domain_model::ToolCallProposal,
+    ) -> bool {
+        let Some(parent_node_id) = self.cursor_node_id else {
+            return self
+                .stop_with_internal_error("task cursor is missing")
+                .await;
+        };
+        let tool_name = ToolName(tool_call.tool_name);
+        let function_call_id = selvedge_db::FunctionCallId(tool_call.call_id);
+        let arguments = tool_call_arguments_from_payload(tool_call.arguments);
+        let node = NewHistoryNode {
+            parent_node_id: Some(parent_node_id),
+            content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
+                function_call_id: function_call_id.clone(),
+                tool_name: tool_name.clone(),
+                arguments: arguments.clone(),
+            }),
+            created_at: now(),
+        };
+        let function_call_node_id =
+            match append_history_node_and_move_cursor(&self.db, &self.task_id, node) {
+                Ok(node_id) => {
+                    self.cursor_node_id = Some(node_id);
+                    node_id
+                }
+                Err(error) => return self.stop_with_db_error(error).await,
+            };
+
+        self.tool_run_sequence += 1;
+        let tool_run_id = ToolExecutionRunId(format!(
+            "{}-tool-{}",
+            self.task_id.0, self.tool_run_sequence
+        ));
+        let request = ToolExecutionRequest {
+            task_id: self.task_id.clone(),
+            tool_execution_run_id: tool_run_id.clone(),
+            function_call_node_id,
+            function_call_id,
+            tool_name,
+            arguments,
+        };
+        self.wait_state = WaitState::WaitingToolResult { tool_run_id };
+        self.send_core(CoreOutputMessage::RequestToolExecution(request))
+            .await
+            .is_err()
+    }
+
+    async fn drain_queue_or_idle(&mut self) -> bool {
+        match consume_next_queued_user_input(&self.db, &self.task_id) {
+            Ok(Some(input)) => {
+                self.wait_state = WaitState::Idle;
+                self.commit_user_message_and_request_model(input.message_text)
+                    .await
+            }
+            Ok(None) => {
+                self.wait_state = WaitState::Idle;
+                false
+            }
+            Err(error) => self.stop_with_db_error(error).await,
+        }
+    }
+
+    async fn send_core(&self, message: CoreOutputMessage) -> Result<(), ()> {
+        self.router_tx
+            .send(RouterIngressMessage::Core(CoreOutputEnvelope {
+                task_id: self.task_id.clone(),
+                message,
+            }))
+            .await
+            .map_err(|_| ())
+    }
+
+    async fn send_exit(&self, reason: TaskRuntimeExitReason) {
+        let _ = self
+            .router_tx
+            .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
+                task_id: self.task_id.clone(),
+                reason,
+            }))
+            .await;
+    }
+
+    async fn stop_with_db_error(&self, error: DbError) -> bool {
+        self.send_exit(TaskRuntimeExitReason::DbError(error.to_string()))
+            .await;
+        true
+    }
+
+    async fn stop_with_internal_error(&self, message: &str) -> bool {
+        self.send_exit(TaskRuntimeExitReason::InternalError(message.to_owned()))
+            .await;
+        true
+    }
+}
+
+fn conversation_to_path(conversation: selvedge_db::Conversation) -> ConversationPath {
+    let messages = conversation
+        .items
+        .into_iter()
+        .map(conversation_item_to_message)
+        .collect();
+    ConversationPath { messages }
+}
+
+fn conversation_item_to_message(item: ConversationItem) -> ConversationMessage {
+    match item {
+        ConversationItem::Message { role, text } => ConversationMessage {
+            role,
+            content: MessageContent::Text(text),
+            source_node_id: None,
+        },
+        ConversationItem::FunctionCall {
+            function_call_id,
+            tool_name,
+            arguments,
+        } => ConversationMessage {
+            role: MessageRole::Assistant,
+            content: MessageContent::Structured(StructuredPayload::Object(BTreeMap::from([
+                (
+                    "function_call_id".to_owned(),
+                    StructuredPayload::String(function_call_id.0),
+                ),
+                (
+                    "tool_name".to_owned(),
+                    StructuredPayload::String(tool_name.0),
+                ),
+                (
+                    "arguments".to_owned(),
+                    StructuredPayload::Array(
+                        arguments
+                            .into_iter()
+                            .map(argument_to_structured_payload)
+                            .collect(),
+                    ),
+                ),
+            ]))),
+            source_node_id: None,
+        },
+        ConversationItem::FunctionOutput {
+            output_text,
+            is_error,
+            ..
+        } => ConversationMessage {
+            role: MessageRole::Tool,
+            content: MessageContent::ToolResultSummary(if is_error {
+                format!("error: {output_text}")
+            } else {
+                output_text
+            }),
+            source_node_id: None,
+        },
+    }
+}
+
+fn argument_to_structured_payload(argument: ToolCallArgument) -> StructuredPayload {
+    StructuredPayload::Object(BTreeMap::from([
+        (
+            "name".to_owned(),
+            StructuredPayload::String(argument.name.0),
+        ),
+        (
+            "value".to_owned(),
+            tool_argument_value_to_payload(argument.value),
+        ),
+    ]))
+}
+
+fn tool_call_arguments_from_payload(payload: StructuredPayload) -> Vec<ToolCallArgument> {
+    let StructuredPayload::Object(arguments) = payload else {
+        return Vec::new();
+    };
+    arguments
+        .into_iter()
+        .filter_map(|(name, value)| {
+            Some(ToolCallArgument {
+                name: ToolParameterName(name),
+                value: tool_argument_value_from_payload(value)?,
+            })
+        })
+        .collect()
+}
+
+fn tool_argument_value_from_payload(payload: StructuredPayload) -> Option<ToolArgumentValue> {
+    match payload {
+        StructuredPayload::String(value) => Some(ToolArgumentValue::String(value)),
+        StructuredPayload::Number(value) => Some(ToolArgumentValue::Number(value)),
+        StructuredPayload::Boolean(value) => Some(ToolArgumentValue::Boolean(value)),
+        StructuredPayload::Object(_) | StructuredPayload::Array(_) | StructuredPayload::Null => {
+            None
+        }
+    }
+}
+
+fn tool_argument_value_to_payload(value: ToolArgumentValue) -> StructuredPayload {
+    match value {
+        ToolArgumentValue::String(value) => StructuredPayload::String(value),
+        ToolArgumentValue::Integer(value) => StructuredPayload::Number(value as f64),
+        ToolArgumentValue::Number(value) => StructuredPayload::Number(value),
+        ToolArgumentValue::Boolean(value) => StructuredPayload::Boolean(value),
+    }
+}
+
+fn now() -> UnixTs {
+    UnixTs(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0),
+    )
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,8 +15,8 @@ use selvedge_db::{
     ToolCallArgument, ToolName, ToolParameterName, UnixTs,
     append_assistant_message_and_drain_queue, append_function_output_and_drain_queue,
     append_model_reply_with_tool_calls_and_move_cursor, append_user_message_and_move_cursor,
-    archive_task, load_active_task, queue_user_input, read_conversation_for_task,
-    read_tool_manifest_for_task,
+    archive_task, drain_queued_user_inputs_and_move_cursor, load_active_task, queue_user_input,
+    read_conversation_for_task, read_open_function_calls_for_task, read_tool_manifest_for_task,
 };
 use selvedge_domain_model::{
     ConversationItem, ConversationMessage, ConversationPath, MessageContent, ModelProfileKey,
@@ -163,6 +163,14 @@ impl TaskRuntimeActor {
     }
 
     async fn start_from_cursor_tail(&mut self, loaded: selvedge_db::LoadedActiveTask) -> bool {
+        match read_open_function_calls_for_task(&self.db, &self.task_id) {
+            Ok(open_calls) if !open_calls.is_empty() => {
+                return self.dispatch_open_tool_calls(open_calls).await;
+            }
+            Ok(_) => {}
+            Err(error) => return self.stop_with_db_error(error).await,
+        }
+
         match loaded.cursor_node {
             HistoryNode::Message { message_role, .. } => match message_role {
                 MessageRole::System | MessageRole::User => self.request_model_call().await,
@@ -206,6 +214,25 @@ impl TaskRuntimeActor {
                     .await
             }
         }
+    }
+
+    async fn dispatch_open_tool_calls(
+        &mut self,
+        open_calls: Vec<selvedge_db::OpenFunctionCall>,
+    ) -> bool {
+        let mut pending_tool_calls = open_calls
+            .into_iter()
+            .map(|call| PendingToolCall {
+                function_call_node_id: call.function_call_node_id,
+                function_call_id: call.function_call_id,
+                tool_name: call.tool_name,
+                arguments: call.arguments,
+            })
+            .collect::<VecDeque<_>>();
+        let Some(tool_call) = pending_tool_calls.pop_front() else {
+            return false;
+        };
+        self.dispatch_tool_call(tool_call, pending_tool_calls).await
     }
 
     async fn handle_user_input(&mut self, message_text: String) -> bool {
@@ -300,6 +327,14 @@ impl TaskRuntimeActor {
                     return false;
                 }
                 self.wait_state = WaitState::AwaitingUserInput;
+                let promoted_queued_input = match drain_queued_user_inputs_and_move_cursor(
+                    &self.db,
+                    &self.task_id,
+                    now(),
+                ) {
+                    Ok(node_id) => node_id.is_some(),
+                    Err(error) => return self.stop_with_db_error(error).await,
+                };
                 if self
                     .send_core(CoreOutputMessage::PublishDomainEvent(
                         DomainEventPublishRequest {
@@ -317,7 +352,11 @@ impl TaskRuntimeActor {
                 {
                     return true;
                 }
-                false
+                if promoted_queued_input {
+                    self.request_model_call().await
+                } else {
+                    false
+                }
             }
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use selvedge_command_model::{
@@ -17,14 +17,16 @@ use selvedge_db::{
     load_active_task, queue_user_input, read_conversation_for_task, read_tool_manifest_for_task,
 };
 use selvedge_domain_model::{
-    ConversationItem, ConversationMessage, ConversationPath, MessageContent, ModelProviderProfile,
-    ResponsePreference, StructuredPayload, ToolCallProposal, ToolManifest, ToolParameterType,
+    ConversationItem, ConversationMessage, ConversationPath, MessageContent, ModelProfileKey,
+    ModelProviderProfile, ResponsePreference, StructuredPayload, ToolCallProposal, ToolManifest,
+    ToolParameterType,
 };
 use uuid::Uuid;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TaskRuntimeConfig {
     pub mailbox_capacity: usize,
+    pub model_profiles: HashMap<ModelProfileKey, ModelProviderProfile>,
 }
 
 #[derive(Clone)]
@@ -65,6 +67,7 @@ pub fn spawn_task_runtime(
         rx: task_runtime_rx,
         cursor_node_id: None,
         started: false,
+        model_profiles: args.config.model_profiles,
         wait_state: WaitState::Idle,
     };
     tokio::spawn(actor.run());
@@ -80,6 +83,7 @@ struct TaskRuntimeActor {
     rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
     cursor_node_id: Option<HistoryNodeId>,
     started: bool,
+    model_profiles: HashMap<ModelProfileKey, ModelProviderProfile>,
     wait_state: WaitState,
 }
 
@@ -305,12 +309,13 @@ impl TaskRuntimeActor {
             Err(error) => return self.stop_with_db_error(error).await,
         };
         let model_run_id = ModelRunId(format!("{}-model-{}", self.task_id.0, Uuid::new_v4()));
-        let Some(provider) = model_provider_profile_from_key(&loaded.task.model_profile_key.0)
+        let Some(provider) = self
+            .model_profiles
+            .get(&loaded.task.model_profile_key)
+            .cloned()
         else {
             return self
-                .stop_with_internal_error(
-                    "model profile key must be provider/model or provider:model",
-                )
+                .stop_with_internal_error("model profile key is not configured")
                 .await;
         };
         let request = ModelCallDispatchRequest {
@@ -454,23 +459,6 @@ fn conversation_to_path(conversation: selvedge_db::Conversation) -> Conversation
         .map(conversation_item_to_message)
         .collect();
     ConversationPath { messages }
-}
-
-fn model_provider_profile_from_key(model_profile_key: &str) -> Option<ModelProviderProfile> {
-    let (provider_name, model_name) = model_profile_key
-        .split_once('/')
-        .or_else(|| model_profile_key.split_once(':'))?;
-    let provider_name = provider_name.trim();
-    let model_name = model_name.trim();
-    if provider_name.is_empty() || model_name.is_empty() {
-        return None;
-    }
-    Some(ModelProviderProfile {
-        provider_name: provider_name.to_owned(),
-        model_name: model_name.to_owned(),
-        temperature: None,
-        max_output_tokens: None,
-    })
 }
 
 fn conversation_item_to_message(item: ConversationItem) -> ConversationMessage {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -96,12 +96,20 @@ enum WaitState {
     },
     WaitingToolResult {
         tool_run_id: ToolExecutionRunId,
-        pending_tool_calls: VecDeque<ValidatedToolCall>,
+        pending_tool_calls: VecDeque<PendingToolCall>,
     },
 }
 
 #[derive(Clone, Debug, PartialEq)]
 struct ValidatedToolCall {
+    function_call_id: FunctionCallId,
+    tool_name: ToolName,
+    arguments: Vec<ToolCallArgument>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct PendingToolCall {
+    function_call_node_id: HistoryNodeId,
     function_call_id: FunctionCallId,
     tool_name: ToolName,
     arguments: Vec<ToolCallArgument>,
@@ -229,12 +237,16 @@ impl TaskRuntimeActor {
                     }
                 }
 
-                let mut pending_tool_calls = pending_tool_calls;
-                if let Some(tool_call) = pending_tool_calls.pop_front() {
-                    self.dispatch_tool_call(tool_call, pending_tool_calls).await
-                } else {
-                    self.wait_state = WaitState::Idle;
-                    self.drain_queue_or_idle().await
+                match self.append_tool_calls(pending_tool_calls) {
+                    Ok(mut pending_tool_calls) => {
+                        if let Some(tool_call) = pending_tool_calls.pop_front() {
+                            self.dispatch_tool_call(tool_call, pending_tool_calls).await
+                        } else {
+                            self.wait_state = WaitState::Idle;
+                            self.drain_queue_or_idle().await
+                        }
+                    }
+                    Err(error) => self.stop_with_db_error(error).await,
                 }
             }
             ApiOutputEnvelope::Failure { correlation, error } => {
@@ -389,39 +401,53 @@ impl TaskRuntimeActor {
             .is_err()
     }
 
+    fn append_tool_calls(
+        &mut self,
+        tool_calls: VecDeque<ValidatedToolCall>,
+    ) -> Result<VecDeque<PendingToolCall>, DbError> {
+        let mut pending_tool_calls = VecDeque::new();
+        for tool_call in tool_calls {
+            let Some(parent_node_id) = self.cursor_node_id else {
+                return Err(DbError::Storage("task cursor is missing".to_owned()));
+            };
+            // A model turn can emit several tool calls at once. Persist every
+            // call from that turn before any tool output so the provider path
+            // remains causal: calls describe requested work, outputs describe
+            // later observations correlated by call id.
+            let node_id = append_history_node_and_move_cursor(
+                &self.db,
+                &self.task_id,
+                NewHistoryNode {
+                    parent_node_id: Some(parent_node_id),
+                    content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
+                        function_call_id: tool_call.function_call_id.clone(),
+                        tool_name: tool_call.tool_name.clone(),
+                        arguments: tool_call.arguments.clone(),
+                    }),
+                    created_at: now(),
+                },
+            )?;
+            self.cursor_node_id = Some(node_id);
+            pending_tool_calls.push_back(PendingToolCall {
+                function_call_node_id: node_id,
+                function_call_id: tool_call.function_call_id,
+                tool_name: tool_call.tool_name,
+                arguments: tool_call.arguments,
+            });
+        }
+        Ok(pending_tool_calls)
+    }
+
     async fn dispatch_tool_call(
         &mut self,
-        tool_call: ValidatedToolCall,
-        pending_tool_calls: VecDeque<ValidatedToolCall>,
+        tool_call: PendingToolCall,
+        pending_tool_calls: VecDeque<PendingToolCall>,
     ) -> bool {
-        let Some(parent_node_id) = self.cursor_node_id else {
-            return self
-                .stop_with_internal_error("task cursor is missing")
-                .await;
-        };
-        let node = NewHistoryNode {
-            parent_node_id: Some(parent_node_id),
-            content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
-                function_call_id: tool_call.function_call_id.clone(),
-                tool_name: tool_call.tool_name.clone(),
-                arguments: tool_call.arguments.clone(),
-            }),
-            created_at: now(),
-        };
-        let function_call_node_id =
-            match append_history_node_and_move_cursor(&self.db, &self.task_id, node) {
-                Ok(node_id) => {
-                    self.cursor_node_id = Some(node_id);
-                    node_id
-                }
-                Err(error) => return self.stop_with_db_error(error).await,
-            };
-
         let tool_run_id = ToolExecutionRunId(format!("{}-tool-{}", self.task_id.0, Uuid::new_v4()));
         let request = ToolExecutionRequest {
             task_id: self.task_id.clone(),
             tool_execution_run_id: tool_run_id.clone(),
-            function_call_node_id,
+            function_call_node_id: tool_call.function_call_node_id,
             function_call_id: tool_call.function_call_id,
             tool_name: tool_call.tool_name,
             arguments: tool_call.arguments,
@@ -437,7 +463,7 @@ impl TaskRuntimeActor {
 
     async fn dispatch_next_tool_or_request_model(
         &mut self,
-        mut pending_tool_calls: VecDeque<ValidatedToolCall>,
+        mut pending_tool_calls: VecDeque<PendingToolCall>,
     ) -> bool {
         if let Some(tool_call) = pending_tool_calls.pop_front() {
             self.dispatch_tool_call(tool_call, pending_tool_calls).await
@@ -506,7 +532,7 @@ fn conversation_to_path(conversation: selvedge_db::Conversation) -> Conversation
 fn validate_conversation_tool_pairs(
     conversation: &selvedge_db::Conversation,
 ) -> Result<(), String> {
-    let mut pending_tool_calls = HashSet::new();
+    let mut pending_tool_calls = HashMap::new();
 
     for item in &conversation.items {
         match item {
@@ -515,8 +541,10 @@ fn validate_conversation_tool_pairs(
                 tool_name,
                 ..
             } => {
-                let key = (function_call_id.0.clone(), tool_name.0.clone());
-                if !pending_tool_calls.insert(key) {
+                if pending_tool_calls
+                    .insert(function_call_id.0.clone(), tool_name.0.clone())
+                    .is_some()
+                {
                     return Err("conversation contains duplicate open tool call id".to_owned());
                 }
             }
@@ -525,11 +553,14 @@ fn validate_conversation_tool_pairs(
                 tool_name,
                 ..
             } => {
-                let key = (function_call_id.0.clone(), tool_name.0.clone());
-                if !pending_tool_calls.remove(&key) {
+                let Some(expected_tool_name) = pending_tool_calls.remove(&function_call_id.0)
+                else {
                     return Err(
                         "conversation contains tool output without matching call".to_owned()
                     );
+                };
+                if expected_tool_name != tool_name.0 {
+                    return Err("conversation contains tool output with mismatched tool".to_owned());
                 }
             }
             ConversationItem::Message { .. } => {}
@@ -630,19 +661,22 @@ fn validate_tool_calls(
     // requested tool call before persisting the first function_call node or
     // dispatching the first tool, so a malformed later call cannot leave
     // earlier side effects behind.
-    tool_calls
-        .into_iter()
-        .map(|tool_call| {
-            let tool_name = ToolName(tool_call.tool_name);
-            let arguments =
-                tool_call_arguments_from_payload(tool_call.arguments, &tool_name, tool_manifest)?;
-            Ok(ValidatedToolCall {
-                function_call_id: FunctionCallId(tool_call.call_id),
-                tool_name,
-                arguments,
-            })
-        })
-        .collect()
+    let mut seen_call_ids = HashSet::new();
+    let mut validated = VecDeque::new();
+    for tool_call in tool_calls {
+        if !seen_call_ids.insert(tool_call.call_id.clone()) {
+            return Err("model reply contains duplicate tool call id".to_owned());
+        }
+        let tool_name = ToolName(tool_call.tool_name);
+        let arguments =
+            tool_call_arguments_from_payload(tool_call.arguments, &tool_name, tool_manifest)?;
+        validated.push_back(ValidatedToolCall {
+            function_call_id: FunctionCallId(tool_call.call_id),
+            tool_name,
+            arguments,
+        });
+    }
+    Ok(validated)
 }
 
 fn tool_call_arguments_from_payload(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use selvedge_command_model::{
@@ -18,7 +18,7 @@ use selvedge_db::{
 };
 use selvedge_domain_model::{
     ConversationItem, ConversationMessage, ConversationPath, MessageContent, ModelProviderProfile,
-    ResponsePreference, StructuredPayload,
+    ResponsePreference, StructuredPayload, ToolCallProposal, ToolManifest, ToolParameterType,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -87,8 +87,13 @@ struct TaskRuntimeActor {
 #[derive(Clone, Debug, PartialEq)]
 enum WaitState {
     Idle,
-    WaitingModelReply { model_run_id: ModelRunId },
-    WaitingToolResult { tool_run_id: ToolExecutionRunId },
+    WaitingModelReply {
+        model_run_id: ModelRunId,
+    },
+    WaitingToolResult {
+        tool_run_id: ToolExecutionRunId,
+        pending_tool_calls: VecDeque<ToolCallProposal>,
+    },
 }
 
 impl TaskRuntimeActor {
@@ -190,8 +195,9 @@ impl TaskRuntimeActor {
                     }
                 }
 
-                if let Some(tool_call) = reply.tool_calls.into_iter().next() {
-                    self.dispatch_tool_call(tool_call).await
+                let mut pending_tool_calls = VecDeque::from(reply.tool_calls);
+                if let Some(tool_call) = pending_tool_calls.pop_front() {
+                    self.dispatch_tool_call(tool_call, pending_tool_calls).await
                 } else {
                     self.wait_state = WaitState::Idle;
                     self.drain_queue_or_idle().await
@@ -212,13 +218,19 @@ impl TaskRuntimeActor {
     }
 
     async fn handle_tool_result(&mut self, result: ToolExecutionResult) -> bool {
-        let expected_tool_run_id = match &self.wait_state {
-            WaitState::WaitingToolResult { tool_run_id } => tool_run_id.clone(),
+        let pending_tool_calls = match std::mem::replace(&mut self.wait_state, WaitState::Idle) {
+            WaitState::WaitingToolResult {
+                tool_run_id,
+                pending_tool_calls,
+            } if result.task_id == self.task_id && result.tool_execution_run_id == tool_run_id => {
+                pending_tool_calls
+            }
+            wait_state @ WaitState::WaitingToolResult { .. } => {
+                self.wait_state = wait_state;
+                return false;
+            }
             WaitState::Idle | WaitState::WaitingModelReply { .. } => return false,
         };
-        if result.task_id != self.task_id || result.tool_execution_run_id != expected_tool_run_id {
-            return false;
-        }
 
         let node = NewHistoryNode {
             parent_node_id: Some(result.function_call_node_id),
@@ -234,7 +246,8 @@ impl TaskRuntimeActor {
         match append_history_node_and_move_cursor(&self.db, &self.task_id, node) {
             Ok(node_id) => {
                 self.cursor_node_id = Some(node_id);
-                self.request_model_call().await
+                self.dispatch_next_tool_or_request_model(pending_tool_calls)
+                    .await
             }
             Err(error) => self.stop_with_db_error(error).await,
         }
@@ -321,7 +334,8 @@ impl TaskRuntimeActor {
 
     async fn dispatch_tool_call(
         &mut self,
-        tool_call: selvedge_domain_model::ToolCallProposal,
+        tool_call: ToolCallProposal,
+        pending_tool_calls: VecDeque<ToolCallProposal>,
     ) -> bool {
         let Some(parent_node_id) = self.cursor_node_id else {
             return self
@@ -330,7 +344,12 @@ impl TaskRuntimeActor {
         };
         let tool_name = ToolName(tool_call.tool_name);
         let function_call_id = selvedge_db::FunctionCallId(tool_call.call_id);
-        let arguments = tool_call_arguments_from_payload(tool_call.arguments);
+        let tool_manifest = match read_tool_manifest_for_task(&self.db, &self.task_id) {
+            Ok(tool_manifest) => tool_manifest,
+            Err(error) => return self.stop_with_db_error(error).await,
+        };
+        let arguments =
+            tool_call_arguments_from_payload(tool_call.arguments, &tool_name, &tool_manifest);
         let node = NewHistoryNode {
             parent_node_id: Some(parent_node_id),
             content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
@@ -362,10 +381,24 @@ impl TaskRuntimeActor {
             tool_name,
             arguments,
         };
-        self.wait_state = WaitState::WaitingToolResult { tool_run_id };
+        self.wait_state = WaitState::WaitingToolResult {
+            tool_run_id,
+            pending_tool_calls,
+        };
         self.send_core(CoreOutputMessage::RequestToolExecution(request))
             .await
             .is_err()
+    }
+
+    async fn dispatch_next_tool_or_request_model(
+        &mut self,
+        mut pending_tool_calls: VecDeque<ToolCallProposal>,
+    ) -> bool {
+        if let Some(tool_call) = pending_tool_calls.pop_front() {
+            self.dispatch_tool_call(tool_call, pending_tool_calls).await
+        } else {
+            self.request_model_call().await
+        }
     }
 
     async fn drain_queue_or_idle(&mut self) -> bool {
@@ -488,24 +521,50 @@ fn argument_to_structured_payload(argument: ToolCallArgument) -> StructuredPaylo
     ]))
 }
 
-fn tool_call_arguments_from_payload(payload: StructuredPayload) -> Vec<ToolCallArgument> {
+fn tool_call_arguments_from_payload(
+    payload: StructuredPayload,
+    tool_name: &ToolName,
+    tool_manifest: &ToolManifest,
+) -> Vec<ToolCallArgument> {
     let StructuredPayload::Object(arguments) = payload else {
         return Vec::new();
     };
     arguments
         .into_iter()
         .filter_map(|(name, value)| {
+            let parameter_type = tool_manifest
+                .tools
+                .iter()
+                .find(|tool| tool.name == tool_name.0)
+                .and_then(|tool| {
+                    tool.parameters
+                        .iter()
+                        .find(|parameter| parameter.name == name)
+                })
+                .map(|parameter| &parameter.parameter_type);
             Some(ToolCallArgument {
                 name: ToolParameterName(name),
-                value: tool_argument_value_from_payload(value)?,
+                value: tool_argument_value_from_payload(value, parameter_type)?,
             })
         })
         .collect()
 }
 
-fn tool_argument_value_from_payload(payload: StructuredPayload) -> Option<ToolArgumentValue> {
+fn tool_argument_value_from_payload(
+    payload: StructuredPayload,
+    parameter_type: Option<&ToolParameterType>,
+) -> Option<ToolArgumentValue> {
     match payload {
         StructuredPayload::String(value) => Some(ToolArgumentValue::String(value)),
+        StructuredPayload::Number(value)
+            if parameter_type == Some(&ToolParameterType::Integer)
+                && value.is_finite()
+                && value.fract() == 0.0
+                && value >= i64::MIN as f64
+                && value <= i64::MAX as f64 =>
+        {
+            Some(ToolArgumentValue::Integer(value as i64))
+        }
         StructuredPayload::Number(value) => Some(ToolArgumentValue::Number(value)),
         StructuredPayload::Boolean(value) => Some(ToolArgumentValue::Boolean(value)),
         StructuredPayload::Object(_) | StructuredPayload::Array(_) | StructuredPayload::Null => {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,6 +20,7 @@ use selvedge_domain_model::{
     ConversationItem, ConversationMessage, ConversationPath, MessageContent, ModelProviderProfile,
     ResponsePreference, StructuredPayload, ToolCallProposal, ToolManifest, ToolParameterType,
 };
+use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TaskRuntimeConfig {
@@ -63,8 +64,7 @@ pub fn spawn_task_runtime(
         self_tx: task_runtime_tx,
         rx: task_runtime_rx,
         cursor_node_id: None,
-        model_run_sequence: 0,
-        tool_run_sequence: 0,
+        started: false,
         wait_state: WaitState::Idle,
     };
     tokio::spawn(actor.run());
@@ -79,8 +79,7 @@ struct TaskRuntimeActor {
     self_tx: TaskRuntimeSender,
     rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
     cursor_node_id: Option<HistoryNodeId>,
-    model_run_sequence: u64,
-    tool_run_sequence: u64,
+    started: bool,
     wait_state: WaitState,
 }
 
@@ -122,8 +121,12 @@ impl TaskRuntimeActor {
     }
 
     async fn handle_start(&mut self) -> bool {
+        if self.started {
+            return false;
+        }
         match load_active_task(&self.db, &self.task_id) {
             Ok(task) => {
+                self.started = true;
                 self.cursor_node_id = Some(task.task.cursor_node_id);
                 if self
                     .send_core(CoreOutputMessage::RuntimeReady {
@@ -301,11 +304,7 @@ impl TaskRuntimeActor {
             Ok(loaded) => loaded,
             Err(error) => return self.stop_with_db_error(error).await,
         };
-        self.model_run_sequence += 1;
-        let model_run_id = ModelRunId(format!(
-            "{}-model-{}",
-            self.task_id.0, self.model_run_sequence
-        ));
+        let model_run_id = ModelRunId(format!("{}-model-{}", self.task_id.0, Uuid::new_v4()));
         let Some(provider) = model_provider_profile_from_key(&loaded.task.model_profile_key.0)
         else {
             return self
@@ -316,10 +315,7 @@ impl TaskRuntimeActor {
         };
         let request = ModelCallDispatchRequest {
             correlation: selvedge_command_model::ApiCallCorrelation {
-                api_effect_id: ApiEffectId(format!(
-                    "{}-api-{}",
-                    self.task_id.0, self.model_run_sequence
-                )),
+                api_effect_id: ApiEffectId(format!("{}-api-{}", self.task_id.0, Uuid::new_v4())),
                 task_id: self.task_id.clone(),
                 model_run_id: model_run_id.clone(),
             },
@@ -374,11 +370,7 @@ impl TaskRuntimeActor {
                 Err(error) => return self.stop_with_db_error(error).await,
             };
 
-        self.tool_run_sequence += 1;
-        let tool_run_id = ToolExecutionRunId(format!(
-            "{}-tool-{}",
-            self.task_id.0, self.tool_run_sequence
-        ));
+        let tool_run_id = ToolExecutionRunId(format!("{}-tool-{}", self.task_id.0, Uuid::new_v4()));
         let request = ToolExecutionRequest {
             task_id: self.task_id.clone(),
             tool_execution_run_id: tool_run_id.clone(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -160,6 +160,12 @@ impl TaskRuntimeActor {
     }
 
     async fn handle_user_input(&mut self, message_text: String) -> bool {
+        if message_text.is_empty() {
+            return self
+                .stop_with_internal_error("user input must not be empty")
+                .await;
+        }
+
         match self.wait_state {
             WaitState::Idle => {
                 self.commit_user_message_and_request_model(message_text)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -600,9 +600,14 @@ fn tool_argument_value_from_payload(
             if value.is_finite()
                 && value.fract() == 0.0
                 && value >= i64::MIN as f64
-                && value <= i64::MAX as f64 =>
+                && value < 9_223_372_036_854_775_808.0 =>
         {
-            Some(ToolArgumentValue::Integer(value as i64))
+            let converted = value as i64;
+            if converted as f64 == value {
+                Some(ToolArgumentValue::Integer(converted))
+            } else {
+                None
+            }
         }
         (ToolParameterType::Number, StructuredPayload::Number(value)) if value.is_finite() => {
             Some(ToolArgumentValue::Number(value))

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,7 +10,7 @@ use selvedge_command_model::{
     ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_db::{
-    DbError, DbPool, HistoryNodeId, MessageRole, NewFunctionCallNodeContent,
+    DbError, DbPool, FunctionCallId, HistoryNodeId, MessageRole, NewFunctionCallNodeContent,
     NewFunctionOutputNodeContent, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
     TaskId, ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
     append_history_node_and_move_cursor, append_next_queued_user_input_and_move_cursor,
@@ -96,8 +96,15 @@ enum WaitState {
     },
     WaitingToolResult {
         tool_run_id: ToolExecutionRunId,
-        pending_tool_calls: VecDeque<ToolCallProposal>,
+        pending_tool_calls: VecDeque<ValidatedToolCall>,
     },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct ValidatedToolCall {
+    function_call_id: FunctionCallId,
+    tool_name: ToolName,
+    arguments: Vec<ToolCallArgument>,
 }
 
 impl TaskRuntimeActor {
@@ -180,6 +187,19 @@ impl TaskRuntimeActor {
                 {
                     return false;
                 }
+                let pending_tool_calls = if reply.tool_calls.is_empty() {
+                    VecDeque::new()
+                } else {
+                    let tool_manifest = match read_tool_manifest_for_task(&self.db, &self.task_id) {
+                        Ok(tool_manifest) => tool_manifest,
+                        Err(error) => return self.stop_with_db_error(error).await,
+                    };
+                    match validate_tool_calls(reply.tool_calls, &tool_manifest) {
+                        Ok(tool_calls) => tool_calls,
+                        Err(message) => return self.stop_with_internal_error(&message).await,
+                    }
+                };
+
                 if let Some(content) = reply.content.filter(|content| !content.trim().is_empty()) {
                     let Some(parent_node_id) = self.cursor_node_id else {
                         return self
@@ -203,7 +223,7 @@ impl TaskRuntimeActor {
                     }
                 }
 
-                let mut pending_tool_calls = VecDeque::from(reply.tool_calls);
+                let mut pending_tool_calls = pending_tool_calls;
                 if let Some(tool_call) = pending_tool_calls.pop_front() {
                     self.dispatch_tool_call(tool_call, pending_tool_calls).await
                 } else {
@@ -349,32 +369,20 @@ impl TaskRuntimeActor {
 
     async fn dispatch_tool_call(
         &mut self,
-        tool_call: ToolCallProposal,
-        pending_tool_calls: VecDeque<ToolCallProposal>,
+        tool_call: ValidatedToolCall,
+        pending_tool_calls: VecDeque<ValidatedToolCall>,
     ) -> bool {
         let Some(parent_node_id) = self.cursor_node_id else {
             return self
                 .stop_with_internal_error("task cursor is missing")
                 .await;
         };
-        let tool_name = ToolName(tool_call.tool_name);
-        let function_call_id = selvedge_db::FunctionCallId(tool_call.call_id);
-        let tool_manifest = match read_tool_manifest_for_task(&self.db, &self.task_id) {
-            Ok(tool_manifest) => tool_manifest,
-            Err(error) => return self.stop_with_db_error(error).await,
-        };
-        let arguments =
-            match tool_call_arguments_from_payload(tool_call.arguments, &tool_name, &tool_manifest)
-            {
-                Ok(arguments) => arguments,
-                Err(message) => return self.stop_with_internal_error(&message).await,
-            };
         let node = NewHistoryNode {
             parent_node_id: Some(parent_node_id),
             content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
-                function_call_id: function_call_id.clone(),
-                tool_name: tool_name.clone(),
-                arguments: arguments.clone(),
+                function_call_id: tool_call.function_call_id.clone(),
+                tool_name: tool_call.tool_name.clone(),
+                arguments: tool_call.arguments.clone(),
             }),
             created_at: now(),
         };
@@ -392,9 +400,9 @@ impl TaskRuntimeActor {
             task_id: self.task_id.clone(),
             tool_execution_run_id: tool_run_id.clone(),
             function_call_node_id,
-            function_call_id,
-            tool_name,
-            arguments,
+            function_call_id: tool_call.function_call_id,
+            tool_name: tool_call.tool_name,
+            arguments: tool_call.arguments,
         };
         self.wait_state = WaitState::WaitingToolResult {
             tool_run_id,
@@ -407,7 +415,7 @@ impl TaskRuntimeActor {
 
     async fn dispatch_next_tool_or_request_model(
         &mut self,
-        mut pending_tool_calls: VecDeque<ToolCallProposal>,
+        mut pending_tool_calls: VecDeque<ValidatedToolCall>,
     ) -> bool {
         if let Some(tool_call) = pending_tool_calls.pop_front() {
             self.dispatch_tool_call(tool_call, pending_tool_calls).await
@@ -590,6 +598,29 @@ fn argument_to_structured_payload(argument: ToolCallArgument) -> StructuredPaylo
             tool_argument_value_to_payload(argument.value),
         ),
     ]))
+}
+
+fn validate_tool_calls(
+    tool_calls: Vec<ToolCallProposal>,
+    tool_manifest: &ToolManifest,
+) -> Result<VecDeque<ValidatedToolCall>, String> {
+    // A provider reply is accepted as one unit. Validate and normalize every
+    // requested tool call before persisting the first function_call node or
+    // dispatching the first tool, so a malformed later call cannot leave
+    // earlier side effects behind.
+    tool_calls
+        .into_iter()
+        .map(|tool_call| {
+            let tool_name = ToolName(tool_call.tool_name);
+            let arguments =
+                tool_call_arguments_from_payload(tool_call.arguments, &tool_name, tool_manifest)?;
+            Ok(ValidatedToolCall {
+                function_call_id: FunctionCallId(tool_call.call_id),
+                tool_name,
+                arguments,
+            })
+        })
+        .collect()
 }
 
 fn tool_call_arguments_from_payload(

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -14,8 +14,8 @@ use selvedge_db::{
     queue_user_input, register_tool,
 };
 use selvedge_domain_model::{
-    ModelFinishReason, ModelReply, StructuredPayload, ToolCallProposal, ToolParameter,
-    ToolParameterType, ToolSpec,
+    MessageContent, ModelFinishReason, ModelReply, StructuredPayload, ToolCallProposal,
+    ToolParameter, ToolParameterType, ToolSpec,
 };
 
 #[tokio::test]
@@ -150,6 +150,132 @@ async fn task_runtime_dispatches_all_tool_calls_before_next_model_call() {
 
     let second_tool_request = recv_tool_request(&mut router_rx).await;
     assert_eq!(second_tool_request.function_call_id.0, "call-2");
+}
+
+#[tokio::test]
+async fn task_runtime_preserves_batched_tool_call_order_in_next_model_request() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "search".to_owned(),
+        description: "search".to_owned(),
+        parameters: Vec::new(),
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![
+                        ToolCallProposal {
+                            call_id: "call-1".to_owned(),
+                            tool_name: "search".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                        ToolCallProposal {
+                            call_id: "call-2".to_owned(),
+                            tool_name: "search".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                    ],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    let first_tool_request = recv_tool_request(&mut router_rx).await;
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ToolResult(ToolExecutionResult {
+            task_id: TaskId("task-1".to_owned()),
+            tool_execution_run_id: first_tool_request.tool_execution_run_id,
+            function_call_node_id: first_tool_request.function_call_node_id,
+            function_call_id: first_tool_request.function_call_id,
+            tool_name: first_tool_request.tool_name,
+            output_text: "first".to_owned(),
+            is_error: false,
+        }))
+        .await
+        .expect("send first tool result");
+
+    let second_tool_request = recv_tool_request(&mut router_rx).await;
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ToolResult(ToolExecutionResult {
+            task_id: TaskId("task-1".to_owned()),
+            tool_execution_run_id: second_tool_request.tool_execution_run_id,
+            function_call_node_id: second_tool_request.function_call_node_id,
+            function_call_id: second_tool_request.function_call_id,
+            tool_name: second_tool_request.tool_name,
+            output_text: "second".to_owned(),
+            is_error: false,
+        }))
+        .await
+        .expect("send second tool result");
+
+    let request = recv_model_request(&mut router_rx).await;
+    assert_eq!(
+        tool_transcript_events(&request),
+        vec![
+            "call:call-1",
+            "call:call-2",
+            "output:call-1",
+            "output:call-2"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn task_runtime_rejects_duplicate_tool_call_ids_in_one_model_reply() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![
+        ToolSpec {
+            name: "search".to_owned(),
+            description: "search".to_owned(),
+            parameters: Vec::new(),
+        },
+        ToolSpec {
+            name: "lookup".to_owned(),
+            description: "lookup".to_owned(),
+            parameters: Vec::new(),
+        },
+    ])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![
+                        ToolCallProposal {
+                            call_id: "call-1".to_owned(),
+                            tool_name: "search".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                        ToolCallProposal {
+                            call_id: "call-1".to_owned(),
+                            tool_name: "lookup".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                    ],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
 }
 
 #[tokio::test]
@@ -910,6 +1036,42 @@ async fn recv_tool_request(
         },
         _ => panic!("unexpected router message"),
     }
+}
+
+async fn recv_model_request(
+    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+) -> ModelCallDispatchRequest {
+    let message = router_rx.recv().await.expect("model request");
+    match message {
+        RouterIngressMessage::Core(envelope) => match envelope.message {
+            CoreOutputMessage::RequestModelCall(request) => request,
+            _ => panic!("unexpected core output"),
+        },
+        _ => panic!("unexpected router message"),
+    }
+}
+
+fn tool_transcript_events(request: &ModelCallDispatchRequest) -> Vec<String> {
+    request
+        .conversation
+        .messages
+        .iter()
+        .filter_map(|message| {
+            let MessageContent::Structured(StructuredPayload::Object(fields)) = &message.content
+            else {
+                return None;
+            };
+            let Some(StructuredPayload::String(function_call_id)) = fields.get("function_call_id")
+            else {
+                return None;
+            };
+            match message.role {
+                selvedge_db::MessageRole::Assistant => Some(format!("call:{function_call_id}")),
+                selvedge_db::MessageRole::Tool => Some(format!("output:{function_call_id}")),
+                _ => None,
+            }
+        })
+        .collect()
 }
 
 async fn assert_internal_exit(router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>) {

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1053,7 +1053,7 @@ async fn task_runtime_rejects_unpaired_tool_calls_before_model_dispatch() {
 }
 
 #[tokio::test]
-async fn task_runtime_rejects_messages_before_open_tool_calls_are_closed() {
+async fn task_runtime_allows_messages_between_tool_call_and_matching_output() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
     })
@@ -1165,7 +1165,11 @@ async fn task_runtime_rejects_messages_before_open_tool_calls_are_closed() {
         .await
         .expect("send input");
 
-    assert_internal_exit(&mut router_rx).await;
+    let request = recv_model_request(&mut router_rx).await;
+    assert_eq!(
+        tool_transcript_events(&request),
+        vec!["call:call-1", "output:call-1"]
+    );
 }
 
 async fn spawn_runtime_with_task(

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -8,8 +8,8 @@ use selvedge_command_model::{
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
     CreateRootTaskInput, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
-    OpenDbOptions, ReasoningEffort, TaskId, ToolArgumentValue, UnixTs, create_root_task, open_db,
-    register_tool,
+    OpenDbOptions, ReasoningEffort, TaskId, ToolArgumentValue, UnixTs, create_root_task,
+    load_active_task, open_db, queue_user_input, register_tool,
 };
 use selvedge_domain_model::{
     ModelFinishReason, ModelReply, StructuredPayload, ToolCallProposal, ToolParameter,
@@ -441,6 +441,103 @@ async fn task_runtime_rejects_unconvertible_required_arguments() {
                         arguments: StructuredPayload::Object(BTreeMap::from([(
                             "count".to_owned(),
                             StructuredPayload::Null,
+                        )])),
+                    }],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
+#[tokio::test]
+async fn task_runtime_preserves_queued_input_when_append_fails() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(4_102_444_800),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(4_102_444_800),
+        },
+    )
+    .expect("create task");
+    queue_user_input(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "queued".to_owned(),
+        UnixTs(4_102_444_801),
+    )
+    .expect("queue input");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db: db.clone(),
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+    let _exit = router_rx.recv().await.expect("db error exit");
+
+    let loaded = load_active_task(&db, &TaskId("task-1".to_owned())).expect("load task");
+    assert_eq!(loaded.queued_inputs.len(), 1);
+}
+
+#[tokio::test]
+async fn task_runtime_rejects_fractional_integer_arguments_before_persistence() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "repeat".to_owned(),
+        description: "repeat".to_owned(),
+        parameters: vec![ToolParameter {
+            name: "count".to_owned(),
+            parameter_type: ToolParameterType::Integer,
+            description: "count".to_owned(),
+            required: true,
+        }],
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![ToolCallProposal {
+                        call_id: "call-1".to_owned(),
+                        tool_name: "repeat".to_owned(),
+                        arguments: StructuredPayload::Object(BTreeMap::from([(
+                            "count".to_owned(),
+                            StructuredPayload::Number(1.5),
                         )])),
                     }],
                     usage: None,

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use selvedge_command_model::{
     ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, ModelCallDispatchRequest,
@@ -34,7 +34,7 @@ async fn task_runtime_starts_and_requests_model_call_for_user_input() {
                 }),
                 created_at: UnixTs(1),
             },
-            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
             now: UnixTs(1),
@@ -49,6 +49,7 @@ async fn task_runtime_starts_and_requests_model_call_for_user_input() {
         router_tx,
         config: TaskRuntimeConfig {
             mailbox_capacity: 8,
+            model_profiles: model_profiles(),
         },
     })
     .expect("spawn runtime");
@@ -221,7 +222,7 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
                 }),
                 created_at: UnixTs(1),
             },
-            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
             now: UnixTs(1),
@@ -235,6 +236,7 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
         router_tx,
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
+            model_profiles: model_profiles(),
         },
     })
     .expect("spawn runtime");
@@ -397,7 +399,7 @@ async fn task_runtime_uses_fresh_model_run_ids_after_respawn() {
                 }),
                 created_at: UnixTs(1),
             },
-            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
             now: UnixTs(1),
@@ -481,7 +483,7 @@ async fn spawn_runtime_with_task(
                 }),
                 created_at: UnixTs(1),
             },
-            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools,
             now: UnixTs(1),
@@ -496,6 +498,7 @@ async fn spawn_runtime_with_task(
         router_tx,
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
+            model_profiles: model_profiles(),
         },
     })
     .expect("spawn runtime");
@@ -577,6 +580,7 @@ async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> Mode
         router_tx,
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
+            model_profiles: model_profiles(),
         },
     })
     .expect("spawn runtime");
@@ -587,4 +591,17 @@ async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> Mode
         .await
         .expect("stop runtime");
     request.correlation.model_run_id
+}
+
+fn model_profiles()
+-> HashMap<selvedge_db::ModelProfileKey, selvedge_domain_model::ModelProviderProfile> {
+    HashMap::from([(
+        selvedge_db::ModelProfileKey("default".to_owned()),
+        selvedge_domain_model::ModelProviderProfile {
+            provider_name: "provider".to_owned(),
+            model_name: "model".to_owned(),
+            temperature: None,
+            max_output_tokens: None,
+        },
+    )])
 }

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use selvedge_command_model::{
     ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, ModelCallDispatchRequest,
-    RouterIngressMessage, TaskRuntimeCommand, TaskRuntimeExitReason, ToolExecutionResult,
+    ModelCallError, ModelCallErrorKind, ModelRunId, RouterIngressMessage, TaskRuntimeCommand,
+    TaskRuntimeExitReason, ToolExecutionResult,
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
@@ -288,6 +289,107 @@ async fn task_runtime_rejects_tool_calls_missing_required_arguments() {
                         call_id: "call-1".to_owned(),
                         tool_name: "repeat".to_owned(),
                         arguments: StructuredPayload::Object(BTreeMap::new()),
+                    }],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
+#[tokio::test]
+async fn task_runtime_ignores_unrelated_validation_failure_while_waiting() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: "queued".to_owned(),
+        })
+        .await
+        .expect("queue while waiting");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Failure {
+                correlation: ApiCallCorrelation {
+                    api_effect_id: selvedge_command_model::ApiEffectId("other".to_owned()),
+                    task_id: TaskId("other-task".to_owned()),
+                    model_run_id: ModelRunId("other-run".to_owned()),
+                },
+                error: ModelCallError {
+                    kind: ModelCallErrorKind::Validation,
+                    message: "unrelated".to_owned(),
+                },
+            },
+        ))
+        .await
+        .expect("send unrelated failure");
+
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), router_rx.recv())
+            .await
+            .is_err()
+    );
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: Some("done".to_owned()),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                    finish_reason: ModelFinishReason::Stop,
+                },
+            },
+        ))
+        .await
+        .expect("send current reply");
+
+    let next_model_request = router_rx.recv().await.expect("queued model request");
+    assert!(matches!(
+        next_model_request,
+        RouterIngressMessage::Core(envelope)
+            if matches!(envelope.message, CoreOutputMessage::RequestModelCall(_))
+    ));
+}
+
+#[tokio::test]
+async fn task_runtime_rejects_unconvertible_required_arguments() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "repeat".to_owned(),
+        description: "repeat".to_owned(),
+        parameters: vec![ToolParameter {
+            name: "count".to_owned(),
+            parameter_type: ToolParameterType::Integer,
+            description: "count".to_owned(),
+            required: true,
+        }],
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![ToolCallProposal {
+                        call_id: "call-1".to_owned(),
+                        tool_name: "repeat".to_owned(),
+                        arguments: StructuredPayload::Object(BTreeMap::from([(
+                            "count".to_owned(),
+                            StructuredPayload::Null,
+                        )])),
                     }],
                     usage: None,
                     finish_reason: ModelFinishReason::ToolCalls,

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
 
 use selvedge_command_model::{
     ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, DomainEvent,
@@ -229,6 +230,124 @@ async fn task_runtime_preserves_batched_tool_call_order_in_next_model_request() 
             "output:call-2"
         ]
     );
+}
+
+#[tokio::test]
+async fn task_runtime_ignores_tool_result_with_mismatched_call_identity() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    register_tool(
+        &db,
+        ToolSpec {
+            name: "search".to_owned(),
+            description: "search".to_owned(),
+            parameters: Vec::new(),
+        },
+    )
+    .expect("register tool");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: vec![ToolName("search".to_owned())],
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db: db.clone(),
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![
+                        ToolCallProposal {
+                            call_id: "call-1".to_owned(),
+                            tool_name: "search".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                        ToolCallProposal {
+                            call_id: "call-2".to_owned(),
+                            tool_name: "search".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                    ],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    let first_tool_request = recv_tool_request(&mut router_rx).await;
+    let call_2_node_id = load_active_task(&db, &TaskId("task-1".to_owned()))
+        .expect("load task")
+        .task
+        .cursor_node_id;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ToolResult(ToolExecutionResult {
+            task_id: TaskId("task-1".to_owned()),
+            tool_execution_run_id: first_tool_request.tool_execution_run_id.clone(),
+            function_call_node_id: call_2_node_id,
+            function_call_id: FunctionCallId("call-2".to_owned()),
+            tool_name: first_tool_request.tool_name.clone(),
+            output_text: "wrong".to_owned(),
+            is_error: false,
+        }))
+        .await
+        .expect("send mismatched tool result");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), router_rx.recv())
+            .await
+            .is_err()
+    );
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ToolResult(ToolExecutionResult {
+            task_id: TaskId("task-1".to_owned()),
+            tool_execution_run_id: first_tool_request.tool_execution_run_id,
+            function_call_node_id: first_tool_request.function_call_node_id,
+            function_call_id: first_tool_request.function_call_id,
+            tool_name: first_tool_request.tool_name,
+            output_text: "first".to_owned(),
+            is_error: false,
+        }))
+        .await
+        .expect("send correct tool result");
+
+    let second_tool_request = recv_tool_request(&mut router_rx).await;
+    assert_eq!(second_tool_request.function_call_id.0, "call-2");
 }
 
 #[tokio::test]
@@ -904,6 +1023,122 @@ async fn task_runtime_rejects_unpaired_tool_calls_before_model_dispatch() {
         },
     )
     .expect("append unpaired function call");
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: "hello".to_owned(),
+        })
+        .await
+        .expect("send input");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
+#[tokio::test]
+async fn task_runtime_rejects_messages_before_open_tool_calls_are_closed() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    register_tool(
+        &db,
+        ToolSpec {
+            name: "repeat".to_owned(),
+            description: "repeat".to_owned(),
+            parameters: vec![ToolParameter {
+                name: "count".to_owned(),
+                parameter_type: ToolParameterType::Integer,
+                description: "count".to_owned(),
+                required: true,
+            }],
+        },
+    )
+    .expect("register tool");
+    let task = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: vec![ToolName("repeat".to_owned())],
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    let function_call_node_id = append_history_node_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        NewHistoryNode {
+            parent_node_id: Some(task.cursor_node_id),
+            content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
+                function_call_id: FunctionCallId("call-1".to_owned()),
+                tool_name: ToolName("repeat".to_owned()),
+                arguments: vec![ToolCallArgument {
+                    name: ToolParameterName("count".to_owned()),
+                    value: ToolArgumentValue::Integer(1),
+                }],
+            }),
+            created_at: UnixTs(2),
+        },
+    )
+    .expect("append function call");
+    append_history_node_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        NewHistoryNode {
+            parent_node_id: Some(function_call_node_id),
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: selvedge_db::MessageRole::User,
+                message_text: "interleaved".to_owned(),
+            }),
+            created_at: UnixTs(3),
+        },
+    )
+    .expect("append interleaved message");
+    append_history_node_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        NewHistoryNode {
+            parent_node_id: Some(function_call_node_id),
+            content: NewHistoryNodeContent::FunctionOutput(
+                selvedge_db::NewFunctionOutputNodeContent {
+                    function_call_node_id,
+                    function_call_id: FunctionCallId("call-1".to_owned()),
+                    tool_name: ToolName("repeat".to_owned()),
+                    output_text: "done".to_owned(),
+                    is_error: false,
+                },
+            ),
+            created_at: UnixTs(4),
+        },
+    )
+    .expect("append function output");
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 
 use selvedge_command_model::{
-    ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, ModelCallDispatchRequest,
-    ModelCallError, ModelCallErrorKind, ModelRunId, RouterIngressMessage, TaskRuntimeCommand,
-    TaskRuntimeExitReason, ToolExecutionResult,
+    ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, DomainEvent,
+    ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind, ModelRunId, RouterIngressMessage,
+    TaskRuntimeCommand, TaskRuntimeExitReason, ToolExecutionResult,
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
@@ -402,6 +402,40 @@ async fn task_runtime_ignores_unrelated_validation_failure_while_waiting() {
         next_model_request,
         RouterIngressMessage::Core(envelope)
             if matches!(envelope.message, CoreOutputMessage::RequestModelCall(_))
+    ));
+}
+
+#[tokio::test]
+async fn task_runtime_reports_current_model_call_failure() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Failure {
+                correlation,
+                error: ModelCallError {
+                    kind: ModelCallErrorKind::ProviderNetwork,
+                    message: "network failed".to_owned(),
+                },
+            },
+        ))
+        .await
+        .expect("send failure");
+
+    let event = tokio::time::timeout(std::time::Duration::from_millis(25), router_rx.recv())
+        .await
+        .expect("error event timeout")
+        .expect("error event");
+    assert!(matches!(
+        &event,
+        RouterIngressMessage::Core(envelope)
+            if matches!(
+                &envelope.message,
+                CoreOutputMessage::PublishDomainEvent(request)
+                    if matches!(&request.event, DomainEvent::ErrorNotice { .. })
+            )
     ));
 }
 

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use selvedge_command_model::{
-    ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, RouterIngressMessage,
-    TaskRuntimeCommand, ToolExecutionResult,
+    ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, ModelCallDispatchRequest,
+    RouterIngressMessage, TaskRuntimeCommand, TaskRuntimeExitReason, ToolExecutionResult,
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
@@ -33,7 +33,7 @@ async fn task_runtime_starts_and_requests_model_call_for_user_input() {
                 }),
                 created_at: UnixTs(1),
             },
-            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
             now: UnixTs(1),
@@ -78,6 +78,16 @@ async fn task_runtime_starts_and_requests_model_call_for_user_input() {
         RouterIngressMessage::Core(envelope)
             if matches!(envelope.message, CoreOutputMessage::RequestModelCall(_))
     ));
+}
+
+#[tokio::test]
+async fn task_runtime_resolves_model_profile_key_into_provider_and_model() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+
+    let request = start_and_recv_model_request(&runtime, &mut router_rx).await;
+
+    assert_eq!(request.provider.provider_name, "provider");
+    assert_eq!(request.provider.model_name, "model");
 }
 
 #[tokio::test]
@@ -183,6 +193,113 @@ async fn task_runtime_uses_tool_parameter_type_for_integer_arguments() {
     );
 }
 
+#[tokio::test]
+async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    register_tool(
+        &db,
+        ToolSpec {
+            name: "disabled".to_owned(),
+            description: "disabled".to_owned(),
+            parameters: Vec::new(),
+        },
+    )
+    .expect("register disabled tool");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+        },
+    })
+    .expect("spawn runtime");
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![ToolCallProposal {
+                        call_id: "call-1".to_owned(),
+                        tool_name: "disabled".to_owned(),
+                        arguments: StructuredPayload::Object(BTreeMap::new()),
+                    }],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
+#[tokio::test]
+async fn task_runtime_rejects_tool_calls_missing_required_arguments() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "repeat".to_owned(),
+        description: "repeat".to_owned(),
+        parameters: vec![ToolParameter {
+            name: "count".to_owned(),
+            parameter_type: ToolParameterType::Integer,
+            description: "count".to_owned(),
+            required: true,
+        }],
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![ToolCallProposal {
+                        call_id: "call-1".to_owned(),
+                        tool_name: "repeat".to_owned(),
+                        arguments: StructuredPayload::Object(BTreeMap::new()),
+                    }],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
 async fn spawn_runtime_with_task(
     tools: Vec<ToolSpec>,
 ) -> (
@@ -212,7 +329,7 @@ async fn spawn_runtime_with_task(
                 }),
                 created_at: UnixTs(1),
             },
-            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools,
             now: UnixTs(1),
@@ -237,6 +354,15 @@ async fn start_and_request_model(
     runtime: &selvedge_core::SpawnedTaskRuntime,
     router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
 ) -> ApiCallCorrelation {
+    start_and_recv_model_request(runtime, router_rx)
+        .await
+        .correlation
+}
+
+async fn start_and_recv_model_request(
+    runtime: &selvedge_core::SpawnedTaskRuntime,
+    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+) -> ModelCallDispatchRequest {
     runtime
         .task_runtime_tx
         .send(TaskRuntimeCommand::Start)
@@ -258,7 +384,7 @@ async fn start_and_request_model(
     let request = router_rx.recv().await.expect("model request");
     match request {
         RouterIngressMessage::Core(envelope) => match envelope.message {
-            CoreOutputMessage::RequestModelCall(request) => request.correlation,
+            CoreOutputMessage::RequestModelCall(request) => request,
             _ => panic!("unexpected core output"),
         },
         _ => panic!("unexpected router message"),
@@ -274,6 +400,19 @@ async fn recv_tool_request(
             CoreOutputMessage::RequestToolExecution(request) => request,
             _ => panic!("unexpected core output"),
         },
+        _ => panic!("unexpected router message"),
+    }
+}
+
+async fn assert_internal_exit(router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>) {
+    let message = router_rx.recv().await.expect("runtime exit");
+    match message {
+        RouterIngressMessage::RuntimeExit(notice) => {
+            assert!(matches!(
+                notice.reason,
+                TaskRuntimeExitReason::InternalError(_)
+            ));
+        }
         _ => panic!("unexpected router message"),
     }
 }

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -362,6 +362,56 @@ async fn task_runtime_ignores_unrelated_validation_failure_while_waiting() {
 }
 
 #[tokio::test]
+async fn task_runtime_ignores_replayed_start_after_model_request() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let _correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send replayed start");
+
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), router_rx.recv())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn task_runtime_uses_fresh_model_run_ids_after_respawn() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+
+    let first_model_run_id = spawn_runtime_and_start_one_model_call(db.clone()).await;
+    let second_model_run_id = spawn_runtime_and_start_one_model_call(db).await;
+
+    assert_ne!(first_model_run_id, second_model_run_id);
+}
+
+#[tokio::test]
 async fn task_runtime_rejects_unconvertible_required_arguments() {
     let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "repeat".to_owned(),
@@ -517,4 +567,24 @@ async fn assert_internal_exit(router_rx: &mut tokio::sync::mpsc::Receiver<Router
         }
         _ => panic!("unexpected router message"),
     }
+}
+
+async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> ModelRunId {
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+        },
+    })
+    .expect("spawn runtime");
+    let request = start_and_recv_model_request(&runtime, &mut router_rx).await;
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Stop)
+        .await
+        .expect("stop runtime");
+    request.correlation.model_run_id
 }

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -13,7 +13,8 @@ use selvedge_db::{
     TaskId, ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
     append_assistant_message_and_drain_queue, append_function_output_and_drain_queue,
     append_model_reply_with_tool_calls_and_move_cursor, append_user_message_and_move_cursor,
-    create_root_task, load_active_task, open_db, queue_user_input, register_tool,
+    create_history_node, create_root_task, load_active_task, open_db, queue_user_input,
+    register_tool,
 };
 use selvedge_domain_model::{
     MessageContent, ModelFinishReason, ModelReply, StructuredPayload, ToolCallProposal,
@@ -30,14 +31,18 @@ async fn task_runtime_starts_and_requests_model_call_from_system_cursor() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -88,14 +93,18 @@ async fn task_runtime_start_requests_model_from_user_cursor_without_draining_que
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -172,14 +181,18 @@ async fn task_runtime_start_promotes_queue_before_awaiting_user_input() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::Assistant,
-                    message_text: "assistant".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::Assistant,
+                        message_text: "assistant".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -252,14 +265,18 @@ async fn task_runtime_start_dispatches_tool_from_function_call_cursor() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: vec![ToolName("search".to_owned())],
@@ -326,14 +343,18 @@ async fn task_runtime_start_reconstructs_open_batched_tool_calls_from_history() 
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: vec![ToolName("search".to_owned())],
@@ -555,14 +576,18 @@ async fn task_runtime_ignores_tool_result_with_mismatched_call_identity() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: vec![ToolName("search".to_owned())],
@@ -765,14 +790,18 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -1043,14 +1072,18 @@ async fn task_runtime_rejects_empty_idle_user_input_before_append() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::Assistant,
-                    message_text: "assistant".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::Assistant,
+                        message_text: "assistant".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -1148,14 +1181,18 @@ async fn task_runtime_uses_fresh_model_run_ids_after_respawn() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -1221,14 +1258,18 @@ async fn task_runtime_preserves_queued_input_when_append_fails() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(4_102_444_800),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(4_102_444_800),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -1373,14 +1414,18 @@ async fn task_runtime_recovers_open_tool_call_before_model_dispatch() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: vec![ToolName("repeat".to_owned())],
@@ -1457,14 +1502,18 @@ async fn task_runtime_allows_messages_between_tool_call_and_matching_output() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: vec![ToolName("repeat".to_owned())],
@@ -1561,14 +1610,18 @@ async fn spawn_runtime_with_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: selvedge_db::MessageRole::System,
-                    message_text: "system".to_owned(),
-                }),
-                created_at: UnixTs(1),
-            },
+            cursor_node_id: create_history_node(
+                &db,
+                NewHistoryNode {
+                    parent_node_id: None,
+                    content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                        message_role: selvedge_db::MessageRole::System,
+                        message_text: "system".to_owned(),
+                    }),
+                    created_at: UnixTs(1),
+                },
+            )
+            .expect("create cursor node"),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools,

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -382,6 +382,39 @@ async fn task_runtime_ignores_replayed_start_after_model_request() {
 }
 
 #[tokio::test]
+async fn task_runtime_preserves_model_wait_state_for_stray_tool_result() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let _correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ToolResult(ToolExecutionResult {
+            task_id: TaskId("task-1".to_owned()),
+            tool_execution_run_id: selvedge_command_model::ToolExecutionRunId("stray".to_owned()),
+            function_call_node_id: selvedge_db::HistoryNodeId(1),
+            function_call_id: selvedge_db::FunctionCallId("call".to_owned()),
+            tool_name: selvedge_db::ToolName("tool".to_owned()),
+            output_text: "stray".to_owned(),
+            is_error: false,
+        }))
+        .await
+        .expect("send stray tool result");
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: "queued".to_owned(),
+        })
+        .await
+        .expect("queue input");
+
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), router_rx.recv())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
 async fn task_runtime_uses_fresh_model_run_ids_after_respawn() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -7,9 +7,11 @@ use selvedge_command_model::{
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
-    CreateRootTaskInput, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
-    OpenDbOptions, ReasoningEffort, TaskId, ToolArgumentValue, UnixTs, create_root_task,
-    load_active_task, open_db, queue_user_input, register_tool,
+    CreateRootTaskInput, FunctionCallId, NewFunctionCallNodeContent, NewHistoryNode,
+    NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId,
+    ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
+    append_history_node_and_move_cursor, create_root_task, load_active_task, open_db,
+    queue_user_input, register_tool,
 };
 use selvedge_domain_model::{
     ModelFinishReason, ModelReply, StructuredPayload, ToolCallProposal, ToolParameter,
@@ -621,6 +623,91 @@ async fn task_runtime_rejects_out_of_range_integer_arguments() {
         ))
         .await
         .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
+#[tokio::test]
+async fn task_runtime_rejects_unpaired_tool_calls_before_model_dispatch() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    register_tool(
+        &db,
+        ToolSpec {
+            name: "repeat".to_owned(),
+            description: "repeat".to_owned(),
+            parameters: vec![ToolParameter {
+                name: "count".to_owned(),
+                parameter_type: ToolParameterType::Integer,
+                description: "count".to_owned(),
+                required: true,
+            }],
+        },
+    )
+    .expect("register tool");
+    let task = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: vec![ToolName("repeat".to_owned())],
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    append_history_node_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        NewHistoryNode {
+            parent_node_id: Some(task.cursor_node_id),
+            content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
+                function_call_id: FunctionCallId("call-1".to_owned()),
+                tool_name: ToolName("repeat".to_owned()),
+                arguments: vec![ToolCallArgument {
+                    name: ToolParameterName("count".to_owned()),
+                    value: ToolArgumentValue::Integer(1),
+                }],
+            }),
+            created_at: UnixTs(2),
+        },
+    )
+    .expect("append unpaired function call");
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: "hello".to_owned(),
+        })
+        .await
+        .expect("send input");
 
     assert_internal_exit(&mut router_rx).await;
 }

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -268,6 +268,46 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
 }
 
 #[tokio::test]
+async fn task_runtime_validates_all_tool_calls_before_dispatching_any() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "enabled".to_owned(),
+        description: "enabled".to_owned(),
+        parameters: Vec::new(),
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![
+                        ToolCallProposal {
+                            call_id: "call-1".to_owned(),
+                            tool_name: "enabled".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                        ToolCallProposal {
+                            call_id: "call-2".to_owned(),
+                            tool_name: "disabled".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                    ],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
+#[tokio::test]
 async fn task_runtime_rejects_tool_calls_missing_required_arguments() {
     let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "repeat".to_owned(),

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -136,7 +136,12 @@ async fn task_runtime_start_requests_model_from_user_cursor_without_draining_que
         .await
         .expect("send start");
     let _ready = router_rx.recv().await.expect("ready");
-    let request = recv_model_request(&mut router_rx).await;
+    let request = tokio::time::timeout(
+        Duration::from_millis(50),
+        recv_model_request(&mut router_rx),
+    )
+    .await
+    .expect("model request from user cursor");
 
     let last_text =
         request
@@ -229,6 +234,83 @@ async fn task_runtime_start_dispatches_tool_from_function_call_cursor() {
 
     assert_eq!(request.function_call_id.0, "call-1");
     assert_eq!(request.tool_name.0, "search");
+}
+
+#[tokio::test]
+async fn task_runtime_start_reconstructs_open_batched_tool_calls_from_history() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    register_tool(
+        &db,
+        ToolSpec {
+            name: "search".to_owned(),
+            description: "search".to_owned(),
+            parameters: Vec::new(),
+        },
+    )
+    .expect("register tool");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: vec![ToolName("search".to_owned())],
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    append_model_reply_with_tool_calls_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        None,
+        vec![
+            NewFunctionCallNodeContent {
+                function_call_id: FunctionCallId("call-1".to_owned()),
+                tool_name: ToolName("search".to_owned()),
+                arguments: Vec::new(),
+            },
+            NewFunctionCallNodeContent {
+                function_call_id: FunctionCallId("call-2".to_owned()),
+                tool_name: ToolName("search".to_owned()),
+                arguments: Vec::new(),
+            },
+        ],
+        UnixTs(2),
+    )
+    .expect("append batched calls");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+    let first_tool_request = recv_tool_request(&mut router_rx).await;
+
+    assert_eq!(first_tool_request.function_call_id.0, "call-1");
 }
 
 #[tokio::test]
@@ -366,7 +448,12 @@ async fn task_runtime_preserves_batched_tool_call_order_in_next_model_request() 
         .await
         .expect("send second tool result");
 
-    let request = recv_model_request(&mut router_rx).await;
+    let request = tokio::time::timeout(
+        Duration::from_millis(50),
+        recv_model_request(&mut router_rx),
+    )
+    .await
+    .expect("promoted queued model request");
     assert_eq!(
         tool_transcript_events(&request),
         vec![
@@ -831,6 +918,51 @@ async fn task_runtime_reports_current_model_call_failure() {
 }
 
 #[tokio::test]
+async fn task_runtime_promotes_queued_input_after_model_failure() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: "queued".to_owned(),
+        })
+        .await
+        .expect("queue input");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Failure {
+                correlation,
+                error: ModelCallError {
+                    kind: ModelCallErrorKind::ProviderNetwork,
+                    message: "network".to_owned(),
+                },
+            },
+        ))
+        .await
+        .expect("send model failure");
+
+    let event = router_rx.recv().await.expect("error event");
+    assert!(matches!(
+        event,
+        RouterIngressMessage::Core(envelope)
+            if matches!(&envelope.message, CoreOutputMessage::PublishDomainEvent(_))
+    ));
+    let request = recv_model_request(&mut router_rx).await;
+    let last_text =
+        request
+            .conversation
+            .messages
+            .last()
+            .and_then(|message| match &message.content {
+                MessageContent::Text(text) => Some(text.as_str()),
+                _ => None,
+            });
+    assert_eq!(last_text, Some("queued"));
+}
+
+#[tokio::test]
 async fn task_runtime_rejects_empty_idle_user_input_before_append() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
@@ -1147,7 +1279,7 @@ async fn task_runtime_rejects_out_of_range_integer_arguments() {
 }
 
 #[tokio::test]
-async fn task_runtime_rejects_unpaired_tool_calls_before_model_dispatch() {
+async fn task_runtime_recovers_open_tool_call_before_model_dispatch() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
     })
@@ -1225,15 +1357,9 @@ async fn task_runtime_rejects_unpaired_tool_calls_before_model_dispatch() {
         .await
         .expect("send start");
     let _ready = router_rx.recv().await.expect("ready");
-    runtime
-        .task_runtime_tx
-        .send(TaskRuntimeCommand::UserInput {
-            message_text: "hello".to_owned(),
-        })
-        .await
-        .expect("send input");
+    let request = recv_tool_request(&mut router_rx).await;
 
-    assert_internal_exit(&mut router_rx).await;
+    assert_eq!(request.function_call_id.0, "call-1");
 }
 
 #[tokio::test]

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -8,11 +8,12 @@ use selvedge_command_model::{
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
-    CreateRootTaskInput, FunctionCallId, NewFunctionCallNodeContent, NewHistoryNode,
-    NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId,
-    ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
-    append_history_node_and_move_cursor, create_root_task, load_active_task, open_db,
-    queue_user_input, register_tool,
+    CreateRootTaskInput, FunctionCallId, NewFunctionCallNodeContent, NewFunctionOutputNodeContent,
+    NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort,
+    TaskId, ToolArgumentValue, ToolCallArgument, ToolName, ToolParameterName, UnixTs,
+    append_assistant_message_and_drain_queue, append_function_output_and_drain_queue,
+    append_model_reply_with_tool_calls_and_move_cursor, append_user_message_and_move_cursor,
+    create_root_task, load_active_task, open_db, queue_user_input, register_tool,
 };
 use selvedge_domain_model::{
     MessageContent, ModelFinishReason, ModelReply, StructuredPayload, ToolCallProposal,
@@ -20,7 +21,7 @@ use selvedge_domain_model::{
 };
 
 #[tokio::test]
-async fn task_runtime_starts_and_requests_model_call_for_user_input() {
+async fn task_runtime_starts_and_requests_model_call_from_system_cursor() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
     })
@@ -66,16 +67,8 @@ async fn task_runtime_starts_and_requests_model_call_for_user_input() {
     assert!(matches!(
         ready,
         RouterIngressMessage::Core(envelope)
-            if matches!(envelope.message, CoreOutputMessage::RuntimeReady { .. })
+            if matches!(envelope.message, CoreOutputMessage::RuntimeReady)
     ));
-
-    runtime
-        .task_runtime_tx
-        .send(TaskRuntimeCommand::UserInput {
-            message_text: "hello".to_owned(),
-        })
-        .await
-        .expect("send input");
 
     let request = router_rx.recv().await.expect("model request");
     assert!(matches!(
@@ -83,6 +76,159 @@ async fn task_runtime_starts_and_requests_model_call_for_user_input() {
         RouterIngressMessage::Core(envelope)
             if matches!(envelope.message, CoreOutputMessage::RequestModelCall(_))
     ));
+}
+
+#[tokio::test]
+async fn task_runtime_start_requests_model_from_user_cursor_without_draining_queue() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    append_user_message_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "current".to_owned(),
+        UnixTs(2),
+    )
+    .expect("append user cursor");
+    queue_user_input(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "queued".to_owned(),
+        UnixTs(3),
+    )
+    .expect("queue input");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db: db.clone(),
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+    let request = recv_model_request(&mut router_rx).await;
+
+    let last_text =
+        request
+            .conversation
+            .messages
+            .last()
+            .and_then(|message| match &message.content {
+                MessageContent::Text(text) => Some(text.as_str()),
+                _ => None,
+            });
+    assert_eq!(last_text, Some("current"));
+    assert_eq!(
+        load_active_task(&db, &TaskId("task-1".to_owned()))
+            .expect("load task")
+            .queued_inputs
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn task_runtime_start_dispatches_tool_from_function_call_cursor() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    register_tool(
+        &db,
+        ToolSpec {
+            name: "search".to_owned(),
+            description: "search".to_owned(),
+            parameters: Vec::new(),
+        },
+    )
+    .expect("register tool");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: vec![ToolName("search".to_owned())],
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    append_model_reply_with_tool_calls_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        None,
+        vec![NewFunctionCallNodeContent {
+            function_call_id: FunctionCallId("call-1".to_owned()),
+            tool_name: ToolName("search".to_owned()),
+            arguments: Vec::new(),
+        }],
+        UnixTs(2),
+    )
+    .expect("append function call");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+    let request =
+        tokio::time::timeout(Duration::from_millis(50), recv_tool_request(&mut router_rx))
+            .await
+            .expect("tool request");
+
+    assert_eq!(request.function_call_id.0, "call-1");
+    assert_eq!(request.tool_name.0, "search");
 }
 
 #[tokio::test]
@@ -686,7 +832,40 @@ async fn task_runtime_reports_current_model_call_failure() {
 
 #[tokio::test]
 async fn task_runtime_rejects_empty_idle_user_input_before_append() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::Assistant,
+                    message_text: "assistant".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
     runtime
         .task_runtime_tx
         .send(TaskRuntimeCommand::Start)
@@ -987,7 +1166,7 @@ async fn task_runtime_rejects_unpaired_tool_calls_before_model_dispatch() {
         },
     )
     .expect("register tool");
-    let task = create_root_task(
+    create_root_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
@@ -1006,23 +1185,28 @@ async fn task_runtime_rejects_unpaired_tool_calls_before_model_dispatch() {
         },
     )
     .expect("create task");
-    append_history_node_and_move_cursor(
+    append_model_reply_with_tool_calls_and_move_cursor(
         &db,
         &TaskId("task-1".to_owned()),
-        NewHistoryNode {
-            parent_node_id: Some(task.cursor_node_id),
-            content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
-                function_call_id: FunctionCallId("call-1".to_owned()),
-                tool_name: ToolName("repeat".to_owned()),
-                arguments: vec![ToolCallArgument {
-                    name: ToolParameterName("count".to_owned()),
-                    value: ToolArgumentValue::Integer(1),
-                }],
-            }),
-            created_at: UnixTs(2),
-        },
+        None,
+        vec![NewFunctionCallNodeContent {
+            function_call_id: FunctionCallId("call-1".to_owned()),
+            tool_name: ToolName("repeat".to_owned()),
+            arguments: vec![ToolCallArgument {
+                name: ToolParameterName("count".to_owned()),
+                value: ToolArgumentValue::Integer(1),
+            }],
+        }],
+        UnixTs(2),
     )
     .expect("append unpaired function call");
+    append_assistant_message_and_drain_queue(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "assistant".to_owned(),
+        UnixTs(3),
+    )
+    .expect("append assistant cursor after open call");
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
@@ -1072,7 +1256,7 @@ async fn task_runtime_allows_messages_between_tool_call_and_matching_output() {
         },
     )
     .expect("register tool");
-    let task = create_root_task(
+    create_root_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
@@ -1091,52 +1275,39 @@ async fn task_runtime_allows_messages_between_tool_call_and_matching_output() {
         },
     )
     .expect("create task");
-    let function_call_node_id = append_history_node_and_move_cursor(
+    let function_call_node_id = append_model_reply_with_tool_calls_and_move_cursor(
         &db,
         &TaskId("task-1".to_owned()),
-        NewHistoryNode {
-            parent_node_id: Some(task.cursor_node_id),
-            content: NewHistoryNodeContent::FunctionCall(NewFunctionCallNodeContent {
-                function_call_id: FunctionCallId("call-1".to_owned()),
-                tool_name: ToolName("repeat".to_owned()),
-                arguments: vec![ToolCallArgument {
-                    name: ToolParameterName("count".to_owned()),
-                    value: ToolArgumentValue::Integer(1),
-                }],
-            }),
-            created_at: UnixTs(2),
-        },
+        None,
+        vec![NewFunctionCallNodeContent {
+            function_call_id: FunctionCallId("call-1".to_owned()),
+            tool_name: ToolName("repeat".to_owned()),
+            arguments: vec![ToolCallArgument {
+                name: ToolParameterName("count".to_owned()),
+                value: ToolArgumentValue::Integer(1),
+            }],
+        }],
+        UnixTs(2),
     )
-    .expect("append function call");
-    append_history_node_and_move_cursor(
+    .expect("append function call")[0];
+    append_user_message_and_move_cursor(
         &db,
         &TaskId("task-1".to_owned()),
-        NewHistoryNode {
-            parent_node_id: Some(function_call_node_id),
-            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                message_role: selvedge_db::MessageRole::User,
-                message_text: "interleaved".to_owned(),
-            }),
-            created_at: UnixTs(3),
-        },
+        "interleaved".to_owned(),
+        UnixTs(3),
     )
     .expect("append interleaved message");
-    append_history_node_and_move_cursor(
+    append_function_output_and_drain_queue(
         &db,
         &TaskId("task-1".to_owned()),
-        NewHistoryNode {
-            parent_node_id: Some(function_call_node_id),
-            content: NewHistoryNodeContent::FunctionOutput(
-                selvedge_db::NewFunctionOutputNodeContent {
-                    function_call_node_id,
-                    function_call_id: FunctionCallId("call-1".to_owned()),
-                    tool_name: ToolName("repeat".to_owned()),
-                    output_text: "done".to_owned(),
-                    is_error: false,
-                },
-            ),
-            created_at: UnixTs(4),
+        NewFunctionOutputNodeContent {
+            function_call_node_id,
+            function_call_id: FunctionCallId("call-1".to_owned()),
+            tool_name: ToolName("repeat".to_owned()),
+            output_text: "done".to_owned(),
+            is_error: false,
         },
+        UnixTs(4),
     )
     .expect("append function output");
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
@@ -1245,15 +1416,8 @@ async fn start_and_recv_model_request(
     assert!(matches!(
         ready,
         RouterIngressMessage::Core(envelope)
-            if matches!(envelope.message, CoreOutputMessage::RuntimeReady { .. })
+            if matches!(envelope.message, CoreOutputMessage::RuntimeReady)
     ));
-    runtime
-        .task_runtime_tx
-        .send(TaskRuntimeCommand::UserInput {
-            message_text: "hello".to_owned(),
-        })
-        .await
-        .expect("send input");
     let request = router_rx.recv().await.expect("model request");
     match request {
         RouterIngressMessage::Core(envelope) => match envelope.message {

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -584,6 +584,47 @@ async fn task_runtime_rejects_fractional_integer_arguments_before_persistence() 
     assert_internal_exit(&mut router_rx).await;
 }
 
+#[tokio::test]
+async fn task_runtime_rejects_out_of_range_integer_arguments() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "repeat".to_owned(),
+        description: "repeat".to_owned(),
+        parameters: vec![ToolParameter {
+            name: "count".to_owned(),
+            parameter_type: ToolParameterType::Integer,
+            description: "count".to_owned(),
+            required: true,
+        }],
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![ToolCallProposal {
+                        call_id: "call-1".to_owned(),
+                        tool_name: "repeat".to_owned(),
+                        arguments: StructuredPayload::Object(BTreeMap::from([(
+                            "count".to_owned(),
+                            StructuredPayload::Number(9_223_372_036_854_775_808.0),
+                        )])),
+                    }],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
 async fn spawn_runtime_with_task(
     tools: Vec<ToolSpec>,
 ) -> (

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1,0 +1,71 @@
+use selvedge_command_model::{CoreOutputMessage, RouterIngressMessage, TaskRuntimeCommand};
+use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
+use selvedge_db::{
+    CreateRootTaskInput, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
+    OpenDbOptions, ReasoningEffort, TaskId, UnixTs, create_root_task, open_db,
+};
+
+#[tokio::test]
+async fn task_runtime_starts_and_requests_model_call_for_user_input() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 8,
+        },
+    })
+    .expect("spawn runtime");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let ready = router_rx.recv().await.expect("ready");
+    assert!(matches!(
+        ready,
+        RouterIngressMessage::Core(envelope)
+            if matches!(envelope.message, CoreOutputMessage::RuntimeReady { .. })
+    ));
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: "hello".to_owned(),
+        })
+        .await
+        .expect("send input");
+
+    let request = router_rx.recv().await.expect("model request");
+    assert!(matches!(
+        request,
+        RouterIngressMessage::Core(envelope)
+            if matches!(envelope.message, CoreOutputMessage::RequestModelCall(_))
+    ));
+}

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -440,6 +440,27 @@ async fn task_runtime_reports_current_model_call_failure() {
 }
 
 #[tokio::test]
+async fn task_runtime_rejects_empty_idle_user_input_before_append() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: String::new(),
+        })
+        .await
+        .expect("send empty input");
+
+    assert_internal_exit(&mut router_rx).await;
+}
+
+#[tokio::test]
 async fn task_runtime_ignores_replayed_start_after_model_request() {
     let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
     let _correlation = start_and_request_model(&runtime, &mut router_rx).await;

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -163,6 +163,77 @@ async fn task_runtime_start_requests_model_from_user_cursor_without_draining_que
 }
 
 #[tokio::test]
+async fn task_runtime_start_promotes_queue_before_awaiting_user_input() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::Assistant,
+                    message_text: "assistant".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+    queue_user_input(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "queued".to_owned(),
+        UnixTs(2),
+    )
+    .expect("queue input");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db: db.clone(),
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+            model_profiles: model_profiles(),
+        },
+    })
+    .expect("spawn runtime");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let _ready = router_rx.recv().await.expect("ready");
+    let request = recv_model_request(&mut router_rx).await;
+    let last_text =
+        request
+            .conversation
+            .messages
+            .last()
+            .and_then(|message| match &message.content {
+                MessageContent::Text(text) => Some(text.as_str()),
+                _ => None,
+            });
+
+    assert_eq!(last_text, Some("queued"));
+    assert!(
+        load_active_task(&db, &TaskId("task-1".to_owned()))
+            .expect("load task")
+            .queued_inputs
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn task_runtime_start_dispatches_tool_from_function_call_cursor() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1,8 +1,18 @@
-use selvedge_command_model::{CoreOutputMessage, RouterIngressMessage, TaskRuntimeCommand};
+use std::collections::BTreeMap;
+
+use selvedge_command_model::{
+    ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, RouterIngressMessage,
+    TaskRuntimeCommand, ToolExecutionResult,
+};
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
     CreateRootTaskInput, NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent,
-    OpenDbOptions, ReasoningEffort, TaskId, UnixTs, create_root_task, open_db,
+    OpenDbOptions, ReasoningEffort, TaskId, ToolArgumentValue, UnixTs, create_root_task, open_db,
+    register_tool,
+};
+use selvedge_domain_model::{
+    ModelFinishReason, ModelReply, StructuredPayload, ToolCallProposal, ToolParameter,
+    ToolParameterType, ToolSpec,
 };
 
 #[tokio::test]
@@ -68,4 +78,202 @@ async fn task_runtime_starts_and_requests_model_call_for_user_input() {
         RouterIngressMessage::Core(envelope)
             if matches!(envelope.message, CoreOutputMessage::RequestModelCall(_))
     ));
+}
+
+#[tokio::test]
+async fn task_runtime_dispatches_all_tool_calls_before_next_model_call() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "search".to_owned(),
+        description: "search".to_owned(),
+        parameters: Vec::new(),
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![
+                        ToolCallProposal {
+                            call_id: "call-1".to_owned(),
+                            tool_name: "search".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                        ToolCallProposal {
+                            call_id: "call-2".to_owned(),
+                            tool_name: "search".to_owned(),
+                            arguments: StructuredPayload::Object(BTreeMap::new()),
+                        },
+                    ],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    let first_tool_request = recv_tool_request(&mut router_rx).await;
+    assert_eq!(first_tool_request.function_call_id.0, "call-1");
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ToolResult(ToolExecutionResult {
+            task_id: TaskId("task-1".to_owned()),
+            tool_execution_run_id: first_tool_request.tool_execution_run_id,
+            function_call_node_id: first_tool_request.function_call_node_id,
+            function_call_id: first_tool_request.function_call_id,
+            tool_name: first_tool_request.tool_name,
+            output_text: "first".to_owned(),
+            is_error: false,
+        }))
+        .await
+        .expect("send first tool result");
+
+    let second_tool_request = recv_tool_request(&mut router_rx).await;
+    assert_eq!(second_tool_request.function_call_id.0, "call-2");
+}
+
+#[tokio::test]
+async fn task_runtime_uses_tool_parameter_type_for_integer_arguments() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+        name: "repeat".to_owned(),
+        description: "repeat".to_owned(),
+        parameters: vec![ToolParameter {
+            name: "count".to_owned(),
+            parameter_type: ToolParameterType::Integer,
+            description: "count".to_owned(),
+            required: true,
+        }],
+    }])
+    .await;
+    let correlation = start_and_request_model(&runtime, &mut router_rx).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::ApiModelReply(
+            ApiOutputEnvelope::Success {
+                correlation,
+                reply: ModelReply {
+                    content: None,
+                    tool_calls: vec![ToolCallProposal {
+                        call_id: "call-1".to_owned(),
+                        tool_name: "repeat".to_owned(),
+                        arguments: StructuredPayload::Object(BTreeMap::from([(
+                            "count".to_owned(),
+                            StructuredPayload::Number(1.0),
+                        )])),
+                    }],
+                    usage: None,
+                    finish_reason: ModelFinishReason::ToolCalls,
+                },
+            },
+        ))
+        .await
+        .expect("send model reply");
+
+    let tool_request = recv_tool_request(&mut router_rx).await;
+    assert_eq!(
+        tool_request.arguments[0].value,
+        ToolArgumentValue::Integer(1)
+    );
+}
+
+async fn spawn_runtime_with_task(
+    tools: Vec<ToolSpec>,
+) -> (
+    selvedge_core::SpawnedTaskRuntime,
+    tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+) {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    let enabled_tools = tools
+        .iter()
+        .map(|tool| selvedge_db::ToolName(tool.name.clone()))
+        .collect();
+    for tool in tools {
+        register_tool(&db, tool).expect("register tool");
+    }
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: selvedge_db::MessageRole::System,
+                    message_text: "system".to_owned(),
+                }),
+                created_at: UnixTs(1),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools,
+            now: UnixTs(1),
+        },
+    )
+    .expect("create task");
+
+    let (router_tx, router_rx) = tokio::sync::mpsc::channel(16);
+    let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
+        task_id: TaskId("task-1".to_owned()),
+        db,
+        router_tx,
+        config: TaskRuntimeConfig {
+            mailbox_capacity: 16,
+        },
+    })
+    .expect("spawn runtime");
+    (runtime, router_rx)
+}
+
+async fn start_and_request_model(
+    runtime: &selvedge_core::SpawnedTaskRuntime,
+    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+) -> ApiCallCorrelation {
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    let ready = router_rx.recv().await.expect("ready");
+    assert!(matches!(
+        ready,
+        RouterIngressMessage::Core(envelope)
+            if matches!(envelope.message, CoreOutputMessage::RuntimeReady { .. })
+    ));
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::UserInput {
+            message_text: "hello".to_owned(),
+        })
+        .await
+        .expect("send input");
+    let request = router_rx.recv().await.expect("model request");
+    match request {
+        RouterIngressMessage::Core(envelope) => match envelope.message {
+            CoreOutputMessage::RequestModelCall(request) => request.correlation,
+            _ => panic!("unexpected core output"),
+        },
+        _ => panic!("unexpected router message"),
+    }
+}
+
+async fn recv_tool_request(
+    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+) -> selvedge_command_model::ToolExecutionRequest {
+    let message = router_rx.recv().await.expect("tool request");
+    match message {
+        RouterIngressMessage::Core(envelope) => match envelope.message {
+            CoreOutputMessage::RequestToolExecution(request) => request,
+            _ => panic!("unexpected core output"),
+        },
+        _ => panic!("unexpected router message"),
+    }
 }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "selvedge-db"
+edition = "2024"
+publish = false
+
+[dependencies]
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+selvedge-domain-model = { path = "../domain-model" }
+
+[dev-dependencies]
+tempfile = "3.14.0"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/db/README.md
+++ b/crates/db/README.md
@@ -1,0 +1,7 @@
+# db
+
+This crate owns SQLite persistence for router-mediated Selvedge tasks.
+
+Use it to open a schema-v3 SQLite database, register global tools, create tasks, append history nodes while moving task cursors, queue user inputs, archive tasks, and read task-local model context.
+
+This crate is for SQLite persistence only. Runtime wait state, provider calls, tool execution, router registries, and event delivery live in other crates.

--- a/crates/db/README.md
+++ b/crates/db/README.md
@@ -6,4 +6,11 @@ Use it to open a schema-v4 SQLite database, register global tools, create tasks,
 
 This crate is for SQLite persistence only. Runtime wait state, provider calls, tool execution, router registries, and event delivery live in other crates.
 
-Public writes are transition-sized: user message commit, model reply with tool calls, assistant reply with queued-input drain, tool output with queued-input drain, queue input, and archive. Single-node history insertion is an internal helper so callers do not split cursor movement across multiple transactions.
+Resource boundaries:
+
+- `create_history_node` inserts one history node. History parent links are a standalone graph.
+- `create_root_task` inserts one task row at a caller-provided existing `cursor_node_id`. Task parent links and history parent links are separate graphs.
+- `create_child_task` records a task-layer parent edge and a caller-provided existing `cursor_node_id`.
+- A task cursor is a pointer into history, with no ownership claim over the pointed node.
+
+Public transition writes keep cursor movement atomic with the history append they perform: user message commit, model reply with tool calls, assistant reply with queued-input drain, tool output with queued-input drain, queued input promotion, queue input, and archive.

--- a/crates/db/README.md
+++ b/crates/db/README.md
@@ -2,6 +2,8 @@
 
 This crate owns SQLite persistence for router-mediated Selvedge tasks.
 
-Use it to open a schema-v3 SQLite database, register global tools, create tasks, append history nodes while moving task cursors, queue user inputs, archive tasks, and read task-local model context.
+Use it to open a schema-v4 SQLite database, register global tools, create tasks, commit task-runtime state transitions, queue user inputs, archive tasks, and read task-local model context.
 
 This crate is for SQLite persistence only. Runtime wait state, provider calls, tool execution, router registries, and event delivery live in other crates.
+
+Public writes are transition-sized: user message commit, model reply with tool calls, assistant reply with queued-input drain, tool output with queued-input drain, queue input, and archive. Single-node history insertion is an internal helper so callers do not split cursor movement across multiple transactions.

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -299,11 +299,6 @@ pub fn register_tool(db: &DbPool, tool: ToolSpec) -> Result<(), DbError> {
 
 pub fn create_root_task(db: &DbPool, input: CreateRootTaskInput) -> Result<TaskRow, DbError> {
     let task_id = input.task_id.clone();
-    if input.initial_node.parent_node_id.is_some() {
-        return Err(DbError::Constraint(
-            "root task initial node must not have a parent".to_owned(),
-        ));
-    }
     {
         let mut connection = db.connection()?;
         let tx = connection.transaction().map_err(map_error)?;
@@ -341,11 +336,6 @@ pub fn create_child_task(db: &DbPool, input: CreateChildTaskInput) -> Result<Tas
         let parent = read_task_in_tx(&tx, &input.parent_task_id)?;
         if parent.task_status != TaskStatusRow::Active {
             return Err(DbError::TaskNotActive);
-        }
-        if !history_node_is_on_parent_chain(&tx, input.cursor_node_id, parent.cursor_node_id)? {
-            return Err(DbError::Constraint(
-                "child cursor must belong to the parent task history chain".to_owned(),
-            ));
         }
         tx.execute(
             "INSERT INTO tasks
@@ -396,14 +386,11 @@ pub fn load_active_task(db: &DbPool, task_id: &TaskId) -> Result<LoadedActiveTas
 pub fn append_history_node_and_move_cursor(
     db: &DbPool,
     task_id: &TaskId,
-    node: NewHistoryNode,
+    mut node: NewHistoryNode,
 ) -> Result<HistoryNodeId, DbError> {
     let mut connection = db.connection()?;
     let tx = connection.transaction().map_err(map_error)?;
     ensure_active_task_in_tx(&tx, task_id)?;
-    let expected_parent_node_id = node.parent_node_id.ok_or_else(|| {
-        DbError::Constraint("history append parent must be the current task cursor".to_owned())
-    })?;
     let current_cursor_node_id: i64 = tx
         .query_row(
             "SELECT cursor_node_id FROM tasks WHERE task_id = ?1 AND task_status = 'active'",
@@ -411,30 +398,29 @@ pub fn append_history_node_and_move_cursor(
             |row| row.get(0),
         )
         .map_err(map_error)?;
-    if current_cursor_node_id != expected_parent_node_id.0 {
-        return Err(DbError::Constraint(
-            "history append parent must match the current task cursor".to_owned(),
-        ));
+
+    // Task edges and history edges are separate models. Append means the DB
+    // reads the task cursor, creates a child history node under that cursor,
+    // and moves the task cursor in one transaction. Runtime cursor caches are
+    // hints for request building, not a second source of truth.
+    node.parent_node_id = Some(HistoryNodeId(current_cursor_node_id));
+
+    if let NewHistoryNodeContent::FunctionOutput(content) = &node.content {
+        ensure_current_cursor_is_function_call(&tx, current_cursor_node_id, content)?;
     }
+
     let updated_at = node.created_at;
     let node_id = insert_history_node(&tx, node)?;
     let changed = tx
         .execute(
             "UPDATE tasks
              SET cursor_node_id = ?1, updated_at = ?2, state_version = state_version + 1
-             WHERE task_id = ?3 AND task_status = 'active' AND cursor_node_id = ?4",
-            params![
-                node_id.0,
-                updated_at.0,
-                task_id.0,
-                expected_parent_node_id.0
-            ],
+             WHERE task_id = ?3 AND task_status = 'active'",
+            params![node_id.0, updated_at.0, task_id.0],
         )
         .map_err(map_error)?;
     if changed == 0 {
-        return Err(DbError::Constraint(
-            "history append parent must match the current task cursor".to_owned(),
-        ));
+        return Err(DbError::TaskNotActive);
     }
     tx.commit().map_err(map_error)?;
     Ok(node_id)
@@ -751,24 +737,44 @@ fn read_task_in_tx(tx: &rusqlite::Transaction<'_>, task_id: &TaskId) -> Result<T
     .ok_or(DbError::NotFound)
 }
 
-fn history_node_is_on_parent_chain(
+fn ensure_current_cursor_is_function_call(
     tx: &rusqlite::Transaction<'_>,
-    candidate_node_id: HistoryNodeId,
-    parent_cursor_node_id: HistoryNodeId,
-) -> Result<bool, DbError> {
-    tx.query_row(
-        "WITH RECURSIVE chain(node_id, parent_node_id) AS (
-             SELECT node_id, parent_node_id FROM history_nodes WHERE node_id = ?1
-             UNION ALL
-             SELECT h.node_id, h.parent_node_id
-             FROM history_nodes h
-             INNER JOIN chain c ON h.node_id = c.parent_node_id
-         )
-         SELECT EXISTS(SELECT 1 FROM chain WHERE node_id = ?2)",
-        params![parent_cursor_node_id.0, candidate_node_id.0],
-        |row| row.get(0),
-    )
-    .map_err(map_error)
+    current_cursor_node_id: i64,
+    output: &NewFunctionOutputNodeContent,
+) -> Result<(), DbError> {
+    if output.function_call_node_id.0 != current_cursor_node_id {
+        return Err(DbError::Constraint(
+            "function output must append directly after its function call node".to_owned(),
+        ));
+    }
+
+    // Provider APIs pair tool results with prior tool calls by call id. The
+    // database therefore validates the output against the current function
+    // call node before persisting it, instead of letting a later model request
+    // discover an uncorrelated tool result.
+    let exists: bool = tx
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1
+                FROM history_function_call_nodes
+                WHERE node_id = ?1 AND function_call_id = ?2 AND tool_name = ?3
+             )",
+            params![
+                output.function_call_node_id.0,
+                output.function_call_id.0,
+                output.tool_name.0
+            ],
+            |row| row.get(0),
+        )
+        .map_err(map_error)?;
+
+    if exists {
+        Ok(())
+    } else {
+        Err(DbError::Constraint(
+            "function output must reference the current function call id and tool".to_owned(),
+        ))
+    }
 }
 
 fn read_history_node(db: &DbPool, node_id: &HistoryNodeId) -> Result<HistoryNodeRow, DbError> {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,0 +1,1149 @@
+#![doc = include_str!("../README.md")]
+
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::{error::Error, fmt};
+
+use rusqlite::{Connection, OptionalExtension, params};
+pub use selvedge_domain_model::{
+    Conversation, ConversationItem, FunctionCallId, HistoryNodeId, MessageRole, ModelProfileKey,
+    ReasoningEffort, TaskId, ToolArgumentValue, ToolCallArgument, ToolManifest, ToolName,
+    ToolParameterName, ToolParameterType, ToolSpec, UnixTs,
+};
+
+const SCHEMA_VERSION: &str = "router-mediated-redesign-v3";
+
+#[derive(Clone)]
+pub struct DbPool {
+    connection: Arc<Mutex<Connection>>,
+}
+
+pub struct DbConnection;
+pub struct DbTransaction;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DbError {
+    NotFound,
+    TaskNotActive,
+    Constraint(String),
+    Storage(String),
+    SchemaMismatch {
+        expected: String,
+        actual: Option<String>,
+    },
+}
+
+impl fmt::Display for DbError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DbError::NotFound => write!(formatter, "row was not found"),
+            DbError::TaskNotActive => write!(formatter, "task is not active"),
+            DbError::Constraint(message) => write!(formatter, "constraint failed: {message}"),
+            DbError::Storage(message) => write!(formatter, "storage failed: {message}"),
+            DbError::SchemaMismatch { expected, actual } => {
+                write!(
+                    formatter,
+                    "schema mismatch: expected {expected}, actual {actual:?}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for DbError {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TaskStatusRow {
+    Active,
+    Archived,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HistoryContentKindRow {
+    Message,
+    Reasoning,
+    FunctionCall,
+    FunctionOutput,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OpenDbOptions {
+    pub sqlite_path: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolRow {
+    pub tool_name: ToolName,
+    pub description_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolParameterRow {
+    pub tool_name: ToolName,
+    pub parameter_name: ToolParameterName,
+    pub parameter_type: ToolParameterType,
+    pub description_text: String,
+    pub is_required: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskRow {
+    pub task_id: TaskId,
+    pub task_status: TaskStatusRow,
+    pub cursor_node_id: HistoryNodeId,
+    pub model_profile_key: ModelProfileKey,
+    pub reasoning_effort: ReasoningEffort,
+    pub state_version: u64,
+    pub created_at: UnixTs,
+    pub updated_at: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskToolRow {
+    pub task_id: TaskId,
+    pub tool_name: ToolName,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskParentEdgeRow {
+    pub parent_task_id: TaskId,
+    pub child_task_id: TaskId,
+    pub created_at: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueuedUserInputRow {
+    pub task_id: TaskId,
+    pub seq_no: u64,
+    pub message_text: String,
+    pub queued_at: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HistoryNodeRow {
+    pub node_id: HistoryNodeId,
+    pub parent_node_id: Option<HistoryNodeId>,
+    pub content_kind: HistoryContentKindRow,
+    pub created_at: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HistoryMessageNodeRow {
+    pub node_id: HistoryNodeId,
+    pub message_role: MessageRole,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HistoryReasoningNodeRow {
+    pub node_id: HistoryNodeId,
+    pub reasoning_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HistoryFunctionCallNodeRow {
+    pub node_id: HistoryNodeId,
+    pub function_call_id: FunctionCallId,
+    pub tool_name: ToolName,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HistoryFunctionCallArgumentRow {
+    pub function_call_node_id: HistoryNodeId,
+    pub tool_name: ToolName,
+    pub argument_name: ToolParameterName,
+    pub value: ToolArgumentValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HistoryFunctionOutputNodeRow {
+    pub node_id: HistoryNodeId,
+    pub function_call_node_id: HistoryNodeId,
+    pub function_call_id: FunctionCallId,
+    pub tool_name: ToolName,
+    pub output_text: String,
+    pub is_error: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreateRootTaskInput {
+    pub task_id: TaskId,
+    pub initial_node: NewHistoryNode,
+    pub model_profile_key: ModelProfileKey,
+    pub reasoning_effort: ReasoningEffort,
+    pub enabled_tools: Vec<ToolName>,
+    pub now: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CreateChildTaskInput {
+    pub parent_task_id: TaskId,
+    pub child_task_id: TaskId,
+    pub cursor_node_id: HistoryNodeId,
+    pub now: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LoadedActiveTask {
+    pub task: TaskRow,
+    pub cursor_node: HistoryNodeRow,
+    pub tool_manifest: ToolManifest,
+    pub queued_inputs: Vec<QueuedUserInputRow>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum NewHistoryNodeContent {
+    Message(NewMessageNodeContent),
+    Reasoning(NewReasoningNodeContent),
+    FunctionCall(NewFunctionCallNodeContent),
+    FunctionOutput(NewFunctionOutputNodeContent),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NewHistoryNode {
+    pub parent_node_id: Option<HistoryNodeId>,
+    pub content: NewHistoryNodeContent,
+    pub created_at: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NewMessageNodeContent {
+    pub message_role: MessageRole,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NewReasoningNodeContent {
+    pub reasoning_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NewFunctionCallNodeContent {
+    pub function_call_id: FunctionCallId,
+    pub tool_name: ToolName,
+    pub arguments: Vec<ToolCallArgument>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NewFunctionOutputNodeContent {
+    pub function_call_node_id: HistoryNodeId,
+    pub function_call_id: FunctionCallId,
+    pub tool_name: ToolName,
+    pub output_text: String,
+    pub is_error: bool,
+}
+
+pub fn open_db(options: OpenDbOptions) -> Result<DbPool, DbError> {
+    let connection = Connection::open(&options.sqlite_path).map_err(map_error)?;
+    connection
+        .pragma_update(None, "foreign_keys", "ON")
+        .map_err(map_error)?;
+
+    if database_is_empty(&connection)? {
+        connection
+            .execute_batch(include_str!("schema.sql"))
+            .map_err(map_error)?;
+    }
+
+    let db = DbPool {
+        connection: Arc::new(Mutex::new(connection)),
+    };
+    verify_schema(&db)?;
+    Ok(db)
+}
+
+pub fn verify_schema(db: &DbPool) -> Result<(), DbError> {
+    let connection = db.connection()?;
+    let actual: Option<String> = connection
+        .query_row(
+            "SELECT schema_value FROM schema_metadata WHERE schema_key = 'selvedge_schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_error)?;
+
+    if actual.as_deref() == Some(SCHEMA_VERSION) {
+        Ok(())
+    } else {
+        Err(DbError::SchemaMismatch {
+            expected: SCHEMA_VERSION.to_owned(),
+            actual,
+        })
+    }
+}
+
+pub fn register_tool(db: &DbPool, tool: ToolSpec) -> Result<(), DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    tx.execute(
+        "INSERT INTO tools (tool_name, description_text) VALUES (?1, ?2)",
+        params![tool.name, tool.description],
+    )
+    .map_err(map_error)?;
+    for parameter in tool.parameters {
+        tx.execute(
+            "INSERT INTO tool_parameters (tool_name, parameter_name, parameter_type, description_text, is_required)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                tool.name,
+                parameter.name,
+                tool_parameter_type_to_db(&parameter.parameter_type),
+                parameter.description,
+                bool_to_i64(parameter.required)
+            ],
+        )
+        .map_err(map_error)?;
+    }
+    tx.commit().map_err(map_error)
+}
+
+pub fn create_root_task(db: &DbPool, input: CreateRootTaskInput) -> Result<TaskRow, DbError> {
+    let task_id = input.task_id.clone();
+    {
+        let mut connection = db.connection()?;
+        let tx = connection.transaction().map_err(map_error)?;
+        let node_id = insert_history_node(&tx, input.initial_node)?;
+        tx.execute(
+            "INSERT INTO tasks
+             (task_id, task_status, cursor_node_id, model_profile_key, reasoning_effort, state_version, created_at, updated_at)
+             VALUES (?1, 'active', ?2, ?3, ?4, 0, ?5, ?5)",
+            params![
+                input.task_id.0,
+                node_id.0,
+                input.model_profile_key.0,
+                reasoning_effort_to_db(&input.reasoning_effort),
+                input.now.0
+            ],
+        )
+        .map_err(map_error)?;
+        for tool_name in input.enabled_tools {
+            tx.execute(
+                "INSERT INTO task_tools (task_id, tool_name) VALUES (?1, ?2)",
+                params![task_id.0, tool_name.0],
+            )
+            .map_err(map_error)?;
+        }
+        tx.commit().map_err(map_error)?;
+    }
+    read_task(db, &task_id)
+}
+
+pub fn create_child_task(db: &DbPool, input: CreateChildTaskInput) -> Result<TaskRow, DbError> {
+    let child_task_id = input.child_task_id.clone();
+    {
+        let mut connection = db.connection()?;
+        let tx = connection.transaction().map_err(map_error)?;
+        let parent = read_task_in_tx(&tx, &input.parent_task_id)?;
+        if parent.task_status != TaskStatusRow::Active {
+            return Err(DbError::TaskNotActive);
+        }
+        tx.execute(
+            "INSERT INTO tasks
+             (task_id, task_status, cursor_node_id, model_profile_key, reasoning_effort, state_version, created_at, updated_at)
+             VALUES (?1, 'active', ?2, ?3, ?4, 0, ?5, ?5)",
+            params![
+                input.child_task_id.0,
+                input.cursor_node_id.0,
+                parent.model_profile_key.0,
+                reasoning_effort_to_db(&parent.reasoning_effort),
+                input.now.0
+            ],
+        )
+        .map_err(map_error)?;
+        tx.execute(
+            "INSERT INTO task_tools (task_id, tool_name)
+             SELECT ?1, tool_name FROM task_tools WHERE task_id = ?2",
+            params![input.child_task_id.0, input.parent_task_id.0],
+        )
+        .map_err(map_error)?;
+        tx.execute(
+            "INSERT INTO task_parent_edges (parent_task_id, child_task_id, created_at)
+             VALUES (?1, ?2, ?3)",
+            params![input.parent_task_id.0, input.child_task_id.0, input.now.0],
+        )
+        .map_err(map_error)?;
+        tx.commit().map_err(map_error)?;
+    }
+    read_task(db, &child_task_id)
+}
+
+pub fn load_active_task(db: &DbPool, task_id: &TaskId) -> Result<LoadedActiveTask, DbError> {
+    let task = read_task(db, task_id)?;
+    if task.task_status != TaskStatusRow::Active {
+        return Err(DbError::TaskNotActive);
+    }
+    let cursor_node = read_history_node(db, &task.cursor_node_id)?;
+    let tool_manifest = read_tool_manifest_for_task(db, task_id)?;
+    let queued_inputs = list_queued_inputs(db, task_id)?;
+    Ok(LoadedActiveTask {
+        task,
+        cursor_node,
+        tool_manifest,
+        queued_inputs,
+    })
+}
+
+pub fn append_history_node_and_move_cursor(
+    db: &DbPool,
+    task_id: &TaskId,
+    node: NewHistoryNode,
+) -> Result<HistoryNodeId, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    let node_id = insert_history_node(&tx, node)?;
+    let changed = tx
+        .execute(
+            "UPDATE tasks
+             SET cursor_node_id = ?1, updated_at = ?2, state_version = state_version + 1
+             WHERE task_id = ?3 AND task_status = 'active'",
+            params![node_id.0, current_db_time(&tx)?, task_id.0],
+        )
+        .map_err(map_error)?;
+    if changed == 0 {
+        return Err(DbError::TaskNotActive);
+    }
+    tx.commit().map_err(map_error)?;
+    Ok(node_id)
+}
+
+pub fn queue_user_input(
+    db: &DbPool,
+    task_id: &TaskId,
+    message_text: String,
+    queued_at: UnixTs,
+) -> Result<QueuedUserInputRow, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    let next_seq_no: i64 = tx
+        .query_row(
+            "SELECT COALESCE(MAX(seq_no), 0) + 1 FROM queued_user_inputs WHERE task_id = ?1",
+            params![task_id.0],
+            |row| row.get(0),
+        )
+        .map_err(map_error)?;
+    tx.execute(
+        "INSERT INTO queued_user_inputs (task_id, seq_no, message_text, queued_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![task_id.0, next_seq_no, message_text, queued_at.0],
+    )
+    .map_err(map_error)?;
+    tx.commit().map_err(map_error)?;
+    Ok(QueuedUserInputRow {
+        task_id: task_id.clone(),
+        seq_no: i64_to_u64(next_seq_no)?,
+        message_text,
+        queued_at,
+    })
+}
+
+pub fn consume_next_queued_user_input(
+    db: &DbPool,
+    task_id: &TaskId,
+) -> Result<Option<QueuedUserInputRow>, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    let queued = tx
+        .query_row(
+            "SELECT task_id, seq_no, message_text, queued_at
+             FROM queued_user_inputs
+             WHERE task_id = ?1
+             ORDER BY seq_no ASC
+             LIMIT 1",
+            params![task_id.0],
+            map_queued_user_input_row,
+        )
+        .optional()
+        .map_err(map_error)?;
+    if let Some(queued) = &queued {
+        tx.execute(
+            "DELETE FROM queued_user_inputs WHERE task_id = ?1 AND seq_no = ?2",
+            params![queued.task_id.0, u64_to_i64(queued.seq_no)?],
+        )
+        .map_err(map_error)?;
+    }
+    tx.commit().map_err(map_error)?;
+    Ok(queued)
+}
+
+pub fn archive_task(db: &DbPool, task_id: &TaskId, now: UnixTs) -> Result<(), DbError> {
+    let connection = db.connection()?;
+    let changed = connection
+        .execute(
+            "UPDATE tasks
+             SET task_status = 'archived', updated_at = ?1, state_version = state_version + 1
+             WHERE task_id = ?2 AND task_status = 'active'",
+            params![now.0, task_id.0],
+        )
+        .map_err(map_error)?;
+    if changed == 0 {
+        Err(DbError::TaskNotActive)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn list_active_tasks(db: &DbPool) -> Result<Vec<TaskRow>, DbError> {
+    let connection = db.connection()?;
+    let mut statement = connection
+        .prepare(
+            "SELECT task_id, task_status, cursor_node_id, model_profile_key, reasoning_effort, state_version, created_at, updated_at
+             FROM tasks
+             WHERE task_status = 'active'
+             ORDER BY updated_at DESC, task_id ASC",
+        )
+        .map_err(map_error)?;
+    let rows = statement
+        .query_map([], map_task_row)
+        .map_err(map_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_error)?;
+    Ok(rows)
+}
+
+pub fn read_tool_manifest_for_task(db: &DbPool, task_id: &TaskId) -> Result<ToolManifest, DbError> {
+    let connection = db.connection()?;
+    ensure_active_task(&connection, task_id)?;
+    let mut statement = connection
+        .prepare(
+            "SELECT t.tool_name, t.description_text
+             FROM tools t
+             INNER JOIN task_tools tt ON tt.tool_name = t.tool_name
+             WHERE tt.task_id = ?1
+             ORDER BY t.tool_name ASC",
+        )
+        .map_err(map_error)?;
+    let tools = statement
+        .query_map(params![task_id.0], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(map_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_error)?;
+
+    let mut manifest_tools = Vec::with_capacity(tools.len());
+    for (name, description) in tools {
+        let mut parameter_statement = connection
+            .prepare(
+                "SELECT parameter_name, parameter_type, description_text, is_required
+                 FROM tool_parameters
+                 WHERE tool_name = ?1
+                 ORDER BY parameter_name ASC",
+            )
+            .map_err(map_error)?;
+        let parameters = parameter_statement
+            .query_map(params![name], |row| {
+                Ok(selvedge_domain_model::ToolParameter {
+                    name: row.get(0)?,
+                    parameter_type: tool_parameter_type_from_db(&row.get::<_, String>(1)?)
+                        .map_err(|error| {
+                            rusqlite::Error::ToSqlConversionFailure(Box::new(error))
+                        })?,
+                    description: row.get(2)?,
+                    required: row.get::<_, i64>(3)? == 1,
+                })
+            })
+            .map_err(map_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_error)?;
+        manifest_tools.push(ToolSpec {
+            name,
+            description,
+            parameters,
+        });
+    }
+    Ok(ToolManifest {
+        tools: manifest_tools,
+    })
+}
+
+pub fn read_conversation_for_task(db: &DbPool, task_id: &TaskId) -> Result<Conversation, DbError> {
+    let task = load_active_task(db, task_id)?.task;
+    let connection = db.connection()?;
+    let mut nodes = Vec::new();
+    let mut next_node_id = Some(task.cursor_node_id);
+    while let Some(node_id) = next_node_id {
+        let node = read_history_node_in_connection(&connection, &node_id)?;
+        next_node_id = node.parent_node_id;
+        nodes.push(node);
+    }
+    nodes.reverse();
+
+    let mut items = Vec::with_capacity(nodes.len());
+    for node in nodes {
+        match node.content_kind {
+            HistoryContentKindRow::Message => {
+                let row = read_message_node(&connection, &node.node_id)?;
+                items.push(ConversationItem::Message {
+                    role: row.message_role,
+                    text: row.message_text,
+                });
+            }
+            HistoryContentKindRow::FunctionCall => {
+                let row = read_function_call_node(&connection, &node.node_id)?;
+                items.push(ConversationItem::FunctionCall {
+                    function_call_id: row.function_call_id,
+                    tool_name: row.tool_name,
+                    arguments: read_function_call_arguments(&connection, &node.node_id)?,
+                });
+            }
+            HistoryContentKindRow::FunctionOutput => {
+                let row = read_function_output_node(&connection, &node.node_id)?;
+                items.push(ConversationItem::FunctionOutput {
+                    function_call_id: row.function_call_id,
+                    tool_name: row.tool_name,
+                    output_text: row.output_text,
+                    is_error: row.is_error,
+                });
+            }
+            HistoryContentKindRow::Reasoning => {}
+        }
+    }
+
+    Ok(Conversation { items })
+}
+
+impl DbPool {
+    fn connection(&self) -> Result<MutexGuard<'_, Connection>, DbError> {
+        self.connection
+            .lock()
+            .map_err(|error| DbError::Storage(format!("database mutex is poisoned: {error}")))
+    }
+}
+
+fn database_is_empty(connection: &Connection) -> Result<bool, DbError> {
+    let count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(map_error)?;
+    Ok(count == 0)
+}
+
+fn read_task(db: &DbPool, task_id: &TaskId) -> Result<TaskRow, DbError> {
+    let connection = db.connection()?;
+    connection
+        .query_row(
+            "SELECT task_id, task_status, cursor_node_id, model_profile_key, reasoning_effort, state_version, created_at, updated_at
+             FROM tasks
+             WHERE task_id = ?1",
+            params![task_id.0],
+            map_task_row,
+        )
+        .optional()
+        .map_err(map_error)?
+        .ok_or(DbError::NotFound)
+}
+
+fn read_task_in_tx(tx: &rusqlite::Transaction<'_>, task_id: &TaskId) -> Result<TaskRow, DbError> {
+    tx.query_row(
+        "SELECT task_id, task_status, cursor_node_id, model_profile_key, reasoning_effort, state_version, created_at, updated_at
+         FROM tasks
+         WHERE task_id = ?1",
+        params![task_id.0],
+        map_task_row,
+    )
+    .optional()
+    .map_err(map_error)?
+    .ok_or(DbError::NotFound)
+}
+
+fn read_history_node(db: &DbPool, node_id: &HistoryNodeId) -> Result<HistoryNodeRow, DbError> {
+    let connection = db.connection()?;
+    read_history_node_in_connection(&connection, node_id)
+}
+
+fn read_history_node_in_connection(
+    connection: &Connection,
+    node_id: &HistoryNodeId,
+) -> Result<HistoryNodeRow, DbError> {
+    connection
+        .query_row(
+            "SELECT node_id, parent_node_id, content_kind, created_at
+             FROM history_nodes
+             WHERE node_id = ?1",
+            params![node_id.0],
+            map_history_node_row,
+        )
+        .optional()
+        .map_err(map_error)?
+        .ok_or(DbError::NotFound)
+}
+
+fn list_queued_inputs(db: &DbPool, task_id: &TaskId) -> Result<Vec<QueuedUserInputRow>, DbError> {
+    let connection = db.connection()?;
+    let mut statement = connection
+        .prepare(
+            "SELECT task_id, seq_no, message_text, queued_at
+             FROM queued_user_inputs
+             WHERE task_id = ?1
+             ORDER BY seq_no ASC",
+        )
+        .map_err(map_error)?;
+    statement
+        .query_map(params![task_id.0], map_queued_user_input_row)
+        .map_err(map_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_error)
+}
+
+fn insert_history_node(
+    tx: &rusqlite::Transaction<'_>,
+    node: NewHistoryNode,
+) -> Result<HistoryNodeId, DbError> {
+    let content_kind = content_kind_to_db(&node.content);
+    tx.execute(
+        "INSERT INTO history_nodes (parent_node_id, content_kind, created_at)
+         VALUES (?1, ?2, ?3)",
+        params![
+            node.parent_node_id.map(|node_id| node_id.0),
+            content_kind,
+            node.created_at.0
+        ],
+    )
+    .map_err(map_error)?;
+    let node_id = HistoryNodeId(tx.last_insert_rowid());
+    match node.content {
+        NewHistoryNodeContent::Message(content) => insert_message_node(tx, node_id, content)?,
+        NewHistoryNodeContent::Reasoning(content) => insert_reasoning_node(tx, node_id, content)?,
+        NewHistoryNodeContent::FunctionCall(content) => {
+            insert_function_call_node(tx, node_id, content)?
+        }
+        NewHistoryNodeContent::FunctionOutput(content) => {
+            insert_function_output_node(tx, node_id, content)?
+        }
+    }
+    Ok(node_id)
+}
+
+fn insert_message_node(
+    tx: &rusqlite::Transaction<'_>,
+    node_id: HistoryNodeId,
+    content: NewMessageNodeContent,
+) -> Result<(), DbError> {
+    let Some(message_role) = message_role_to_db(&content.message_role) else {
+        return Err(DbError::Constraint(
+            "message role cannot be persisted as a history message".to_owned(),
+        ));
+    };
+    tx.execute(
+        "INSERT INTO history_message_nodes (node_id, message_role, message_text)
+         VALUES (?1, ?2, ?3)",
+        params![node_id.0, message_role, content.message_text],
+    )
+    .map_err(map_error)?;
+    Ok(())
+}
+
+fn insert_reasoning_node(
+    tx: &rusqlite::Transaction<'_>,
+    node_id: HistoryNodeId,
+    content: NewReasoningNodeContent,
+) -> Result<(), DbError> {
+    tx.execute(
+        "INSERT INTO history_reasoning_nodes (node_id, reasoning_text)
+         VALUES (?1, ?2)",
+        params![node_id.0, content.reasoning_text],
+    )
+    .map_err(map_error)?;
+    Ok(())
+}
+
+fn insert_function_call_node(
+    tx: &rusqlite::Transaction<'_>,
+    node_id: HistoryNodeId,
+    content: NewFunctionCallNodeContent,
+) -> Result<(), DbError> {
+    tx.execute(
+        "INSERT INTO history_function_call_nodes (node_id, function_call_id, tool_name)
+         VALUES (?1, ?2, ?3)",
+        params![node_id.0, content.function_call_id.0, content.tool_name.0],
+    )
+    .map_err(map_error)?;
+    for argument in content.arguments {
+        let (value_type, string_value, integer_value, number_value, boolean_value) =
+            tool_argument_value_to_db(argument.value);
+        tx.execute(
+            "INSERT INTO history_function_call_arguments
+             (function_call_node_id, tool_name, argument_name, value_type, string_value, integer_value, number_value, boolean_value)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                node_id.0,
+                content.tool_name.0,
+                argument.name.0,
+                value_type,
+                string_value,
+                integer_value,
+                number_value,
+                boolean_value
+            ],
+        )
+        .map_err(map_error)?;
+    }
+    Ok(())
+}
+
+fn insert_function_output_node(
+    tx: &rusqlite::Transaction<'_>,
+    node_id: HistoryNodeId,
+    content: NewFunctionOutputNodeContent,
+) -> Result<(), DbError> {
+    tx.execute(
+        "INSERT INTO history_function_output_nodes
+         (node_id, function_call_node_id, function_call_id, tool_name, output_text, is_error)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            node_id.0,
+            content.function_call_node_id.0,
+            content.function_call_id.0,
+            content.tool_name.0,
+            content.output_text,
+            bool_to_i64(content.is_error)
+        ],
+    )
+    .map_err(map_error)?;
+    Ok(())
+}
+
+fn ensure_active_task(connection: &Connection, task_id: &TaskId) -> Result<(), DbError> {
+    let status: Option<String> = connection
+        .query_row(
+            "SELECT task_status FROM tasks WHERE task_id = ?1",
+            params![task_id.0],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_error)?;
+    match status.as_deref() {
+        Some("active") => Ok(()),
+        Some(_) => Err(DbError::TaskNotActive),
+        None => Err(DbError::NotFound),
+    }
+}
+
+fn ensure_active_task_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    task_id: &TaskId,
+) -> Result<(), DbError> {
+    let status: Option<String> = tx
+        .query_row(
+            "SELECT task_status FROM tasks WHERE task_id = ?1",
+            params![task_id.0],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_error)?;
+    match status.as_deref() {
+        Some("active") => Ok(()),
+        Some(_) => Err(DbError::TaskNotActive),
+        None => Err(DbError::NotFound),
+    }
+}
+
+fn current_db_time(tx: &rusqlite::Transaction<'_>) -> Result<i64, DbError> {
+    tx.query_row("SELECT unixepoch()", [], |row| row.get(0))
+        .map_err(map_error)
+}
+
+fn read_message_node(
+    connection: &Connection,
+    node_id: &HistoryNodeId,
+) -> Result<HistoryMessageNodeRow, DbError> {
+    connection
+        .query_row(
+            "SELECT node_id, message_role, message_text FROM history_message_nodes WHERE node_id = ?1",
+            params![node_id.0],
+            |row| {
+                Ok(HistoryMessageNodeRow {
+                    node_id: HistoryNodeId(row.get(0)?),
+                    message_role: message_role_from_db(&row.get::<_, String>(1)?)
+                        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+                    message_text: row.get(2)?,
+                })
+            },
+        )
+        .map_err(map_error)
+}
+
+fn read_function_call_node(
+    connection: &Connection,
+    node_id: &HistoryNodeId,
+) -> Result<HistoryFunctionCallNodeRow, DbError> {
+    connection
+        .query_row(
+            "SELECT node_id, function_call_id, tool_name FROM history_function_call_nodes WHERE node_id = ?1",
+            params![node_id.0],
+            |row| {
+                Ok(HistoryFunctionCallNodeRow {
+                    node_id: HistoryNodeId(row.get(0)?),
+                    function_call_id: FunctionCallId(row.get(1)?),
+                    tool_name: ToolName(row.get(2)?),
+                })
+            },
+        )
+        .map_err(map_error)
+}
+
+fn read_function_call_arguments(
+    connection: &Connection,
+    node_id: &HistoryNodeId,
+) -> Result<Vec<ToolCallArgument>, DbError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT argument_name, value_type, string_value, integer_value, number_value, boolean_value
+             FROM history_function_call_arguments
+             WHERE function_call_node_id = ?1
+             ORDER BY argument_name ASC",
+        )
+        .map_err(map_error)?;
+    statement
+        .query_map(params![node_id.0], |row| {
+            let value_type: String = row.get(1)?;
+            Ok(ToolCallArgument {
+                name: ToolParameterName(row.get(0)?),
+                value: tool_argument_value_from_db(
+                    &value_type,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                )
+                .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+            })
+        })
+        .map_err(map_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_error)
+}
+
+fn read_function_output_node(
+    connection: &Connection,
+    node_id: &HistoryNodeId,
+) -> Result<HistoryFunctionOutputNodeRow, DbError> {
+    connection
+        .query_row(
+            "SELECT node_id, function_call_node_id, function_call_id, tool_name, output_text, is_error
+             FROM history_function_output_nodes
+             WHERE node_id = ?1",
+            params![node_id.0],
+            |row| {
+                Ok(HistoryFunctionOutputNodeRow {
+                    node_id: HistoryNodeId(row.get(0)?),
+                    function_call_node_id: HistoryNodeId(row.get(1)?),
+                    function_call_id: FunctionCallId(row.get(2)?),
+                    tool_name: ToolName(row.get(3)?),
+                    output_text: row.get(4)?,
+                    is_error: row.get::<_, i64>(5)? == 1,
+                })
+            },
+        )
+        .map_err(map_error)
+}
+
+fn map_task_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskRow> {
+    Ok(TaskRow {
+        task_id: TaskId(row.get(0)?),
+        task_status: task_status_from_db(&row.get::<_, String>(1)?)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+        cursor_node_id: HistoryNodeId(row.get(2)?),
+        model_profile_key: ModelProfileKey(row.get(3)?),
+        reasoning_effort: reasoning_effort_from_db(&row.get::<_, String>(4)?)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+        state_version: i64_to_u64(row.get(5)?)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+        created_at: UnixTs(row.get(6)?),
+        updated_at: UnixTs(row.get(7)?),
+    })
+}
+
+fn map_history_node_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HistoryNodeRow> {
+    let parent_node_id: Option<i64> = row.get(1)?;
+    Ok(HistoryNodeRow {
+        node_id: HistoryNodeId(row.get(0)?),
+        parent_node_id: parent_node_id.map(HistoryNodeId),
+        content_kind: content_kind_from_db(&row.get::<_, String>(2)?)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+        created_at: UnixTs(row.get(3)?),
+    })
+}
+
+fn map_queued_user_input_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueuedUserInputRow> {
+    Ok(QueuedUserInputRow {
+        task_id: TaskId(row.get(0)?),
+        seq_no: i64_to_u64(row.get(1)?)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+        message_text: row.get(2)?,
+        queued_at: UnixTs(row.get(3)?),
+    })
+}
+
+fn content_kind_to_db(content: &NewHistoryNodeContent) -> &'static str {
+    match content {
+        NewHistoryNodeContent::Message(_) => "message",
+        NewHistoryNodeContent::Reasoning(_) => "reasoning",
+        NewHistoryNodeContent::FunctionCall(_) => "function_call",
+        NewHistoryNodeContent::FunctionOutput(_) => "function_output",
+    }
+}
+
+fn content_kind_from_db(value: &str) -> Result<HistoryContentKindRow, DbError> {
+    match value {
+        "message" => Ok(HistoryContentKindRow::Message),
+        "reasoning" => Ok(HistoryContentKindRow::Reasoning),
+        "function_call" => Ok(HistoryContentKindRow::FunctionCall),
+        "function_output" => Ok(HistoryContentKindRow::FunctionOutput),
+        other => Err(DbError::Storage(format!(
+            "unknown history content kind: {other}"
+        ))),
+    }
+}
+
+fn task_status_from_db(value: &str) -> Result<TaskStatusRow, DbError> {
+    match value {
+        "active" => Ok(TaskStatusRow::Active),
+        "archived" => Ok(TaskStatusRow::Archived),
+        other => Err(DbError::Storage(format!("unknown task status: {other}"))),
+    }
+}
+
+fn message_role_to_db(role: &MessageRole) -> Option<&'static str> {
+    match role {
+        MessageRole::System => Some("system"),
+        MessageRole::Developer => Some("developer"),
+        MessageRole::User => Some("user"),
+        MessageRole::Assistant => Some("assistant"),
+        MessageRole::Tool => None,
+    }
+}
+
+fn message_role_from_db(value: &str) -> Result<MessageRole, DbError> {
+    match value {
+        "system" => Ok(MessageRole::System),
+        "developer" => Ok(MessageRole::Developer),
+        "user" => Ok(MessageRole::User),
+        "assistant" => Ok(MessageRole::Assistant),
+        other => Err(DbError::Storage(format!("unknown message role: {other}"))),
+    }
+}
+
+fn reasoning_effort_to_db(value: &ReasoningEffort) -> &'static str {
+    match value {
+        ReasoningEffort::Minimal => "minimal",
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High => "high",
+    }
+}
+
+fn reasoning_effort_from_db(value: &str) -> Result<ReasoningEffort, DbError> {
+    match value {
+        "minimal" => Ok(ReasoningEffort::Minimal),
+        "low" => Ok(ReasoningEffort::Low),
+        "medium" => Ok(ReasoningEffort::Medium),
+        "high" => Ok(ReasoningEffort::High),
+        other => Err(DbError::Storage(format!(
+            "unknown reasoning effort: {other}"
+        ))),
+    }
+}
+
+fn tool_parameter_type_to_db(value: &ToolParameterType) -> &'static str {
+    match value {
+        ToolParameterType::String => "string",
+        ToolParameterType::Integer => "integer",
+        ToolParameterType::Number => "number",
+        ToolParameterType::Boolean => "boolean",
+    }
+}
+
+fn tool_parameter_type_from_db(value: &str) -> Result<ToolParameterType, DbError> {
+    match value {
+        "string" => Ok(ToolParameterType::String),
+        "integer" => Ok(ToolParameterType::Integer),
+        "number" => Ok(ToolParameterType::Number),
+        "boolean" => Ok(ToolParameterType::Boolean),
+        other => Err(DbError::Storage(format!(
+            "unknown tool parameter type: {other}"
+        ))),
+    }
+}
+
+type DbArgumentValue = (
+    &'static str,
+    Option<String>,
+    Option<i64>,
+    Option<f64>,
+    Option<i64>,
+);
+
+fn tool_argument_value_to_db(value: ToolArgumentValue) -> DbArgumentValue {
+    match value {
+        ToolArgumentValue::String(value) => ("string", Some(value), None, None, None),
+        ToolArgumentValue::Integer(value) => ("integer", None, Some(value), None, None),
+        ToolArgumentValue::Number(value) => ("number", None, None, Some(value), None),
+        ToolArgumentValue::Boolean(value) => {
+            ("boolean", None, None, None, Some(bool_to_i64(value)))
+        }
+    }
+}
+
+fn tool_argument_value_from_db(
+    value_type: &str,
+    string_value: Option<String>,
+    integer_value: Option<i64>,
+    number_value: Option<f64>,
+    boolean_value: Option<i64>,
+) -> Result<ToolArgumentValue, DbError> {
+    match value_type {
+        "string" => string_value
+            .map(ToolArgumentValue::String)
+            .ok_or_else(|| DbError::Storage("string argument value is missing".to_owned())),
+        "integer" => integer_value
+            .map(ToolArgumentValue::Integer)
+            .ok_or_else(|| DbError::Storage("integer argument value is missing".to_owned())),
+        "number" => number_value
+            .map(ToolArgumentValue::Number)
+            .ok_or_else(|| DbError::Storage("number argument value is missing".to_owned())),
+        "boolean" => boolean_value
+            .map(|value| ToolArgumentValue::Boolean(value == 1))
+            .ok_or_else(|| DbError::Storage("boolean argument value is missing".to_owned())),
+        other => Err(DbError::Storage(format!(
+            "unknown argument value type: {other}"
+        ))),
+    }
+}
+
+fn bool_to_i64(value: bool) -> i64 {
+    if value { 1 } else { 0 }
+}
+
+fn i64_to_u64(value: i64) -> Result<u64, DbError> {
+    u64::try_from(value).map_err(|_| DbError::Storage(format!("negative integer: {value}")))
+}
+
+fn u64_to_i64(value: u64) -> Result<i64, DbError> {
+    i64::try_from(value).map_err(|_| DbError::Storage(format!("integer is too large: {value}")))
+}
+
+fn map_error(error: rusqlite::Error) -> DbError {
+    match error {
+        rusqlite::Error::QueryReturnedNoRows => DbError::NotFound,
+        rusqlite::Error::SqliteFailure(failure, message) => {
+            if failure.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_FOREIGNKEY
+                || failure.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY
+                || failure.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+                || failure.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_CHECK
+                || failure.code == rusqlite::ErrorCode::ConstraintViolation
+            {
+                DbError::Constraint(message.unwrap_or_else(|| failure.to_string()))
+            } else {
+                DbError::Storage(message.unwrap_or_else(|| failure.to_string()))
+            }
+        }
+        other => DbError::Storage(other.to_string()),
+    }
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -10,7 +10,7 @@ pub use selvedge_domain_model::{
     ToolParameterName, ToolParameterType, ToolSpec, UnixTs,
 };
 
-const SCHEMA_VERSION: &str = "router-mediated-redesign-v3";
+const SCHEMA_VERSION: &str = "router-mediated-redesign-v4";
 
 #[derive(Clone)]
 pub struct DbPool {
@@ -748,22 +748,56 @@ fn ensure_current_cursor_is_function_call(
     current_cursor_node_id: i64,
     output: &NewFunctionOutputNodeContent,
 ) -> Result<(), DbError> {
-    if output.function_call_node_id.0 != current_cursor_node_id {
+    // Provider APIs pair tool results with prior tool calls by call id. A
+    // model turn may contain several tool calls, so the matching call can be
+    // earlier in the current conversation path while later sibling calls are
+    // still waiting for results. The DB checks that the output references a
+    // real call on the active path and that this call has a single output.
+    let exists: bool = tx
+        .query_row(
+            "WITH RECURSIVE current_path(node_id, parent_node_id) AS (
+                SELECT node_id, parent_node_id
+                FROM history_nodes
+                WHERE node_id = ?1
+                UNION ALL
+                SELECT parent.node_id, parent.parent_node_id
+                FROM history_nodes parent
+                JOIN current_path child ON parent.node_id = child.parent_node_id
+             )
+             SELECT EXISTS(
+                SELECT 1
+                FROM current_path path
+                JOIN history_function_call_nodes calls ON calls.node_id = path.node_id
+                WHERE calls.node_id = ?2
+                  AND calls.function_call_id = ?3
+                  AND calls.tool_name = ?4
+             )",
+            params![
+                current_cursor_node_id,
+                output.function_call_node_id.0,
+                output.function_call_id.0,
+                output.tool_name.0
+            ],
+            |row| row.get(0),
+        )
+        .map_err(map_error)?;
+
+    if !exists {
         return Err(DbError::Constraint(
-            "function output must append directly after its function call node".to_owned(),
+            "function output must reference an open function call id and tool".to_owned(),
         ));
     }
 
-    // Provider APIs pair tool results with prior tool calls by call id. The
-    // database therefore validates the output against the current function
-    // call node before persisting it, instead of letting a later model request
-    // discover an uncorrelated tool result.
-    let exists: bool = tx
+    let output_exists: bool = tx
         .query_row(
             "SELECT EXISTS(
                 SELECT 1
                 FROM history_function_call_nodes
-                WHERE node_id = ?1 AND function_call_id = ?2 AND tool_name = ?3
+                JOIN history_function_output_nodes
+                  ON history_function_output_nodes.function_call_node_id = history_function_call_nodes.node_id
+                WHERE history_function_call_nodes.node_id = ?1
+                  AND history_function_call_nodes.function_call_id = ?2
+                  AND history_function_call_nodes.tool_name = ?3
              )",
             params![
                 output.function_call_node_id.0,
@@ -774,12 +808,12 @@ fn ensure_current_cursor_is_function_call(
         )
         .map_err(map_error)?;
 
-    if exists {
-        Ok(())
-    } else {
+    if output_exists {
         Err(DbError::Constraint(
-            "function output must reference the current function call id and tool".to_owned(),
+            "function output already exists for function call id and tool".to_owned(),
         ))
+    } else {
+        Ok(())
     }
 }
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -391,13 +391,14 @@ pub fn append_history_node_and_move_cursor(
     let mut connection = db.connection()?;
     let tx = connection.transaction().map_err(map_error)?;
     ensure_active_task_in_tx(&tx, task_id)?;
+    let updated_at = node.created_at;
     let node_id = insert_history_node(&tx, node)?;
     let changed = tx
         .execute(
             "UPDATE tasks
              SET cursor_node_id = ?1, updated_at = ?2, state_version = state_version + 1
              WHERE task_id = ?3 AND task_status = 'active'",
-            params![node_id.0, current_db_time(&tx)?, task_id.0],
+            params![node_id.0, updated_at.0, task_id.0],
         )
         .map_err(map_error)?;
     if changed == 0 {
@@ -850,11 +851,6 @@ fn ensure_active_task_in_tx(
         Some(_) => Err(DbError::TaskNotActive),
         None => Err(DbError::NotFound),
     }
-}
-
-fn current_db_time(tx: &rusqlite::Transaction<'_>) -> Result<i64, DbError> {
-    tx.query_row("SELECT unixepoch()", [], |row| row.get(0))
-        .map_err(map_error)
 }
 
 fn read_message_node(

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::{error::Error, fmt};
 
@@ -165,6 +166,52 @@ pub struct HistoryFunctionOutputNodeRow {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum HistoryNode {
+    Message {
+        node_id: HistoryNodeId,
+        parent_node_id: Option<HistoryNodeId>,
+        created_at: UnixTs,
+        message_role: MessageRole,
+        message_text: String,
+    },
+    Reasoning {
+        node_id: HistoryNodeId,
+        parent_node_id: Option<HistoryNodeId>,
+        created_at: UnixTs,
+        reasoning_text: String,
+    },
+    FunctionCall {
+        node_id: HistoryNodeId,
+        parent_node_id: Option<HistoryNodeId>,
+        created_at: UnixTs,
+        function_call_id: FunctionCallId,
+        tool_name: ToolName,
+        arguments: Vec<ToolCallArgument>,
+    },
+    FunctionOutput {
+        node_id: HistoryNodeId,
+        parent_node_id: Option<HistoryNodeId>,
+        created_at: UnixTs,
+        function_call_node_id: HistoryNodeId,
+        function_call_id: FunctionCallId,
+        tool_name: ToolName,
+        output_text: String,
+        is_error: bool,
+    },
+}
+
+impl HistoryNode {
+    pub fn node_id(&self) -> HistoryNodeId {
+        match self {
+            HistoryNode::Message { node_id, .. }
+            | HistoryNode::Reasoning { node_id, .. }
+            | HistoryNode::FunctionCall { node_id, .. }
+            | HistoryNode::FunctionOutput { node_id, .. } => *node_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct CreateRootTaskInput {
     pub task_id: TaskId,
     pub initial_node: NewHistoryNode,
@@ -185,7 +232,7 @@ pub struct CreateChildTaskInput {
 #[derive(Clone, Debug, PartialEq)]
 pub struct LoadedActiveTask {
     pub task: TaskRow,
-    pub cursor_node: HistoryNodeRow,
+    pub cursor_node: HistoryNode,
     pub tool_manifest: ToolManifest,
     pub queued_inputs: Vec<QueuedUserInputRow>,
 }
@@ -383,7 +430,116 @@ pub fn load_active_task(db: &DbPool, task_id: &TaskId) -> Result<LoadedActiveTas
     })
 }
 
-pub fn append_history_node_and_move_cursor(
+pub fn append_user_message_and_move_cursor(
+    db: &DbPool,
+    task_id: &TaskId,
+    message_text: String,
+    created_at: UnixTs,
+) -> Result<HistoryNodeId, DbError> {
+    append_history_node_and_move_cursor(
+        db,
+        task_id,
+        NewHistoryNode {
+            parent_node_id: None,
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::User,
+                message_text,
+            }),
+            created_at,
+        },
+    )
+}
+
+pub fn append_model_reply_with_tool_calls_and_move_cursor(
+    db: &DbPool,
+    task_id: &TaskId,
+    assistant_message_text: Option<String>,
+    tool_calls: Vec<NewFunctionCallNodeContent>,
+    created_at: UnixTs,
+) -> Result<Vec<HistoryNodeId>, DbError> {
+    if tool_calls.is_empty() {
+        return Err(DbError::Constraint(
+            "model reply tool call commit requires at least one function call".to_owned(),
+        ));
+    }
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    if let Some(message_text) = assistant_message_text {
+        append_node_to_current_cursor_in_tx(
+            &tx,
+            task_id,
+            NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::Assistant,
+                message_text,
+            }),
+            created_at,
+        )?;
+    }
+    let mut function_call_node_ids = Vec::with_capacity(tool_calls.len());
+    for tool_call in tool_calls {
+        let node_id = append_node_to_current_cursor_in_tx(
+            &tx,
+            task_id,
+            NewHistoryNodeContent::FunctionCall(tool_call),
+            created_at,
+        )?;
+        function_call_node_ids.push(node_id);
+    }
+    tx.commit().map_err(map_error)?;
+    Ok(function_call_node_ids)
+}
+
+pub fn append_assistant_message_and_drain_queue(
+    db: &DbPool,
+    task_id: &TaskId,
+    message_text: String,
+    created_at: UnixTs,
+) -> Result<HistoryNodeId, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    let mut last_node_id = append_node_to_current_cursor_in_tx(
+        &tx,
+        task_id,
+        NewHistoryNodeContent::Message(NewMessageNodeContent {
+            message_role: MessageRole::Assistant,
+            message_text,
+        }),
+        created_at,
+    )?;
+    if let Some(node_id) = append_all_queued_user_inputs_in_tx(&tx, task_id, created_at)? {
+        last_node_id = node_id;
+    }
+    tx.commit().map_err(map_error)?;
+    Ok(last_node_id)
+}
+
+pub fn append_function_output_and_drain_queue(
+    db: &DbPool,
+    task_id: &TaskId,
+    output: NewFunctionOutputNodeContent,
+    created_at: UnixTs,
+) -> Result<HistoryNodeId, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    let current_cursor_node_id = current_cursor_node_id_in_tx(&tx, task_id)?;
+    ensure_current_path_contains_open_function_call(&tx, current_cursor_node_id, &output)?;
+    let mut last_node_id = append_node_to_current_cursor_in_tx(
+        &tx,
+        task_id,
+        NewHistoryNodeContent::FunctionOutput(output),
+        created_at,
+    )?;
+    if let Some(node_id) = append_all_queued_user_inputs_in_tx(&tx, task_id, created_at)? {
+        last_node_id = node_id;
+    }
+    tx.commit().map_err(map_error)?;
+    Ok(last_node_id)
+}
+
+fn append_history_node_and_move_cursor(
     db: &DbPool,
     task_id: &TaskId,
     mut node: NewHistoryNode,
@@ -391,13 +547,7 @@ pub fn append_history_node_and_move_cursor(
     let mut connection = db.connection()?;
     let tx = connection.transaction().map_err(map_error)?;
     ensure_active_task_in_tx(&tx, task_id)?;
-    let current_cursor_node_id: i64 = tx
-        .query_row(
-            "SELECT cursor_node_id FROM tasks WHERE task_id = ?1 AND task_status = 'active'",
-            params![task_id.0],
-            |row| row.get(0),
-        )
-        .map_err(map_error)?;
+    let current_cursor_node_id = current_cursor_node_id_in_tx(&tx, task_id)?;
 
     // Task edges and history edges are separate models. Append means the DB
     // reads the task cursor, creates a child history node under that cursor,
@@ -406,7 +556,7 @@ pub fn append_history_node_and_move_cursor(
     node.parent_node_id = Some(HistoryNodeId(current_cursor_node_id));
 
     if let NewHistoryNodeContent::FunctionOutput(content) = &node.content {
-        ensure_current_cursor_is_function_call(&tx, current_cursor_node_id, content)?;
+        ensure_current_path_contains_open_function_call(&tx, current_cursor_node_id, content)?;
     }
 
     let updated_at = node.created_at;
@@ -424,6 +574,100 @@ pub fn append_history_node_and_move_cursor(
     }
     tx.commit().map_err(map_error)?;
     Ok(node_id)
+}
+
+fn current_cursor_node_id_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    task_id: &TaskId,
+) -> Result<i64, DbError> {
+    tx.query_row(
+        "SELECT cursor_node_id FROM tasks WHERE task_id = ?1 AND task_status = 'active'",
+        params![task_id.0],
+        |row| row.get(0),
+    )
+    .map_err(map_error)
+}
+
+fn append_node_to_current_cursor_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    task_id: &TaskId,
+    content: NewHistoryNodeContent,
+    created_at: UnixTs,
+) -> Result<HistoryNodeId, DbError> {
+    let current_cursor_node_id = current_cursor_node_id_in_tx(tx, task_id)?;
+    let node_id = insert_history_node(
+        tx,
+        NewHistoryNode {
+            parent_node_id: Some(HistoryNodeId(current_cursor_node_id)),
+            content,
+            created_at,
+        },
+    )?;
+    update_task_cursor_in_tx(tx, task_id, node_id, created_at)?;
+    Ok(node_id)
+}
+
+fn append_all_queued_user_inputs_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    task_id: &TaskId,
+    created_at: UnixTs,
+) -> Result<Option<HistoryNodeId>, DbError> {
+    let queued_inputs = {
+        let mut statement = tx
+            .prepare(
+                "SELECT task_id, seq_no, message_text, queued_at
+                 FROM queued_user_inputs
+                 WHERE task_id = ?1
+                 ORDER BY seq_no ASC",
+            )
+            .map_err(map_error)?;
+        statement
+            .query_map(params![task_id.0], map_queued_user_input_row)
+            .map_err(map_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_error)?
+    };
+
+    let mut last_node_id = None;
+    for queued in queued_inputs {
+        let node_id = append_node_to_current_cursor_in_tx(
+            tx,
+            task_id,
+            NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::User,
+                message_text: queued.message_text,
+            }),
+            created_at,
+        )?;
+        tx.execute(
+            "DELETE FROM queued_user_inputs WHERE task_id = ?1 AND seq_no = ?2",
+            params![queued.task_id.0, u64_to_i64(queued.seq_no)?],
+        )
+        .map_err(map_error)?;
+        last_node_id = Some(node_id);
+    }
+    Ok(last_node_id)
+}
+
+fn update_task_cursor_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    task_id: &TaskId,
+    node_id: HistoryNodeId,
+    updated_at: UnixTs,
+) -> Result<(), DbError> {
+    let changed = tx
+        .execute(
+            "UPDATE tasks
+             SET cursor_node_id = ?1, updated_at = ?2, state_version = state_version + 1
+             WHERE task_id = ?3 AND task_status = 'active'",
+            params![node_id.0, updated_at.0, task_id.0],
+        )
+        .map_err(map_error)?;
+    if changed == 0 {
+        Err(DbError::TaskNotActive)
+    } else {
+        Ok(())
+    }
 }
 
 pub fn queue_user_input(
@@ -743,7 +987,7 @@ fn read_task_in_tx(tx: &rusqlite::Transaction<'_>, task_id: &TaskId) -> Result<T
     .ok_or(DbError::NotFound)
 }
 
-fn ensure_current_cursor_is_function_call(
+fn ensure_current_path_contains_open_function_call(
     tx: &rusqlite::Transaction<'_>,
     current_cursor_node_id: i64,
     output: &NewFunctionOutputNodeContent,
@@ -817,9 +1061,61 @@ fn ensure_current_cursor_is_function_call(
     }
 }
 
-fn read_history_node(db: &DbPool, node_id: &HistoryNodeId) -> Result<HistoryNodeRow, DbError> {
+fn read_history_node(db: &DbPool, node_id: &HistoryNodeId) -> Result<HistoryNode, DbError> {
     let connection = db.connection()?;
-    read_history_node_in_connection(&connection, node_id)
+    read_history_node_concrete_in_connection(&connection, node_id)
+}
+
+fn read_history_node_concrete_in_connection(
+    connection: &Connection,
+    node_id: &HistoryNodeId,
+) -> Result<HistoryNode, DbError> {
+    let base = read_history_node_in_connection(connection, node_id)?;
+    match base.content_kind {
+        HistoryContentKindRow::Message => {
+            let row = read_message_node(connection, &base.node_id)?;
+            Ok(HistoryNode::Message {
+                node_id: base.node_id,
+                parent_node_id: base.parent_node_id,
+                created_at: base.created_at,
+                message_role: row.message_role,
+                message_text: row.message_text,
+            })
+        }
+        HistoryContentKindRow::Reasoning => {
+            let row = read_reasoning_node(connection, &base.node_id)?;
+            Ok(HistoryNode::Reasoning {
+                node_id: base.node_id,
+                parent_node_id: base.parent_node_id,
+                created_at: base.created_at,
+                reasoning_text: row.reasoning_text,
+            })
+        }
+        HistoryContentKindRow::FunctionCall => {
+            let row = read_function_call_node(connection, &base.node_id)?;
+            Ok(HistoryNode::FunctionCall {
+                node_id: base.node_id,
+                parent_node_id: base.parent_node_id,
+                created_at: base.created_at,
+                function_call_id: row.function_call_id,
+                tool_name: row.tool_name,
+                arguments: read_function_call_arguments(connection, &base.node_id)?,
+            })
+        }
+        HistoryContentKindRow::FunctionOutput => {
+            let row = read_function_output_node(connection, &base.node_id)?;
+            Ok(HistoryNode::FunctionOutput {
+                node_id: base.node_id,
+                parent_node_id: base.parent_node_id,
+                created_at: base.created_at,
+                function_call_node_id: row.function_call_node_id,
+                function_call_id: row.function_call_id,
+                tool_name: row.tool_name,
+                output_text: row.output_text,
+                is_error: row.is_error,
+            })
+        }
+    }
 }
 
 fn read_history_node_in_connection(
@@ -923,6 +1219,35 @@ fn insert_function_call_node(
     node_id: HistoryNodeId,
     content: NewFunctionCallNodeContent,
 ) -> Result<(), DbError> {
+    let argument_names = content
+        .arguments
+        .iter()
+        .map(|argument| argument.name.0.as_str())
+        .collect::<HashSet<_>>();
+    let required_parameters = {
+        let mut statement = tx
+            .prepare(
+                "SELECT parameter_name
+                 FROM tool_parameters
+                 WHERE tool_name = ?1 AND is_required = 1
+                 ORDER BY parameter_name ASC",
+            )
+            .map_err(map_error)?;
+        statement
+            .query_map(params![content.tool_name.0], |row| row.get::<_, String>(0))
+            .map_err(map_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_error)?
+    };
+    for parameter_name in required_parameters {
+        if !argument_names.contains(parameter_name.as_str()) {
+            return Err(DbError::Constraint(format!(
+                "required tool argument is missing: {}.{}",
+                content.tool_name.0, parameter_name
+            )));
+        }
+    }
+
     tx.execute(
         "INSERT INTO history_function_call_nodes (node_id, function_call_id, tool_name)
          VALUES (?1, ?2, ?3)",
@@ -1023,6 +1348,24 @@ fn read_message_node(
                     message_role: message_role_from_db(&row.get::<_, String>(1)?)
                         .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
                     message_text: row.get(2)?,
+                })
+            },
+        )
+        .map_err(map_error)
+}
+
+fn read_reasoning_node(
+    connection: &Connection,
+    node_id: &HistoryNodeId,
+) -> Result<HistoryReasoningNodeRow, DbError> {
+    connection
+        .query_row(
+            "SELECT node_id, reasoning_text FROM history_reasoning_nodes WHERE node_id = ?1",
+            params![node_id.0],
+            |row| {
+                Ok(HistoryReasoningNodeRow {
+                    node_id: HistoryNodeId(row.get(0)?),
+                    reasoning_text: row.get(1)?,
                 })
             },
         )

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -337,6 +337,11 @@ pub fn create_child_task(db: &DbPool, input: CreateChildTaskInput) -> Result<Tas
         if parent.task_status != TaskStatusRow::Active {
             return Err(DbError::TaskNotActive);
         }
+        if !history_node_is_on_parent_chain(&tx, input.cursor_node_id, parent.cursor_node_id)? {
+            return Err(DbError::Constraint(
+                "child cursor must belong to the parent task history chain".to_owned(),
+            ));
+        }
         tx.execute(
             "INSERT INTO tasks
              (task_id, task_status, cursor_node_id, model_profile_key, reasoning_effort, state_version, created_at, updated_at)
@@ -489,6 +494,64 @@ pub fn consume_next_queued_user_input(
     }
     tx.commit().map_err(map_error)?;
     Ok(queued)
+}
+
+pub fn append_next_queued_user_input_and_move_cursor(
+    db: &DbPool,
+    task_id: &TaskId,
+    created_at: UnixTs,
+) -> Result<Option<HistoryNodeId>, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    let queued = tx
+        .query_row(
+            "SELECT task_id, seq_no, message_text, queued_at
+             FROM queued_user_inputs
+             WHERE task_id = ?1
+             ORDER BY seq_no ASC
+             LIMIT 1",
+            params![task_id.0],
+            map_queued_user_input_row,
+        )
+        .optional()
+        .map_err(map_error)?;
+    let Some(queued) = queued else {
+        tx.commit().map_err(map_error)?;
+        return Ok(None);
+    };
+    let current_cursor_node_id: i64 = tx
+        .query_row(
+            "SELECT cursor_node_id FROM tasks WHERE task_id = ?1 AND task_status = 'active'",
+            params![task_id.0],
+            |row| row.get(0),
+        )
+        .map_err(map_error)?;
+    let node_id = insert_history_node(
+        &tx,
+        NewHistoryNode {
+            parent_node_id: Some(HistoryNodeId(current_cursor_node_id)),
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::User,
+                message_text: queued.message_text,
+            }),
+            created_at,
+        },
+    )?;
+    tx.execute(
+        "UPDATE tasks
+         SET cursor_node_id = ?1, updated_at = ?2, state_version = state_version + 1
+         WHERE task_id = ?3 AND task_status = 'active' AND cursor_node_id = ?4",
+        params![node_id.0, created_at.0, task_id.0, current_cursor_node_id],
+    )
+    .map_err(map_error)?;
+    tx.execute(
+        "DELETE FROM queued_user_inputs WHERE task_id = ?1 AND seq_no = ?2",
+        params![queued.task_id.0, u64_to_i64(queued.seq_no)?],
+    )
+    .map_err(map_error)?;
+    tx.commit().map_err(map_error)?;
+    Ok(Some(node_id))
 }
 
 pub fn archive_task(db: &DbPool, task_id: &TaskId, now: UnixTs) -> Result<(), DbError> {
@@ -681,6 +744,26 @@ fn read_task_in_tx(tx: &rusqlite::Transaction<'_>, task_id: &TaskId) -> Result<T
     .optional()
     .map_err(map_error)?
     .ok_or(DbError::NotFound)
+}
+
+fn history_node_is_on_parent_chain(
+    tx: &rusqlite::Transaction<'_>,
+    candidate_node_id: HistoryNodeId,
+    parent_cursor_node_id: HistoryNodeId,
+) -> Result<bool, DbError> {
+    tx.query_row(
+        "WITH RECURSIVE chain(node_id, parent_node_id) AS (
+             SELECT node_id, parent_node_id FROM history_nodes WHERE node_id = ?1
+             UNION ALL
+             SELECT h.node_id, h.parent_node_id
+             FROM history_nodes h
+             INNER JOIN chain c ON h.node_id = c.parent_node_id
+         )
+         SELECT EXISTS(SELECT 1 FROM chain WHERE node_id = ?2)",
+        params![parent_cursor_node_id.0, candidate_node_id.0],
+        |row| row.get(0),
+    )
+    .map_err(map_error)
 }
 
 fn read_history_node(db: &DbPool, node_id: &HistoryNodeId) -> Result<HistoryNodeRow, DbError> {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -222,7 +222,9 @@ impl HistoryNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CreateRootTaskInput {
     pub task_id: TaskId,
-    pub initial_node: NewHistoryNode,
+    /// Cursor ownership stays at the task layer. The caller selects an
+    /// already-persisted history node; task creation records that pointer.
+    pub cursor_node_id: HistoryNodeId,
     pub model_profile_key: ModelProfileKey,
     pub reasoning_effort: ReasoningEffort,
     pub enabled_tools: Vec<ToolName>,
@@ -352,19 +354,34 @@ pub fn register_tool(db: &DbPool, tool: ToolSpec) -> Result<(), DbError> {
     tx.commit().map_err(map_error)
 }
 
+/// Insert one history node and leave task rows unchanged.
+///
+/// History is a standalone graph. A task may point at any existing node chosen
+/// by the caller's creation strategy; this write only materializes that node.
+pub fn create_history_node(db: &DbPool, node: NewHistoryNode) -> Result<HistoryNodeId, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    let node_id = insert_history_node(&tx, node)?;
+    tx.commit().map_err(map_error)?;
+    Ok(node_id)
+}
+
+/// Insert one root task whose cursor points at an existing history node.
+///
+/// Task relations and history relations are separate graphs. Creating a task
+/// records the task-layer cursor pointer and tool manifest only.
 pub fn create_root_task(db: &DbPool, input: CreateRootTaskInput) -> Result<TaskRow, DbError> {
     let task_id = input.task_id.clone();
     {
         let mut connection = db.connection()?;
         let tx = connection.transaction().map_err(map_error)?;
-        let node_id = insert_history_node(&tx, input.initial_node)?;
         tx.execute(
             "INSERT INTO tasks
              (task_id, task_status, cursor_node_id, model_profile_key, reasoning_effort, state_version, created_at, updated_at)
              VALUES (?1, 'active', ?2, ?3, ?4, 0, ?5, ?5)",
             params![
                 input.task_id.0,
-                node_id.0,
+                input.cursor_node_id.0,
                 input.model_profile_key.0,
                 reasoning_effort_to_db(&input.reasoning_effort),
                 input.now.0

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -391,18 +391,40 @@ pub fn append_history_node_and_move_cursor(
     let mut connection = db.connection()?;
     let tx = connection.transaction().map_err(map_error)?;
     ensure_active_task_in_tx(&tx, task_id)?;
+    let expected_parent_node_id = node.parent_node_id.ok_or_else(|| {
+        DbError::Constraint("history append parent must be the current task cursor".to_owned())
+    })?;
+    let current_cursor_node_id: i64 = tx
+        .query_row(
+            "SELECT cursor_node_id FROM tasks WHERE task_id = ?1 AND task_status = 'active'",
+            params![task_id.0],
+            |row| row.get(0),
+        )
+        .map_err(map_error)?;
+    if current_cursor_node_id != expected_parent_node_id.0 {
+        return Err(DbError::Constraint(
+            "history append parent must match the current task cursor".to_owned(),
+        ));
+    }
     let updated_at = node.created_at;
     let node_id = insert_history_node(&tx, node)?;
     let changed = tx
         .execute(
             "UPDATE tasks
              SET cursor_node_id = ?1, updated_at = ?2, state_version = state_version + 1
-             WHERE task_id = ?3 AND task_status = 'active'",
-            params![node_id.0, updated_at.0, task_id.0],
+             WHERE task_id = ?3 AND task_status = 'active' AND cursor_node_id = ?4",
+            params![
+                node_id.0,
+                updated_at.0,
+                task_id.0,
+                expected_parent_node_id.0
+            ],
         )
         .map_err(map_error)?;
     if changed == 0 {
-        return Err(DbError::TaskNotActive);
+        return Err(DbError::Constraint(
+            "history append parent must match the current task cursor".to_owned(),
+        ));
     }
     tx.commit().map_err(map_error)?;
     Ok(node_id)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -299,6 +299,11 @@ pub fn register_tool(db: &DbPool, tool: ToolSpec) -> Result<(), DbError> {
 
 pub fn create_root_task(db: &DbPool, input: CreateRootTaskInput) -> Result<TaskRow, DbError> {
     let task_id = input.task_id.clone();
+    if input.initial_node.parent_node_id.is_some() {
+        return Err(DbError::Constraint(
+            "root task initial node must not have a parent".to_owned(),
+        ));
+    }
     {
         let mut connection = db.connection()?;
         let tx = connection.transaction().map_err(map_error)?;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -166,6 +166,14 @@ pub struct HistoryFunctionOutputNodeRow {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct OpenFunctionCall {
+    pub function_call_node_id: HistoryNodeId,
+    pub function_call_id: FunctionCallId,
+    pub tool_name: ToolName,
+    pub arguments: Vec<ToolCallArgument>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum HistoryNode {
     Message {
         node_id: HistoryNodeId,
@@ -537,6 +545,80 @@ pub fn append_function_output_and_drain_queue(
     }
     tx.commit().map_err(map_error)?;
     Ok(last_node_id)
+}
+
+pub fn drain_queued_user_inputs_and_move_cursor(
+    db: &DbPool,
+    task_id: &TaskId,
+    created_at: UnixTs,
+) -> Result<Option<HistoryNodeId>, DbError> {
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    let last_node_id = append_all_queued_user_inputs_in_tx(&tx, task_id, created_at)?;
+    tx.commit().map_err(map_error)?;
+    Ok(last_node_id)
+}
+
+pub fn read_open_function_calls_for_task(
+    db: &DbPool,
+    task_id: &TaskId,
+) -> Result<Vec<OpenFunctionCall>, DbError> {
+    let task = load_active_task(db, task_id)?.task;
+    let connection = db.connection()?;
+    let mut nodes = Vec::new();
+    let mut next_node_id = Some(task.cursor_node_id);
+    while let Some(node_id) = next_node_id {
+        let node = read_history_node_concrete_in_connection(&connection, &node_id)?;
+        next_node_id = match &node {
+            HistoryNode::Message { parent_node_id, .. }
+            | HistoryNode::Reasoning { parent_node_id, .. }
+            | HistoryNode::FunctionCall { parent_node_id, .. }
+            | HistoryNode::FunctionOutput { parent_node_id, .. } => *parent_node_id,
+        };
+        nodes.push(node);
+    }
+    nodes.reverse();
+
+    let mut open_calls = Vec::<OpenFunctionCall>::new();
+    for node in nodes {
+        match node {
+            HistoryNode::FunctionCall {
+                node_id,
+                function_call_id,
+                tool_name,
+                arguments,
+                ..
+            } => {
+                open_calls.push(OpenFunctionCall {
+                    function_call_node_id: node_id,
+                    function_call_id,
+                    tool_name,
+                    arguments,
+                });
+            }
+            HistoryNode::FunctionOutput {
+                function_call_node_id,
+                function_call_id,
+                tool_name,
+                ..
+            } => {
+                if let Some(index) = open_calls.iter().position(|call| {
+                    call.function_call_node_id == function_call_node_id
+                        && call.function_call_id == function_call_id
+                        && call.tool_name == tool_name
+                }) {
+                    open_calls.remove(index);
+                } else {
+                    return Err(DbError::Constraint(
+                        "function output must reference a prior open function call".to_owned(),
+                    ));
+                }
+            }
+            HistoryNode::Message { .. } | HistoryNode::Reasoning { .. } => {}
+        }
+    }
+    Ok(open_calls)
 }
 
 fn append_history_node_and_move_cursor(

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -469,8 +469,15 @@ pub fn consume_next_queued_user_input(
 }
 
 pub fn archive_task(db: &DbPool, task_id: &TaskId, now: UnixTs) -> Result<(), DbError> {
-    let connection = db.connection()?;
-    let changed = connection
+    let mut connection = db.connection()?;
+    let tx = connection.transaction().map_err(map_error)?;
+    ensure_active_task_in_tx(&tx, task_id)?;
+    tx.execute(
+        "DELETE FROM queued_user_inputs WHERE task_id = ?1",
+        params![task_id.0],
+    )
+    .map_err(map_error)?;
+    let changed = tx
         .execute(
             "UPDATE tasks
              SET task_status = 'archived', updated_at = ?1, state_version = state_version + 1
@@ -481,6 +488,7 @@ pub fn archive_task(db: &DbPool, task_id: &TaskId, now: UnixTs) -> Result<(), Db
     if changed == 0 {
         Err(DbError::TaskNotActive)
     } else {
+        tx.commit().map_err(map_error)?;
         Ok(())
     }
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -529,13 +529,19 @@ pub fn append_next_queued_user_input_and_move_cursor(
             created_at,
         },
     )?;
-    tx.execute(
-        "UPDATE tasks
+    let changed = tx
+        .execute(
+            "UPDATE tasks
          SET cursor_node_id = ?1, updated_at = ?2, state_version = state_version + 1
          WHERE task_id = ?3 AND task_status = 'active' AND cursor_node_id = ?4",
-        params![node_id.0, created_at.0, task_id.0, current_cursor_node_id],
-    )
-    .map_err(map_error)?;
+            params![node_id.0, created_at.0, task_id.0, current_cursor_node_id],
+        )
+        .map_err(map_error)?;
+    if changed == 0 {
+        return Err(DbError::Constraint(
+            "queued input append cursor changed before update".to_owned(),
+        ));
+    }
     tx.execute(
         "DELETE FROM queued_user_inputs WHERE task_id = ?1 AND seq_no = ?2",
         params![queued.task_id.0, u64_to_i64(queued.seq_no)?],

--- a/crates/db/src/schema.sql
+++ b/crates/db/src/schema.sql
@@ -1,0 +1,174 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE schema_metadata (
+    schema_key TEXT PRIMARY KEY CHECK (length(schema_key) > 0),
+    schema_value TEXT NOT NULL CHECK (length(schema_value) > 0)
+);
+
+INSERT INTO schema_metadata (schema_key, schema_value)
+VALUES ('selvedge_schema_version', 'router-mediated-redesign-v3');
+
+CREATE TABLE tools (
+    tool_name TEXT PRIMARY KEY CHECK (length(tool_name) > 0),
+    description_text TEXT NOT NULL CHECK (length(description_text) > 0)
+);
+
+CREATE TABLE tool_parameters (
+    tool_name TEXT NOT NULL,
+    parameter_name TEXT NOT NULL CHECK (length(parameter_name) > 0),
+    parameter_type TEXT NOT NULL CHECK (parameter_type IN ('string', 'integer', 'number', 'boolean')),
+    description_text TEXT NOT NULL CHECK (length(description_text) > 0),
+    is_required INTEGER NOT NULL CHECK (is_required IN (0, 1)),
+    PRIMARY KEY (tool_name, parameter_name),
+    UNIQUE (tool_name, parameter_name, parameter_type),
+    FOREIGN KEY (tool_name) REFERENCES tools(tool_name) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX idx_tool_parameters_tool_required
+    ON tool_parameters(tool_name, is_required, parameter_name);
+
+CREATE TABLE history_nodes (
+    node_id INTEGER PRIMARY KEY,
+    parent_node_id INTEGER,
+    content_kind TEXT NOT NULL CHECK (content_kind IN ('message', 'reasoning', 'function_call', 'function_output')),
+    created_at INTEGER NOT NULL CHECK (created_at >= 0),
+    UNIQUE (node_id, content_kind),
+    UNIQUE (node_id, parent_node_id),
+    FOREIGN KEY (parent_node_id) REFERENCES history_nodes(node_id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+    CHECK (parent_node_id IS NULL OR parent_node_id <> node_id)
+);
+
+CREATE INDEX idx_history_nodes_parent
+    ON history_nodes(parent_node_id, node_id);
+
+CREATE TABLE history_message_nodes (
+    node_id INTEGER PRIMARY KEY,
+    node_content_kind TEXT NOT NULL DEFAULT 'message' CHECK (node_content_kind = 'message'),
+    message_role TEXT NOT NULL CHECK (message_role IN ('system', 'developer', 'user', 'assistant')),
+    message_text TEXT NOT NULL,
+    FOREIGN KEY (node_id, node_content_kind) REFERENCES history_nodes(node_id, content_kind) ON UPDATE RESTRICT ON DELETE CASCADE
+);
+
+CREATE TABLE history_reasoning_nodes (
+    node_id INTEGER PRIMARY KEY,
+    node_content_kind TEXT NOT NULL DEFAULT 'reasoning' CHECK (node_content_kind = 'reasoning'),
+    reasoning_text TEXT NOT NULL,
+    FOREIGN KEY (node_id, node_content_kind) REFERENCES history_nodes(node_id, content_kind) ON UPDATE RESTRICT ON DELETE CASCADE
+);
+
+CREATE TABLE history_function_call_nodes (
+    node_id INTEGER PRIMARY KEY,
+    node_content_kind TEXT NOT NULL DEFAULT 'function_call' CHECK (node_content_kind = 'function_call'),
+    function_call_id TEXT NOT NULL CHECK (length(function_call_id) > 0),
+    tool_name TEXT NOT NULL CHECK (length(tool_name) > 0),
+    FOREIGN KEY (node_id, node_content_kind) REFERENCES history_nodes(node_id, content_kind) ON UPDATE RESTRICT ON DELETE CASCADE,
+    FOREIGN KEY (tool_name) REFERENCES tools(tool_name) ON UPDATE CASCADE ON DELETE RESTRICT,
+    UNIQUE (node_id, tool_name),
+    UNIQUE (node_id, function_call_id, tool_name)
+);
+
+CREATE INDEX idx_history_function_call_id
+    ON history_function_call_nodes(function_call_id);
+
+CREATE INDEX idx_history_function_call_tool
+    ON history_function_call_nodes(tool_name, node_id);
+
+CREATE TABLE history_function_call_arguments (
+    function_call_node_id INTEGER NOT NULL,
+    tool_name TEXT NOT NULL CHECK (length(tool_name) > 0),
+    argument_name TEXT NOT NULL CHECK (length(argument_name) > 0),
+    value_type TEXT NOT NULL CHECK (value_type IN ('string', 'integer', 'number', 'boolean')),
+    string_value TEXT,
+    integer_value INTEGER,
+    number_value REAL,
+    boolean_value INTEGER CHECK (boolean_value IN (0, 1)),
+    PRIMARY KEY (function_call_node_id, argument_name),
+    FOREIGN KEY (function_call_node_id, tool_name) REFERENCES history_function_call_nodes(node_id, tool_name) ON UPDATE RESTRICT ON DELETE CASCADE,
+    FOREIGN KEY (tool_name, argument_name, value_type) REFERENCES tool_parameters(tool_name, parameter_name, parameter_type) ON UPDATE CASCADE ON DELETE RESTRICT,
+    CHECK (
+        (value_type = 'string' AND string_value IS NOT NULL AND integer_value IS NULL AND number_value IS NULL AND boolean_value IS NULL)
+        OR (value_type = 'integer' AND string_value IS NULL AND integer_value IS NOT NULL AND number_value IS NULL AND boolean_value IS NULL)
+        OR (value_type = 'number' AND string_value IS NULL AND integer_value IS NULL AND number_value IS NOT NULL AND boolean_value IS NULL)
+        OR (value_type = 'boolean' AND string_value IS NULL AND integer_value IS NULL AND number_value IS NULL AND boolean_value IS NOT NULL)
+    )
+);
+
+CREATE INDEX idx_history_function_call_args_call_tool
+    ON history_function_call_arguments(function_call_node_id, tool_name);
+
+CREATE INDEX idx_history_function_call_args_parameter
+    ON history_function_call_arguments(tool_name, argument_name, value_type);
+
+CREATE TABLE history_function_output_nodes (
+    node_id INTEGER PRIMARY KEY,
+    node_content_kind TEXT NOT NULL DEFAULT 'function_output' CHECK (node_content_kind = 'function_output'),
+    function_call_node_id INTEGER NOT NULL,
+    function_call_id TEXT NOT NULL CHECK (length(function_call_id) > 0),
+    tool_name TEXT NOT NULL CHECK (length(tool_name) > 0),
+    output_text TEXT NOT NULL,
+    is_error INTEGER NOT NULL CHECK (is_error IN (0, 1)),
+    FOREIGN KEY (node_id, node_content_kind) REFERENCES history_nodes(node_id, content_kind) ON UPDATE RESTRICT ON DELETE CASCADE,
+    FOREIGN KEY (node_id, function_call_node_id) REFERENCES history_nodes(node_id, parent_node_id) ON UPDATE RESTRICT ON DELETE CASCADE,
+    FOREIGN KEY (function_call_node_id, function_call_id, tool_name) REFERENCES history_function_call_nodes(node_id, function_call_id, tool_name) ON UPDATE RESTRICT ON DELETE RESTRICT,
+    UNIQUE (function_call_node_id)
+);
+
+CREATE INDEX idx_history_function_output_call
+    ON history_function_output_nodes(function_call_node_id);
+
+CREATE TABLE tasks (
+    task_id TEXT PRIMARY KEY CHECK (length(task_id) > 0),
+    task_status TEXT NOT NULL CHECK (task_status IN ('active', 'archived')),
+    cursor_node_id INTEGER NOT NULL,
+    model_profile_key TEXT NOT NULL CHECK (length(model_profile_key) > 0),
+    reasoning_effort TEXT NOT NULL CHECK (reasoning_effort IN ('minimal', 'low', 'medium', 'high')),
+    state_version INTEGER NOT NULL DEFAULT 0 CHECK (state_version >= 0),
+    created_at INTEGER NOT NULL CHECK (created_at >= 0),
+    updated_at INTEGER NOT NULL CHECK (updated_at >= created_at),
+    UNIQUE (task_id, task_status),
+    FOREIGN KEY (cursor_node_id) REFERENCES history_nodes(node_id) ON UPDATE RESTRICT ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_tasks_status_updated
+    ON tasks(task_status, updated_at DESC, task_id);
+
+CREATE INDEX idx_tasks_cursor
+    ON tasks(cursor_node_id, task_id);
+
+CREATE TABLE task_tools (
+    task_id TEXT NOT NULL,
+    tool_name TEXT NOT NULL CHECK (length(tool_name) > 0),
+    PRIMARY KEY (task_id, tool_name),
+    FOREIGN KEY (task_id) REFERENCES tasks(task_id) ON UPDATE RESTRICT ON DELETE CASCADE,
+    FOREIGN KEY (tool_name) REFERENCES tools(tool_name) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_task_tools_tool
+    ON task_tools(tool_name, task_id);
+
+CREATE TABLE task_parent_edges (
+    parent_task_id TEXT NOT NULL,
+    child_task_id TEXT NOT NULL,
+    created_at INTEGER NOT NULL CHECK (created_at >= 0),
+    PRIMARY KEY (parent_task_id, child_task_id),
+    UNIQUE (child_task_id),
+    FOREIGN KEY (parent_task_id) REFERENCES tasks(task_id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+    FOREIGN KEY (child_task_id) REFERENCES tasks(task_id) ON UPDATE RESTRICT ON DELETE CASCADE,
+    CHECK (parent_task_id <> child_task_id)
+);
+
+CREATE INDEX idx_task_parent_edges_parent_created
+    ON task_parent_edges(parent_task_id, created_at, child_task_id);
+
+CREATE TABLE queued_user_inputs (
+    task_id TEXT NOT NULL,
+    seq_no INTEGER NOT NULL CHECK (seq_no >= 1),
+    task_status TEXT NOT NULL DEFAULT 'active' CHECK (task_status = 'active'),
+    message_text TEXT NOT NULL CHECK (length(message_text) > 0),
+    queued_at INTEGER NOT NULL CHECK (queued_at >= 0),
+    PRIMARY KEY (task_id, seq_no),
+    FOREIGN KEY (task_id, task_status) REFERENCES tasks(task_id, task_status) ON UPDATE RESTRICT ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE INDEX idx_queued_user_inputs_task_order
+    ON queued_user_inputs(task_id, seq_no);

--- a/crates/db/src/schema.sql
+++ b/crates/db/src/schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE schema_metadata (
 );
 
 INSERT INTO schema_metadata (schema_key, schema_value)
-VALUES ('selvedge_schema_version', 'router-mediated-redesign-v3');
+VALUES ('selvedge_schema_version', 'router-mediated-redesign-v4');
 
 CREATE TABLE tools (
     tool_name TEXT PRIMARY KEY CHECK (length(tool_name) > 0),
@@ -108,7 +108,6 @@ CREATE TABLE history_function_output_nodes (
     output_text TEXT NOT NULL,
     is_error INTEGER NOT NULL CHECK (is_error IN (0, 1)),
     FOREIGN KEY (node_id, node_content_kind) REFERENCES history_nodes(node_id, content_kind) ON UPDATE RESTRICT ON DELETE CASCADE,
-    FOREIGN KEY (node_id, function_call_node_id) REFERENCES history_nodes(node_id, parent_node_id) ON UPDATE RESTRICT ON DELETE CASCADE,
     FOREIGN KEY (function_call_node_id, function_call_id, tool_name) REFERENCES history_function_call_nodes(node_id, function_call_id, tool_name) ON UPDATE RESTRICT ON DELETE RESTRICT,
     UNIQUE (function_call_node_id)
 );

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -1,7 +1,8 @@
 use selvedge_db::{
     CreateRootTaskInput, HistoryContentKindRow, MessageRole, NewHistoryNode, NewHistoryNodeContent,
     NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId, TaskStatusRow, UnixTs,
-    archive_task, create_root_task, load_active_task, open_db, queue_user_input,
+    append_history_node_and_move_cursor, archive_task, create_root_task, load_active_task, open_db,
+    queue_user_input,
 };
 
 #[test]
@@ -96,7 +97,7 @@ fn append_history_uses_new_node_timestamp_for_task_updated_at() {
                 }),
                 created_at: UnixTs(4_102_444_800),
             },
-            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
             now: UnixTs(4_102_444_800),
@@ -117,4 +118,60 @@ fn append_history_uses_new_node_timestamp_for_task_updated_at() {
         },
     )
     .expect("append history");
+}
+
+#[test]
+fn append_history_rejects_stale_parent_cursor() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    let task = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "hello".to_owned(),
+                }),
+                created_at: UnixTs(10),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(10),
+        },
+    )
+    .expect("create root task");
+    append_history_node_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        NewHistoryNode {
+            parent_node_id: Some(task.cursor_node_id),
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::User,
+                message_text: "first append".to_owned(),
+            }),
+            created_at: UnixTs(11),
+        },
+    )
+    .expect("append once");
+
+    let error = append_history_node_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        NewHistoryNode {
+            parent_node_id: Some(task.cursor_node_id),
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::User,
+                message_text: "stale append".to_owned(),
+            }),
+            created_at: UnixTs(12),
+        },
+    )
+    .expect_err("stale append");
+
+    assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
 }

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -1,7 +1,7 @@
 use selvedge_db::{
-    CreateChildTaskInput, CreateRootTaskInput, HistoryContentKindRow, MessageRole, NewHistoryNode,
+    CreateChildTaskInput, CreateRootTaskInput, HistoryNode, MessageRole, NewHistoryNode,
     NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId,
-    TaskStatusRow, UnixTs, append_history_node_and_move_cursor, archive_task, create_child_task,
+    TaskStatusRow, UnixTs, append_user_message_and_move_cursor, archive_task, create_child_task,
     create_root_task, load_active_task, open_db, queue_user_input, read_conversation_for_task,
 };
 use selvedge_domain_model::ConversationItem;
@@ -38,10 +38,7 @@ fn open_db_creates_schema_and_root_task_transaction_moves_cursor() {
 
     let loaded = load_active_task(&db, &TaskId("task-1".to_owned())).expect("load active task");
     assert_eq!(loaded.task.cursor_node_id, task.cursor_node_id);
-    assert_eq!(
-        loaded.cursor_node.content_kind,
-        HistoryContentKindRow::Message
-    );
+    assert!(matches!(loaded.cursor_node, HistoryNode::Message { .. }));
 }
 
 #[test]
@@ -86,7 +83,7 @@ fn append_history_uses_new_node_timestamp_for_task_updated_at() {
         sqlite_path: ":memory:".to_owned(),
     })
     .expect("open db");
-    let task = create_root_task(
+    create_root_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
@@ -106,17 +103,11 @@ fn append_history_uses_new_node_timestamp_for_task_updated_at() {
     )
     .expect("create root task");
 
-    selvedge_db::append_history_node_and_move_cursor(
+    append_user_message_and_move_cursor(
         &db,
         &TaskId("task-1".to_owned()),
-        NewHistoryNode {
-            parent_node_id: Some(task.cursor_node_id),
-            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                message_role: MessageRole::User,
-                message_text: "future append".to_owned(),
-            }),
-            created_at: UnixTs(4_102_444_801),
-        },
+        "future append".to_owned(),
+        UnixTs(4_102_444_801),
     )
     .expect("append history");
 }
@@ -127,7 +118,7 @@ fn append_history_uses_database_cursor_as_parent() {
         sqlite_path: ":memory:".to_owned(),
     })
     .expect("open db");
-    let task = create_root_task(
+    create_root_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
@@ -146,31 +137,19 @@ fn append_history_uses_database_cursor_as_parent() {
         },
     )
     .expect("create root task");
-    append_history_node_and_move_cursor(
+    append_user_message_and_move_cursor(
         &db,
         &TaskId("task-1".to_owned()),
-        NewHistoryNode {
-            parent_node_id: Some(task.cursor_node_id),
-            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                message_role: MessageRole::User,
-                message_text: "first append".to_owned(),
-            }),
-            created_at: UnixTs(11),
-        },
+        "first append".to_owned(),
+        UnixTs(11),
     )
     .expect("append once");
 
-    append_history_node_and_move_cursor(
+    append_user_message_and_move_cursor(
         &db,
         &TaskId("task-1".to_owned()),
-        NewHistoryNode {
-            parent_node_id: Some(task.cursor_node_id),
-            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                message_role: MessageRole::User,
-                message_text: "stale append".to_owned(),
-            }),
-            created_at: UnixTs(12),
-        },
+        "stale append".to_owned(),
+        UnixTs(12),
     )
     .expect("append uses database cursor");
 

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -1,10 +1,32 @@
 use selvedge_db::{
-    CreateChildTaskInput, CreateRootTaskInput, HistoryNode, MessageRole, NewHistoryNode,
-    NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId,
-    TaskStatusRow, UnixTs, append_user_message_and_move_cursor, archive_task, create_child_task,
-    create_root_task, load_active_task, open_db, queue_user_input, read_conversation_for_task,
+    CreateChildTaskInput, CreateRootTaskInput, DbPool, HistoryNode, HistoryNodeId, MessageRole,
+    NewHistoryNode, NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort,
+    TaskId, TaskStatusRow, UnixTs, append_user_message_and_move_cursor, archive_task,
+    create_child_task, create_history_node, create_root_task, load_active_task, open_db,
+    queue_user_input, read_conversation_for_task,
 };
 use selvedge_domain_model::ConversationItem;
+
+fn create_message_node(
+    db: &DbPool,
+    parent_node_id: Option<HistoryNodeId>,
+    message_role: MessageRole,
+    message_text: &str,
+    created_at: UnixTs,
+) -> HistoryNodeId {
+    create_history_node(
+        db,
+        NewHistoryNode {
+            parent_node_id,
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role,
+                message_text: message_text.to_owned(),
+            }),
+            created_at,
+        },
+    )
+    .expect("create history node")
+}
 
 #[test]
 fn open_db_creates_schema_and_root_task_transaction_moves_cursor() {
@@ -17,14 +39,7 @@ fn open_db_creates_schema_and_root_task_transaction_moves_cursor() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "hello".to_owned(),
-                }),
-                created_at: UnixTs(10),
-            },
+            cursor_node_id: create_message_node(&db, None, MessageRole::User, "hello", UnixTs(10)),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -51,14 +66,7 @@ fn archive_task_clears_queued_inputs_before_status_update() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "hello".to_owned(),
-                }),
-                created_at: UnixTs(10),
-            },
+            cursor_node_id: create_message_node(&db, None, MessageRole::User, "hello", UnixTs(10)),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -87,14 +95,13 @@ fn append_history_uses_new_node_timestamp_for_task_updated_at() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "hello".to_owned(),
-                }),
-                created_at: UnixTs(4_102_444_800),
-            },
+            cursor_node_id: create_message_node(
+                &db,
+                None,
+                MessageRole::User,
+                "hello",
+                UnixTs(4_102_444_800),
+            ),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -122,14 +129,7 @@ fn append_history_uses_database_cursor_as_parent() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("task-1".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "hello".to_owned(),
-                }),
-                created_at: UnixTs(10),
-            },
+            cursor_node_id: create_message_node(&db, None, MessageRole::User, "hello", UnixTs(10)),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -176,14 +176,7 @@ fn create_child_task_accepts_strategy_cursor_outside_parent_chain() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("parent".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "parent".to_owned(),
-                }),
-                created_at: UnixTs(10),
-            },
+            cursor_node_id: create_message_node(&db, None, MessageRole::User, "parent", UnixTs(10)),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -195,14 +188,13 @@ fn create_child_task_accepts_strategy_cursor_outside_parent_chain() {
         &db,
         CreateRootTaskInput {
             task_id: TaskId("foreign".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "foreign".to_owned(),
-                }),
-                created_at: UnixTs(10),
-            },
+            cursor_node_id: create_message_node(
+                &db,
+                None,
+                MessageRole::User,
+                "foreign",
+                UnixTs(10),
+            ),
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -227,23 +219,18 @@ fn create_child_task_accepts_strategy_cursor_outside_parent_chain() {
 }
 
 #[test]
-fn create_root_task_accepts_strategy_parented_initial_node() {
+fn create_history_node_accepts_strategy_parent_and_root_task_uses_existing_cursor() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
     })
     .expect("open db");
-    let existing = create_root_task(
+    let existing_node_id =
+        create_message_node(&db, None, MessageRole::User, "existing", UnixTs(10));
+    create_root_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("existing".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: None,
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "existing".to_owned(),
-                }),
-                created_at: UnixTs(10),
-            },
+            cursor_node_id: existing_node_id,
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),
@@ -251,19 +238,19 @@ fn create_root_task_accepts_strategy_parented_initial_node() {
         },
     )
     .expect("create existing");
+    let root_node_id = create_message_node(
+        &db,
+        Some(existing_node_id),
+        MessageRole::User,
+        "root",
+        UnixTs(11),
+    );
 
     let root = create_root_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("root".to_owned()),
-            initial_node: NewHistoryNode {
-                parent_node_id: Some(existing.cursor_node_id),
-                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
-                    message_role: MessageRole::User,
-                    message_text: "root".to_owned(),
-                }),
-                created_at: UnixTs(11),
-            },
+            cursor_node_id: root_node_id,
             model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
             reasoning_effort: ReasoningEffort::Medium,
             enabled_tools: Vec::new(),

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -1,0 +1,43 @@
+use selvedge_db::{
+    CreateRootTaskInput, HistoryContentKindRow, MessageRole, NewHistoryNode, NewHistoryNodeContent,
+    NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId, TaskStatusRow, UnixTs,
+    create_root_task, load_active_task, open_db,
+};
+
+#[test]
+fn open_db_creates_schema_and_root_task_transaction_moves_cursor() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+
+    let task = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "hello".to_owned(),
+                }),
+                created_at: UnixTs(10),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(10),
+        },
+    )
+    .expect("create root task");
+
+    assert_eq!(task.task_status, TaskStatusRow::Active);
+    assert_eq!(task.state_version, 0);
+
+    let loaded = load_active_task(&db, &TaskId("task-1".to_owned())).expect("load active task");
+    assert_eq!(loaded.task.cursor_node_id, task.cursor_node_id);
+    assert_eq!(
+        loaded.cursor_node.content_kind,
+        HistoryContentKindRow::Message
+    );
+}

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -235,3 +235,52 @@ fn create_child_task_rejects_cursor_outside_parent_chain() {
 
     assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
 }
+
+#[test]
+fn create_root_task_rejects_parented_initial_node() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    let existing = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("existing".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "existing".to_owned(),
+                }),
+                created_at: UnixTs(10),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(10),
+        },
+    )
+    .expect("create existing");
+
+    let error = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("root".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: Some(existing.cursor_node_id),
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "root".to_owned(),
+                }),
+                created_at: UnixTs(11),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(11),
+        },
+    )
+    .expect_err("parented root rejected");
+
+    assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
+}

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -1,8 +1,8 @@
 use selvedge_db::{
-    CreateRootTaskInput, HistoryContentKindRow, MessageRole, NewHistoryNode, NewHistoryNodeContent,
-    NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId, TaskStatusRow, UnixTs,
-    append_history_node_and_move_cursor, archive_task, create_root_task, load_active_task, open_db,
-    queue_user_input,
+    CreateChildTaskInput, CreateRootTaskInput, HistoryContentKindRow, MessageRole, NewHistoryNode,
+    NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId,
+    TaskStatusRow, UnixTs, append_history_node_and_move_cursor, archive_task, create_child_task,
+    create_root_task, load_active_task, open_db, queue_user_input,
 };
 
 #[test]
@@ -172,6 +172,66 @@ fn append_history_rejects_stale_parent_cursor() {
         },
     )
     .expect_err("stale append");
+
+    assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
+}
+
+#[test]
+fn create_child_task_rejects_cursor_outside_parent_chain() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    let parent = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("parent".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "parent".to_owned(),
+                }),
+                created_at: UnixTs(10),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(10),
+        },
+    )
+    .expect("create parent");
+    let foreign = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("foreign".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "foreign".to_owned(),
+                }),
+                created_at: UnixTs(10),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(10),
+        },
+    )
+    .expect("create foreign");
+    assert_ne!(parent.cursor_node_id, foreign.cursor_node_id);
+
+    let error = create_child_task(
+        &db,
+        CreateChildTaskInput {
+            parent_task_id: TaskId("parent".to_owned()),
+            child_task_id: TaskId("child".to_owned()),
+            cursor_node_id: foreign.cursor_node_id,
+            now: UnixTs(11),
+        },
+    )
+    .expect_err("foreign cursor rejected");
 
     assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
 }

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -2,8 +2,9 @@ use selvedge_db::{
     CreateChildTaskInput, CreateRootTaskInput, HistoryContentKindRow, MessageRole, NewHistoryNode,
     NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId,
     TaskStatusRow, UnixTs, append_history_node_and_move_cursor, archive_task, create_child_task,
-    create_root_task, load_active_task, open_db, queue_user_input,
+    create_root_task, load_active_task, open_db, queue_user_input, read_conversation_for_task,
 };
+use selvedge_domain_model::ConversationItem;
 
 #[test]
 fn open_db_creates_schema_and_root_task_transaction_moves_cursor() {
@@ -121,7 +122,7 @@ fn append_history_uses_new_node_timestamp_for_task_updated_at() {
 }
 
 #[test]
-fn append_history_rejects_stale_parent_cursor() {
+fn append_history_uses_database_cursor_as_parent() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
     })
@@ -159,7 +160,7 @@ fn append_history_rejects_stale_parent_cursor() {
     )
     .expect("append once");
 
-    let error = append_history_node_and_move_cursor(
+    append_history_node_and_move_cursor(
         &db,
         &TaskId("task-1".to_owned()),
         NewHistoryNode {
@@ -171,13 +172,23 @@ fn append_history_rejects_stale_parent_cursor() {
             created_at: UnixTs(12),
         },
     )
-    .expect_err("stale append");
+    .expect("append uses database cursor");
 
-    assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
+    let conversation =
+        read_conversation_for_task(&db, &TaskId("task-1".to_owned())).expect("conversation");
+    let messages = conversation
+        .items
+        .into_iter()
+        .filter_map(|item| match item {
+            ConversationItem::Message { text, .. } => Some(text),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(messages, vec!["hello", "first append", "stale append"]);
 }
 
 #[test]
-fn create_child_task_rejects_cursor_outside_parent_chain() {
+fn create_child_task_accepts_strategy_cursor_outside_parent_chain() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
     })
@@ -222,7 +233,7 @@ fn create_child_task_rejects_cursor_outside_parent_chain() {
     .expect("create foreign");
     assert_ne!(parent.cursor_node_id, foreign.cursor_node_id);
 
-    let error = create_child_task(
+    let child = create_child_task(
         &db,
         CreateChildTaskInput {
             parent_task_id: TaskId("parent".to_owned()),
@@ -231,13 +242,13 @@ fn create_child_task_rejects_cursor_outside_parent_chain() {
             now: UnixTs(11),
         },
     )
-    .expect_err("foreign cursor rejected");
+    .expect("create child task");
 
-    assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
+    assert_eq!(child.cursor_node_id, foreign.cursor_node_id);
 }
 
 #[test]
-fn create_root_task_rejects_parented_initial_node() {
+fn create_root_task_accepts_strategy_parented_initial_node() {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
     })
@@ -262,7 +273,7 @@ fn create_root_task_rejects_parented_initial_node() {
     )
     .expect("create existing");
 
-    let error = create_root_task(
+    let root = create_root_task(
         &db,
         CreateRootTaskInput {
             task_id: TaskId("root".to_owned()),
@@ -280,7 +291,10 @@ fn create_root_task_rejects_parented_initial_node() {
             now: UnixTs(11),
         },
     )
-    .expect_err("parented root rejected");
+    .expect("create root with strategy parent");
 
-    assert!(matches!(error, selvedge_db::DbError::Constraint(_)));
+    let conversation =
+        read_conversation_for_task(&db, &TaskId("root".to_owned())).expect("conversation");
+    assert_eq!(root.task_id, TaskId("root".to_owned()));
+    assert_eq!(conversation.items.len(), 2);
 }

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -77,3 +77,44 @@ fn archive_task_clears_queued_inputs_before_status_update() {
 
     archive_task(&db, &TaskId("task-1".to_owned()), UnixTs(12)).expect("archive task");
 }
+
+#[test]
+fn append_history_uses_new_node_timestamp_for_task_updated_at() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    let task = create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "hello".to_owned(),
+                }),
+                created_at: UnixTs(4_102_444_800),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("provider/model".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(4_102_444_800),
+        },
+    )
+    .expect("create root task");
+
+    selvedge_db::append_history_node_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        NewHistoryNode {
+            parent_node_id: Some(task.cursor_node_id),
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::User,
+                message_text: "future append".to_owned(),
+            }),
+            created_at: UnixTs(4_102_444_801),
+        },
+    )
+    .expect("append history");
+}

--- a/crates/db/tests/db_contract.rs
+++ b/crates/db/tests/db_contract.rs
@@ -1,7 +1,7 @@
 use selvedge_db::{
     CreateRootTaskInput, HistoryContentKindRow, MessageRole, NewHistoryNode, NewHistoryNodeContent,
     NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId, TaskStatusRow, UnixTs,
-    create_root_task, load_active_task, open_db,
+    archive_task, create_root_task, load_active_task, open_db, queue_user_input,
 };
 
 #[test]
@@ -40,4 +40,40 @@ fn open_db_creates_schema_and_root_task_transaction_moves_cursor() {
         loaded.cursor_node.content_kind,
         HistoryContentKindRow::Message
     );
+}
+
+#[test]
+fn archive_task_clears_queued_inputs_before_status_update() {
+    let db = open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("task-1".to_owned()),
+            initial_node: NewHistoryNode {
+                parent_node_id: None,
+                content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                    message_role: MessageRole::User,
+                    message_text: "hello".to_owned(),
+                }),
+                created_at: UnixTs(10),
+            },
+            model_profile_key: selvedge_db::ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(10),
+        },
+    )
+    .expect("create root task");
+    queue_user_input(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "queued".to_owned(),
+        UnixTs(11),
+    )
+    .expect("queue input");
+
+    archive_task(&db, &TaskId("task-1".to_owned()), UnixTs(12)).expect("archive task");
 }

--- a/crates/domain-model/src/lib.rs
+++ b/crates/domain-model/src/lib.rs
@@ -7,6 +7,27 @@ use serde::Serialize;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct HistoryNodeIdRef(pub String);
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+pub struct TaskId(pub String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]
+pub struct HistoryNodeId(pub i64);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+pub struct ToolName(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+pub struct ToolParameterName(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+pub struct FunctionCallId(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+pub struct ModelProfileKey(pub String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+pub struct UnixTs(pub i64);
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ConversationPath {
     pub messages: Vec<ConversationMessage>,
@@ -22,6 +43,7 @@ pub struct ConversationMessage {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum MessageRole {
     System,
+    Developer,
     User,
     Assistant,
     Tool,
@@ -60,6 +82,52 @@ pub enum ToolParameterType {
     Integer,
     Number,
     Boolean,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub enum ReasoningEffort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Conversation {
+    pub items: Vec<ConversationItem>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub enum ConversationItem {
+    Message {
+        role: MessageRole,
+        text: String,
+    },
+    FunctionCall {
+        function_call_id: FunctionCallId,
+        tool_name: ToolName,
+        arguments: Vec<ToolCallArgument>,
+    },
+    FunctionOutput {
+        function_call_id: FunctionCallId,
+        tool_name: ToolName,
+        output_text: String,
+        is_error: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ToolCallArgument {
+    pub name: ToolParameterName,
+    pub value: ToolArgumentValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub enum ToolArgumentValue {
+    String(String),
+    Integer(i64),
+    Number(f64),
+    Boolean(bool),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]


### PR DESCRIPTION
## What changed

- Added `selvedge-db` SQLite persistence for tasks, history, tools, queued input, cursor movement, archive, and task relationships.
- Added `selvedge-core` task runtime actor with Start cursor-tail classification, model/tool dispatch, queued input handling, stale result filtering, and restart recovery for open tool calls.
- Extended command/domain model contracts for router-mediated model calls, tool execution, events, and runtime readiness.
- Added focused contract tests and module README notes for the corrected runtime and DB transaction model.

## Why

The branch implements the router-mediated core/database slice while correcting the runtime state model: durable task progress is driven by the SQLite cursor, and runtime memory only keeps in-flight correlation ids plus pending tool-call identity.

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `just hooks`
- `codex-review-final main`
