### PR TITLE
feat(events): add router-mediated client event task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,logging/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -100,6 +100,9 @@ This file is for coding agents working in this repository.
 |crates/domain-model:{src/,tests/,Cargo.toml,README.md}
 |crates/domain-model/src:{lib.rs}
 |crates/domain-model/tests:{domain_contract.rs}
+|crates/events:{src/,tests/,Cargo.toml,README.md}
+|crates/events/src:{lib.rs}
+|crates/events/tests:{events_contract.rs}
 |crates/logging:{src/,Cargo.toml,README.md}
 |crates/logging/src:{lib.rs}
 |scripts:{bootstrap.sh,create-worktree.sh}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-events"
+version = "0.0.0"
+dependencies = [
+ "selvedge-command-model",
+ "selvedge-domain-model",
+ "tokio",
+]
+
+[[package]]
 name = "selvedge-logging"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/core",
     "crates/db",
     "crates/domain-model",
+    "crates/events",
     "crates/logging",
     "xtask",
 ]

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -1,9 +1,11 @@
 # command-model
 
-This crate defines the Selvedge command model API slice used to dispatch model calls and return completed API outputs to the router.
+This crate defines the Selvedge command model API slice used to dispatch model calls, return completed API outputs to the router, and describe router-mediated client event ingress.
 
-Use it to define model-call request correlation, dispatch request, output envelope, call error, and router ingress API message types.
+Use it to define model-call request correlation, dispatch request, output envelope, call error, router ingress API message types, event ingress messages, client subscriptions, client snapshots, raw events, and client outbound frames.
 
 This crate is not for network access, database access, filesystem access, provider execution, or task runtime mutation.
 
 `RuntimeReady` is only a readiness signal. The task runtime sender is returned by `selvedge-core::spawn_task_runtime` to the creator that owns router registration.
+
+`EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -131,12 +131,14 @@ pub struct DeliverNotice {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UpdateSubscription {
     pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
     pub subscription: ClientSubscription,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DetachClient {
     pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
     pub reason: DetachReason,
 }
 

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -1,12 +1,14 @@
 #![doc = include_str!("../README.md")]
 
+use std::collections::BTreeSet;
+
 use tokio::sync::{mpsc, oneshot};
 
 use selvedge_domain_model::{
-    ApiDomainValidationError, ConversationPath, FunctionCallId, HistoryNodeId,
-    ModelProviderProfile, ModelReply, ResponsePreference, ToolCallArgument, ToolManifest, ToolName,
-    validate_conversation_path, validate_model_provider_profile, validate_model_reply,
-    validate_tool_manifest,
+    ApiDomainValidationError, ConversationPath, FunctionCallId, HistoryNodeId, MessageRole,
+    ModelProfileKey, ModelProviderProfile, ModelReply, ReasoningEffort, ResponsePreference,
+    ToolCallArgument, ToolManifest, ToolName, UnixTs, validate_conversation_path,
+    validate_model_provider_profile, validate_model_reply, validate_tool_manifest,
 };
 
 pub use selvedge_domain_model::TaskId;
@@ -77,6 +79,308 @@ pub type RouterIngressApiMessage = RouterIngressMessage;
 pub type RouterIngressSender = mpsc::Sender<RouterIngressMessage>;
 pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
 pub type ModelCallRequest = ModelCallDispatchRequest;
+pub type EventIngressSender = mpsc::Sender<EventIngress>;
+pub type ClientFrameSender = mpsc::Sender<ClientFrame>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ClientId(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ClientCommandId(pub String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DeliverySeq(pub u64);
+
+#[derive(Debug)]
+pub enum EventIngress {
+    Control(EventControlMessage),
+    Raw(RawEvent),
+}
+
+#[derive(Debug)]
+pub enum EventControlMessage {
+    BeginClientHydration(BeginClientHydration),
+    DeliverSnapshot(DeliverSnapshot),
+    DeliverNotice(DeliverNotice),
+    UpdateSubscription(UpdateSubscription),
+    DetachClient(DetachClient),
+}
+
+#[derive(Debug)]
+pub struct BeginClientHydration {
+    pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
+    pub outbound: ClientFrameSender,
+    pub subscription: ClientSubscription,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeliverSnapshot {
+    pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
+    pub snapshot: ClientSnapshot,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeliverNotice {
+    pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
+    pub notice: ClientNotice,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpdateSubscription {
+    pub client_id: ClientId,
+    pub subscription: ClientSubscription,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DetachClient {
+    pub client_id: ClientId,
+    pub reason: DetachReason,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientSubscription {
+    pub task_scope: TaskScope,
+    pub detail_level: DetailLevel,
+    pub include_model_call_status: bool,
+    pub include_tool_execution_status: bool,
+    pub include_debug_notices: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TaskScope {
+    AllTasks,
+    TaskIds(BTreeSet<TaskId>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DetailLevel {
+    Summary,
+    Verbose,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RawEvent {
+    TaskChanged(TaskChangedRawEvent),
+    HistoryAppended(HistoryAppendedRawEvent),
+    ModelCallStatus(ModelCallStatusRawEvent),
+    ToolExecutionStatus(ToolExecutionStatusRawEvent),
+    Debug(DebugRawEvent),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TaskChangedRawEvent {
+    pub task: TaskProjection,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HistoryAppendedRawEvent {
+    pub task_id: TaskId,
+    pub task_state_version: u64,
+    pub appended_nodes: Vec<HistoryNodeProjection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelCallStatusRawEvent {
+    pub task_id: TaskId,
+    pub model_call_id: ModelCallId,
+    pub phase: ModelCallStatusPhase,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolExecutionStatusRawEvent {
+    pub task_id: TaskId,
+    pub tool_execution_run_id: ToolExecutionRunId,
+    pub function_call_node_id: HistoryNodeId,
+    pub tool_name: ToolName,
+    pub phase: ToolExecutionStatusPhase,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebugRawEvent {
+    pub task_id: Option<TaskId>,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ClientSnapshot {
+    pub generated_at: UnixTs,
+    pub tasks: Vec<TaskProjection>,
+    pub task_parent_edges: Vec<TaskParentProjection>,
+    pub history_nodes: Vec<HistoryNodeProjection>,
+    pub task_versions: Vec<SnapshotTaskVersion>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotTaskVersion {
+    pub task_id: TaskId,
+    pub state_version: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskProjection {
+    pub task_id: TaskId,
+    pub status: TaskProjectionStatus,
+    pub cursor_node_id: HistoryNodeId,
+    pub model_profile_key: ModelProfileKey,
+    pub reasoning_effort: ReasoningEffort,
+    pub state_version: u64,
+    pub created_at: UnixTs,
+    pub updated_at: UnixTs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TaskProjectionStatus {
+    Active,
+    Archived,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskParentProjection {
+    pub parent_task_id: TaskId,
+    pub child_task_id: TaskId,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HistoryNodeProjection {
+    pub node_id: HistoryNodeId,
+    pub parent_node_id: Option<HistoryNodeId>,
+    pub created_at: UnixTs,
+    pub body: HistoryNodeProjectionBody,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum HistoryNodeProjectionBody {
+    Message {
+        role: MessageRole,
+        text: String,
+    },
+    Reasoning {
+        text: String,
+    },
+    FunctionCall {
+        function_call_id: FunctionCallId,
+        tool_name: ToolName,
+        arguments: Vec<ToolCallArgument>,
+    },
+    FunctionOutput {
+        function_call_node_id: HistoryNodeId,
+        function_call_id: FunctionCallId,
+        tool_name: ToolName,
+        output_text: String,
+        is_error: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ClientFrame {
+    Snapshot(ClientSnapshotFrame),
+    Event(ClientEventFrame),
+    Notice(ClientNoticeFrame),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ClientSnapshotFrame {
+    pub delivery_seq: DeliverySeq,
+    pub client_command_id: ClientCommandId,
+    pub snapshot: ClientSnapshot,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ClientEventFrame {
+    pub delivery_seq: DeliverySeq,
+    pub event: ClientEvent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientNoticeFrame {
+    pub delivery_seq: DeliverySeq,
+    pub client_command_id: ClientCommandId,
+    pub notice: ClientNotice,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ClientEvent {
+    TaskChanged(TaskChangedEvent),
+    HistoryAppended(HistoryAppendedEvent),
+    ModelCallStatus(ModelCallStatusEvent),
+    ToolExecutionStatus(ToolExecutionStatusEvent),
+    DebugNotice(DebugNoticeEvent),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TaskChangedEvent {
+    pub task: TaskProjection,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HistoryAppendedEvent {
+    pub task_id: TaskId,
+    pub task_state_version: u64,
+    pub appended_nodes: Vec<HistoryNodeProjection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelCallStatusEvent {
+    pub task_id: TaskId,
+    pub model_call_id: ModelCallId,
+    pub phase: ModelCallStatusPhase,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolExecutionStatusEvent {
+    pub task_id: TaskId,
+    pub tool_execution_run_id: ToolExecutionRunId,
+    pub function_call_node_id: HistoryNodeId,
+    pub tool_name: ToolName,
+    pub phase: ToolExecutionStatusPhase,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebugNoticeEvent {
+    pub task_id: Option<TaskId>,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientNotice {
+    pub level: ClientNoticeLevel,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClientNoticeLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelCallStatusPhase {
+    Requested,
+    Completed,
+    Failed,
+    Discarded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ToolExecutionStatusPhase {
+    Requested,
+    Completed,
+    Failed,
+    Discarded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DetachReason {
+    ClientRequested,
+    ReplacedByNewHydration,
+    DeliveryFailed,
+    HydrationBufferOverflow,
+    EventsShutdown,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ToolExecutionRunId(pub String);

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -1,11 +1,16 @@
 use selvedge_command_model::{
-    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ModelCallDispatchRequest, ModelCallError,
-    ModelCallErrorKind, ModelRunId, RouterIngressApiMessage, TaskId, validate_api_output_envelope,
+    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommandId,
+    ClientEvent, ClientEventFrame, ClientFrame, ClientId, ClientSnapshot, ClientSnapshotFrame,
+    ClientSubscription, DeliverySeq, DetailLevel, EventControlMessage, EventIngress,
+    HistoryAppendedEvent, HistoryAppendedRawEvent, ModelCallDispatchRequest, ModelCallError,
+    ModelCallErrorKind, ModelRunId, RouterIngressApiMessage, SnapshotTaskVersion, TaskId,
+    TaskProjection, TaskProjectionStatus, TaskScope, validate_api_output_envelope,
     validate_dispatch_request,
 };
 use selvedge_domain_model::{
-    ConversationMessage, ConversationPath, MessageContent, MessageRole, ModelFinishReason,
-    ModelProviderProfile, ModelReply, ResponsePreference,
+    ConversationMessage, ConversationPath, HistoryNodeId, MessageContent, MessageRole,
+    ModelFinishReason, ModelProfileKey, ModelProviderProfile, ModelReply, ReasoningEffort,
+    ResponsePreference, UnixTs,
 };
 
 #[test]
@@ -83,6 +88,82 @@ fn router_ingress_api_message_wraps_output_envelope() {
     }
 }
 
+#[test]
+fn event_ingress_and_client_frames_expose_router_events_contract() {
+    let (outbound, _rx) = tokio::sync::mpsc::channel(4);
+    let task = task_projection("task-1", 7);
+
+    let ingress = EventIngress::Control(EventControlMessage::BeginClientHydration(
+        BeginClientHydration {
+            client_id: ClientId("client-1".to_owned()),
+            client_command_id: ClientCommandId("attach-1".to_owned()),
+            outbound,
+            subscription: ClientSubscription {
+                task_scope: TaskScope::AllTasks,
+                detail_level: DetailLevel::Verbose,
+                include_model_call_status: true,
+                include_tool_execution_status: true,
+                include_debug_notices: true,
+            },
+        },
+    ));
+
+    match ingress {
+        EventIngress::Control(EventControlMessage::BeginClientHydration(begin)) => {
+            assert_eq!(begin.client_id, ClientId("client-1".to_owned()));
+            assert_eq!(
+                begin.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+            assert_eq!(begin.subscription.detail_level, DetailLevel::Verbose);
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    let raw = EventIngress::Raw(selvedge_command_model::RawEvent::HistoryAppended(
+        HistoryAppendedRawEvent {
+            task_id: TaskId("task-1".to_owned()),
+            task_state_version: 8,
+            appended_nodes: Vec::new(),
+        },
+    ));
+
+    match raw {
+        EventIngress::Raw(selvedge_command_model::RawEvent::HistoryAppended(event)) => {
+            assert_eq!(event.task_id, TaskId("task-1".to_owned()));
+            assert_eq!(event.task_state_version, 8);
+        }
+        _ => panic!("unexpected raw event"),
+    }
+
+    let snapshot_frame = ClientFrame::Snapshot(ClientSnapshotFrame {
+        delivery_seq: DeliverySeq(1),
+        client_command_id: ClientCommandId("attach-1".to_owned()),
+        snapshot: ClientSnapshot {
+            generated_at: UnixTs(100),
+            tasks: vec![task.clone()],
+            task_parent_edges: Vec::new(),
+            history_nodes: Vec::new(),
+            task_versions: vec![SnapshotTaskVersion {
+                task_id: task.task_id.clone(),
+                state_version: task.state_version,
+            }],
+        },
+    });
+
+    let event_frame = ClientFrame::Event(ClientEventFrame {
+        delivery_seq: DeliverySeq(2),
+        event: ClientEvent::HistoryAppended(HistoryAppendedEvent {
+            task_id: TaskId("task-1".to_owned()),
+            task_state_version: 8,
+            appended_nodes: Vec::new(),
+        }),
+    });
+
+    assert!(matches!(snapshot_frame, ClientFrame::Snapshot(_)));
+    assert!(matches!(event_frame, ClientFrame::Event(_)));
+}
+
 fn valid_dispatch_request() -> ModelCallDispatchRequest {
     ModelCallDispatchRequest {
         correlation: valid_correlation(),
@@ -109,5 +190,18 @@ fn valid_correlation() -> ApiCallCorrelation {
         api_effect_id: ApiEffectId("api-1".to_owned()),
         task_id: TaskId("task-1".to_owned()),
         model_run_id: ModelRunId("run-1".to_owned()),
+    }
+}
+
+fn task_projection(task_id: &str, state_version: u64) -> TaskProjection {
+    TaskProjection {
+        task_id: TaskId(task_id.to_owned()),
+        status: TaskProjectionStatus::Active,
+        cursor_node_id: HistoryNodeId(1),
+        model_profile_key: ModelProfileKey("default".to_owned()),
+        reasoning_effort: ReasoningEffort::Medium,
+        state_version,
+        created_at: UnixTs(10),
+        updated_at: UnixTs(20),
     }
 }

--- a/crates/domain-model/src/lib.rs
+++ b/crates/domain-model/src/lib.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct HistoryNodeIdRef(pub String);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct TaskId(pub String);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "selvedge-events"
+edition = "2024"
+publish = false
+
+[dependencies]
+selvedge-command-model = { path = "../command-model" }
+tokio = { version = "1.42.0", features = ["rt", "sync"] }
+
+[dev-dependencies]
+selvedge-domain-model = { path = "../domain-model" }
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/events/README.md
+++ b/crates/events/README.md
@@ -1,0 +1,7 @@
+# events
+
+This crate runs the client outbound event aggregator task.
+
+Use it from the router to register client outbound channels, deliver attach snapshots, update subscriptions, detach clients, and fan out raw command-model events as client frames.
+
+This crate only receives router-mediated ingress and only sends `ClientFrame` values through router-provided client channels. It does not access the database, filesystem, network, API providers, tools, or task runtimes.

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -84,9 +84,7 @@ impl EventsTask {
             EventControlMessage::DeliverSnapshot(snapshot) => self.deliver_snapshot(snapshot).await,
             EventControlMessage::DeliverNotice(notice) => self.deliver_notice(notice).await,
             EventControlMessage::UpdateSubscription(update) => self.update_subscription(update),
-            EventControlMessage::DetachClient(detach) => {
-                self.sessions.remove(&detach.client_id);
-            }
+            EventControlMessage::DetachClient(detach) => self.detach_client(detach),
         }
     }
 
@@ -178,12 +176,28 @@ impl EventsTask {
             return;
         };
 
+        if session.client_command_id != update.client_command_id {
+            return;
+        }
+
         session.subscription = update.subscription;
 
         if let ClientSessionState::Hydrating { buffer, .. } = &mut session.state {
             buffer
                 .retain(|raw| client_event_for_subscription(raw, &session.subscription).is_some());
         }
+    }
+
+    fn detach_client(&mut self, detach: selvedge_command_model::DetachClient) {
+        let Some(session) = self.sessions.get(&detach.client_id) else {
+            return;
+        };
+
+        if session.client_command_id != detach.client_command_id {
+            return;
+        }
+
+        self.sessions.remove(&detach.client_id);
     }
 
     async fn handle_raw(&mut self, raw: RawEvent) {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -158,9 +158,13 @@ impl EventsTask {
             return;
         };
 
+        if session.client_command_id != notice.client_command_id {
+            return;
+        }
+
         let frame = ClientFrame::Notice(ClientNoticeFrame {
             delivery_seq: session.next_delivery_seq(),
-            client_command_id: notice.client_command_id,
+            client_command_id: session.client_command_id.clone(),
             notice: notice.notice,
         });
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -8,7 +8,7 @@ use selvedge_command_model::{
     DeliverSnapshot, DetailLevel, EventControlMessage, EventIngress, EventIngressSender, RawEvent,
     TaskId, TaskScope, UpdateSubscription,
 };
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, error::TrySendError};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EventsStartArgs {
@@ -97,7 +97,10 @@ impl EventsTask {
                 outbound: begin.outbound,
                 subscription: begin.subscription,
                 delivery_seq: 1,
-                state: ClientSessionState::Hydrating { buffer: Vec::new() },
+                state: ClientSessionState::Hydrating {
+                    client_command_id: begin.client_command_id,
+                    buffer: Vec::new(),
+                },
             },
         );
     }
@@ -107,6 +110,14 @@ impl EventsTask {
             return;
         };
 
+        if let ClientSessionState::Hydrating {
+            client_command_id, ..
+        } = &session.state
+            && client_command_id != &snapshot.client_command_id
+        {
+            return;
+        }
+
         let snapshot_versions = snapshot_versions(&snapshot.snapshot);
         let frame = ClientFrame::Snapshot(ClientSnapshotFrame {
             delivery_seq: session.next_delivery_seq(),
@@ -114,13 +125,13 @@ impl EventsTask {
             snapshot: snapshot.snapshot,
         });
 
-        if session.outbound.send(frame).await.is_err() {
+        if session.send_frame(frame).is_err() {
             self.sessions.remove(&snapshot.client_id);
             return;
         }
 
         match &mut session.state {
-            ClientSessionState::Hydrating { buffer } => {
+            ClientSessionState::Hydrating { buffer, .. } => {
                 let buffered = std::mem::take(buffer);
                 session.state = ClientSessionState::Live;
 
@@ -138,7 +149,7 @@ impl EventsTask {
                         event,
                     });
 
-                    if session.outbound.send(frame).await.is_err() {
+                    if session.send_frame(frame).is_err() {
                         self.sessions.remove(&snapshot.client_id);
                         return;
                     }
@@ -159,7 +170,7 @@ impl EventsTask {
             notice: notice.notice,
         });
 
-        if session.outbound.send(frame).await.is_err() {
+        if session.send_frame(frame).is_err() {
             self.sessions.remove(&notice.client_id);
         }
     }
@@ -171,7 +182,7 @@ impl EventsTask {
 
         session.subscription = update.subscription;
 
-        if let ClientSessionState::Hydrating { buffer } = &mut session.state {
+        if let ClientSessionState::Hydrating { buffer, .. } = &mut session.state {
             buffer
                 .retain(|raw| client_event_for_subscription(raw, &session.subscription).is_some());
         }
@@ -191,7 +202,7 @@ impl EventsTask {
                 };
 
                 match &mut session.state {
-                    ClientSessionState::Hydrating { buffer } => {
+                    ClientSessionState::Hydrating { buffer, .. } => {
                         if client_event_for_subscription(&raw, &session.subscription).is_some() {
                             if buffer.len() >= self.hydration_buffer_capacity {
                                 true
@@ -211,7 +222,7 @@ impl EventsTask {
                                 delivery_seq: session.next_delivery_seq(),
                                 event,
                             });
-                            session.outbound.send(frame).await.is_err()
+                            session.send_frame(frame).is_err()
                         } else {
                             false
                         }
@@ -239,10 +250,20 @@ impl ClientSession {
         self.delivery_seq += 1;
         delivery_seq
     }
+
+    fn send_frame(&self, frame: ClientFrame) -> Result<(), ()> {
+        match self.outbound.try_send(frame) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) | Err(TrySendError::Closed(_)) => Err(()),
+        }
+    }
 }
 
 enum ClientSessionState {
-    Hydrating { buffer: Vec<RawEvent> },
+    Hydrating {
+        client_command_id: selvedge_command_model::ClientCommandId,
+        buffer: Vec<RawEvent>,
+    },
     Live,
 }
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -96,11 +96,9 @@ impl EventsTask {
             ClientSession {
                 outbound: begin.outbound,
                 subscription: begin.subscription,
+                client_command_id: begin.client_command_id,
                 delivery_seq: 1,
-                state: ClientSessionState::Hydrating {
-                    client_command_id: begin.client_command_id,
-                    buffer: Vec::new(),
-                },
+                state: ClientSessionState::Hydrating { buffer: Vec::new() },
             },
         );
     }
@@ -110,18 +108,14 @@ impl EventsTask {
             return;
         };
 
-        if let ClientSessionState::Hydrating {
-            client_command_id, ..
-        } = &session.state
-            && client_command_id != &snapshot.client_command_id
-        {
+        if session.client_command_id != snapshot.client_command_id {
             return;
         }
 
         let snapshot_versions = snapshot_versions(&snapshot.snapshot);
         let frame = ClientFrame::Snapshot(ClientSnapshotFrame {
             delivery_seq: session.next_delivery_seq(),
-            client_command_id: snapshot.client_command_id,
+            client_command_id: session.client_command_id.clone(),
             snapshot: snapshot.snapshot,
         });
 
@@ -240,6 +234,7 @@ impl EventsTask {
 struct ClientSession {
     outbound: ClientFrameSender,
     subscription: ClientSubscription,
+    client_command_id: selvedge_command_model::ClientCommandId,
     delivery_seq: u64,
     state: ClientSessionState,
 }
@@ -260,10 +255,7 @@ impl ClientSession {
 }
 
 enum ClientSessionState {
-    Hydrating {
-        client_command_id: selvedge_command_model::ClientCommandId,
-        buffer: Vec<RawEvent>,
-    },
+    Hydrating { buffer: Vec<RawEvent> },
     Live,
 }
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -60,6 +60,7 @@ pub fn spawn_events_task(args: EventsStartArgs) -> Result<EventsHandle, SpawnEve
 
 struct EventsTask {
     sessions: HashMap<ClientId, ClientSession>,
+    client_registry_capacity: usize,
     hydration_buffer_capacity: usize,
 }
 
@@ -67,6 +68,7 @@ impl EventsTask {
     fn new(args: EventsStartArgs) -> Self {
         Self {
             sessions: HashMap::with_capacity(args.client_registry_capacity),
+            client_registry_capacity: args.client_registry_capacity,
             hydration_buffer_capacity: args.hydration_buffer_capacity,
         }
     }
@@ -89,6 +91,12 @@ impl EventsTask {
     }
 
     fn begin_hydration(&mut self, begin: BeginClientHydration) {
+        if !self.sessions.contains_key(&begin.client_id)
+            && self.sessions.len() >= self.client_registry_capacity
+        {
+            return;
+        }
+
         self.sessions.insert(
             begin.client_id,
             ClientSession {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,0 +1,366 @@
+#![doc = include_str!("../README.md")]
+
+use std::collections::{BTreeMap, HashMap};
+
+use selvedge_command_model::{
+    BeginClientHydration, ClientEvent, ClientEventFrame, ClientFrame, ClientFrameSender, ClientId,
+    ClientNoticeFrame, ClientSnapshot, ClientSnapshotFrame, ClientSubscription, DeliverNotice,
+    DeliverSnapshot, DetailLevel, EventControlMessage, EventIngress, EventIngressSender, RawEvent,
+    TaskId, TaskScope, UpdateSubscription,
+};
+use tokio::sync::mpsc;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EventsStartArgs {
+    pub ingress_capacity: usize,
+    pub client_registry_capacity: usize,
+    pub hydration_buffer_capacity: usize,
+}
+
+#[derive(Debug)]
+pub struct EventsHandle {
+    pub ingress_tx: EventIngressSender,
+    pub join_handle: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpawnEventsError {
+    InvalidIngressCapacity,
+    InvalidClientRegistryCapacity,
+    InvalidHydrationBufferCapacity,
+}
+
+pub fn spawn_events_task(args: EventsStartArgs) -> Result<EventsHandle, SpawnEventsError> {
+    if args.ingress_capacity == 0 {
+        return Err(SpawnEventsError::InvalidIngressCapacity);
+    }
+
+    if args.client_registry_capacity == 0 {
+        return Err(SpawnEventsError::InvalidClientRegistryCapacity);
+    }
+
+    if args.hydration_buffer_capacity == 0 {
+        return Err(SpawnEventsError::InvalidHydrationBufferCapacity);
+    }
+
+    let (ingress_tx, mut ingress_rx) = mpsc::channel(args.ingress_capacity);
+    let join_handle = tokio::spawn(async move {
+        let mut task = EventsTask::new(args);
+
+        while let Some(ingress) = ingress_rx.recv().await {
+            task.handle_ingress(ingress).await;
+        }
+    });
+
+    Ok(EventsHandle {
+        ingress_tx,
+        join_handle,
+    })
+}
+
+struct EventsTask {
+    sessions: HashMap<ClientId, ClientSession>,
+    hydration_buffer_capacity: usize,
+}
+
+impl EventsTask {
+    fn new(args: EventsStartArgs) -> Self {
+        Self {
+            sessions: HashMap::with_capacity(args.client_registry_capacity),
+            hydration_buffer_capacity: args.hydration_buffer_capacity,
+        }
+    }
+
+    async fn handle_ingress(&mut self, ingress: EventIngress) {
+        match ingress {
+            EventIngress::Control(control) => self.handle_control(control).await,
+            EventIngress::Raw(raw) => self.handle_raw(raw).await,
+        }
+    }
+
+    async fn handle_control(&mut self, control: EventControlMessage) {
+        match control {
+            EventControlMessage::BeginClientHydration(begin) => self.begin_hydration(begin),
+            EventControlMessage::DeliverSnapshot(snapshot) => self.deliver_snapshot(snapshot).await,
+            EventControlMessage::DeliverNotice(notice) => self.deliver_notice(notice).await,
+            EventControlMessage::UpdateSubscription(update) => self.update_subscription(update),
+            EventControlMessage::DetachClient(detach) => {
+                self.sessions.remove(&detach.client_id);
+            }
+        }
+    }
+
+    fn begin_hydration(&mut self, begin: BeginClientHydration) {
+        self.sessions.insert(
+            begin.client_id,
+            ClientSession {
+                outbound: begin.outbound,
+                subscription: begin.subscription,
+                delivery_seq: 1,
+                state: ClientSessionState::Hydrating { buffer: Vec::new() },
+            },
+        );
+    }
+
+    async fn deliver_snapshot(&mut self, snapshot: DeliverSnapshot) {
+        let Some(session) = self.sessions.get_mut(&snapshot.client_id) else {
+            return;
+        };
+
+        let snapshot_versions = snapshot_versions(&snapshot.snapshot);
+        let frame = ClientFrame::Snapshot(ClientSnapshotFrame {
+            delivery_seq: session.next_delivery_seq(),
+            client_command_id: snapshot.client_command_id,
+            snapshot: snapshot.snapshot,
+        });
+
+        if session.outbound.send(frame).await.is_err() {
+            self.sessions.remove(&snapshot.client_id);
+            return;
+        }
+
+        match &mut session.state {
+            ClientSessionState::Hydrating { buffer } => {
+                let buffered = std::mem::take(buffer);
+                session.state = ClientSessionState::Live;
+
+                for raw in buffered
+                    .into_iter()
+                    .filter(|raw| raw_survives_snapshot(raw, &snapshot_versions))
+                {
+                    let Some(event) = client_event_for_subscription(&raw, &session.subscription)
+                    else {
+                        continue;
+                    };
+
+                    let frame = ClientFrame::Event(ClientEventFrame {
+                        delivery_seq: session.next_delivery_seq(),
+                        event,
+                    });
+
+                    if session.outbound.send(frame).await.is_err() {
+                        self.sessions.remove(&snapshot.client_id);
+                        return;
+                    }
+                }
+            }
+            ClientSessionState::Live => {}
+        }
+    }
+
+    async fn deliver_notice(&mut self, notice: DeliverNotice) {
+        let Some(session) = self.sessions.get_mut(&notice.client_id) else {
+            return;
+        };
+
+        let frame = ClientFrame::Notice(ClientNoticeFrame {
+            delivery_seq: session.next_delivery_seq(),
+            client_command_id: notice.client_command_id,
+            notice: notice.notice,
+        });
+
+        if session.outbound.send(frame).await.is_err() {
+            self.sessions.remove(&notice.client_id);
+        }
+    }
+
+    fn update_subscription(&mut self, update: UpdateSubscription) {
+        let Some(session) = self.sessions.get_mut(&update.client_id) else {
+            return;
+        };
+
+        session.subscription = update.subscription;
+
+        if let ClientSessionState::Hydrating { buffer } = &mut session.state {
+            buffer
+                .retain(|raw| client_event_for_subscription(raw, &session.subscription).is_some());
+        }
+    }
+
+    async fn handle_raw(&mut self, raw: RawEvent) {
+        let client_ids = self.sessions.keys().cloned().collect::<Vec<_>>();
+
+        for client_id in client_ids {
+            if !self.sessions.contains_key(&client_id) {
+                continue;
+            }
+
+            let should_remove = {
+                let Some(session) = self.sessions.get_mut(&client_id) else {
+                    continue;
+                };
+
+                match &mut session.state {
+                    ClientSessionState::Hydrating { buffer } => {
+                        if client_event_for_subscription(&raw, &session.subscription).is_some() {
+                            if buffer.len() >= self.hydration_buffer_capacity {
+                                true
+                            } else {
+                                buffer.push(raw.clone());
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    }
+                    ClientSessionState::Live => {
+                        if let Some(event) =
+                            client_event_for_subscription(&raw, &session.subscription)
+                        {
+                            let frame = ClientFrame::Event(ClientEventFrame {
+                                delivery_seq: session.next_delivery_seq(),
+                                event,
+                            });
+                            session.outbound.send(frame).await.is_err()
+                        } else {
+                            false
+                        }
+                    }
+                }
+            };
+
+            if should_remove {
+                self.sessions.remove(&client_id);
+            }
+        }
+    }
+}
+
+struct ClientSession {
+    outbound: ClientFrameSender,
+    subscription: ClientSubscription,
+    delivery_seq: u64,
+    state: ClientSessionState,
+}
+
+impl ClientSession {
+    fn next_delivery_seq(&mut self) -> selvedge_command_model::DeliverySeq {
+        let delivery_seq = selvedge_command_model::DeliverySeq(self.delivery_seq);
+        self.delivery_seq += 1;
+        delivery_seq
+    }
+}
+
+enum ClientSessionState {
+    Hydrating { buffer: Vec<RawEvent> },
+    Live,
+}
+
+fn client_event_for_subscription(
+    raw: &RawEvent,
+    subscription: &ClientSubscription,
+) -> Option<ClientEvent> {
+    if !task_scope_matches(raw_task_id(raw), &subscription.task_scope) {
+        return None;
+    }
+
+    match raw {
+        RawEvent::TaskChanged(event) => Some(ClientEvent::TaskChanged(
+            selvedge_command_model::TaskChangedEvent {
+                task: event.task.clone(),
+            },
+        )),
+        RawEvent::HistoryAppended(event) => {
+            if subscription.detail_level == DetailLevel::Verbose {
+                Some(ClientEvent::HistoryAppended(
+                    selvedge_command_model::HistoryAppendedEvent {
+                        task_id: event.task_id.clone(),
+                        task_state_version: event.task_state_version,
+                        appended_nodes: event.appended_nodes.clone(),
+                    },
+                ))
+            } else {
+                None
+            }
+        }
+        RawEvent::ModelCallStatus(event) => {
+            if subscription.detail_level == DetailLevel::Verbose
+                && subscription.include_model_call_status
+            {
+                Some(ClientEvent::ModelCallStatus(
+                    selvedge_command_model::ModelCallStatusEvent {
+                        task_id: event.task_id.clone(),
+                        model_call_id: event.model_call_id.clone(),
+                        phase: event.phase.clone(),
+                    },
+                ))
+            } else {
+                None
+            }
+        }
+        RawEvent::ToolExecutionStatus(event) => {
+            if subscription.detail_level == DetailLevel::Verbose
+                && subscription.include_tool_execution_status
+            {
+                Some(ClientEvent::ToolExecutionStatus(
+                    selvedge_command_model::ToolExecutionStatusEvent {
+                        task_id: event.task_id.clone(),
+                        tool_execution_run_id: event.tool_execution_run_id.clone(),
+                        function_call_node_id: event.function_call_node_id,
+                        tool_name: event.tool_name.clone(),
+                        phase: event.phase.clone(),
+                    },
+                ))
+            } else {
+                None
+            }
+        }
+        RawEvent::Debug(event) => {
+            if subscription.include_debug_notices {
+                Some(ClientEvent::DebugNotice(
+                    selvedge_command_model::DebugNoticeEvent {
+                        task_id: event.task_id.clone(),
+                        message_text: event.message_text.clone(),
+                    },
+                ))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn raw_task_id(raw: &RawEvent) -> Option<&TaskId> {
+    match raw {
+        RawEvent::TaskChanged(event) => Some(&event.task.task_id),
+        RawEvent::HistoryAppended(event) => Some(&event.task_id),
+        RawEvent::ModelCallStatus(event) => Some(&event.task_id),
+        RawEvent::ToolExecutionStatus(event) => Some(&event.task_id),
+        RawEvent::Debug(event) => event.task_id.as_ref(),
+    }
+}
+
+fn task_scope_matches(task_id: Option<&TaskId>, task_scope: &TaskScope) -> bool {
+    match task_scope {
+        TaskScope::AllTasks => true,
+        TaskScope::TaskIds(task_ids) => task_id.is_some_and(|task_id| task_ids.contains(task_id)),
+    }
+}
+
+fn snapshot_versions(snapshot: &ClientSnapshot) -> BTreeMap<TaskId, u64> {
+    snapshot
+        .task_versions
+        .iter()
+        .map(|version| (version.task_id.clone(), version.state_version))
+        .collect()
+}
+
+fn raw_survives_snapshot(raw: &RawEvent, snapshot_versions: &BTreeMap<TaskId, u64>) -> bool {
+    let Some((task_id, state_version)) = raw_state_version(raw) else {
+        return true;
+    };
+
+    snapshot_versions
+        .get(task_id)
+        .is_none_or(|snapshot_version| state_version > *snapshot_version)
+}
+
+fn raw_state_version(raw: &RawEvent) -> Option<(&TaskId, u64)> {
+    match raw {
+        RawEvent::TaskChanged(event) => Some((&event.task.task_id, event.task.state_version)),
+        RawEvent::HistoryAppended(event) => Some((&event.task_id, event.task_state_version)),
+        RawEvent::ModelCallStatus(_) | RawEvent::ToolExecutionStatus(_) | RawEvent::Debug(_) => {
+            None
+        }
+    }
+}

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -543,6 +543,23 @@ async fn stale_hydration_snapshot_is_ignored_after_replacement_begin() {
         _ => panic!("expected buffered event"),
     }
 
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
+            DeliverSnapshot {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                snapshot: empty_snapshot(),
+            },
+        )))
+        .await
+        .expect("send late stale snapshot");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), second_rx.recv())
+            .await
+            .is_err()
+    );
+
     drop(handle.ingress_tx);
     handle.join_handle.await.expect("events task exits cleanly");
 }

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -3,9 +3,9 @@ use std::{collections::BTreeSet, time::Duration};
 use selvedge_command_model::{
     BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
     ClientNoticeLevel, ClientSnapshot, ClientSubscription, DebugRawEvent, DeliverNotice,
-    DeliverSnapshot, DetailLevel, EventControlMessage, EventIngress, HistoryAppendedRawEvent,
-    RawEvent, SnapshotTaskVersion, TaskChangedRawEvent, TaskProjection, TaskProjectionStatus,
-    TaskScope, UpdateSubscription,
+    DeliverSnapshot, DetachClient, DetachReason, DetailLevel, EventControlMessage, EventIngress,
+    HistoryAppendedRawEvent, RawEvent, SnapshotTaskVersion, TaskChangedRawEvent, TaskProjection,
+    TaskProjectionStatus, TaskScope, UpdateSubscription,
 };
 use selvedge_domain_model::{HistoryNodeId, ModelProfileKey, ReasoningEffort, TaskId, UnixTs};
 use selvedge_events::{EventsStartArgs, SpawnEventsError, spawn_events_task};
@@ -277,6 +277,7 @@ async fn hydrating_subscription_update_rescreens_buffer_before_snapshot_flush() 
         .send(EventIngress::Control(
             EventControlMessage::UpdateSubscription(UpdateSubscription {
                 client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
                 subscription: summary_task_subscription("task-2"),
             }),
         ))
@@ -579,6 +580,97 @@ async fn stale_hydration_snapshot_is_ignored_after_replacement_begin() {
             .await
             .is_err()
     );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn stale_session_controls_do_not_mutate_replacement_client() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 16,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (first_outbound, mut first_rx) = mpsc::channel(8);
+    let (second_outbound, mut second_rx) = mpsc::channel(8);
+
+    begin_client_with_command(
+        &handle.ingress_tx,
+        first_outbound,
+        ClientCommandId("attach-1".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+    begin_client_with_command(
+        &handle.ingress_tx,
+        second_outbound,
+        ClientCommandId("attach-2".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(
+            EventControlMessage::UpdateSubscription(UpdateSubscription {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                subscription: summary_task_subscription("task-2"),
+            }),
+        ))
+        .await
+        .expect("send stale subscription update");
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DetachClient(
+            DetachClient {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                reason: DetachReason::ClientRequested,
+            },
+        )))
+        .await
+        .expect("send stale detach");
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), first_rx.recv())
+            .await
+            .expect("first channel closes when replaced")
+            .is_none()
+    );
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
+            DeliverSnapshot {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-2".to_owned()),
+                snapshot: empty_snapshot(),
+            },
+        )))
+        .await
+        .expect("send active snapshot");
+    assert!(matches!(
+        recv_frame(&mut second_rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::TaskChanged(
+            TaskChangedRawEvent {
+                task: task_projection("task-1", 1),
+            },
+        )))
+        .await
+        .expect("send raw event");
+    let event = recv_frame(&mut second_rx).await;
+    match event {
+        ClientFrame::Event(frame) => assert!(matches!(frame.event, ClientEvent::TaskChanged(_))),
+        _ => panic!("expected task event"),
+    }
 
     drop(handle.ingress_tx);
     handle.join_handle.await.expect("events task exits cleanly");

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -387,6 +387,166 @@ async fn notice_during_hydration_uses_current_delivery_sequence() {
     handle.join_handle.await.expect("events task exits cleanly");
 }
 
+#[tokio::test]
+async fn full_client_channel_is_removed_without_blocking_other_clients() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 16,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (slow_outbound, mut slow_rx) = mpsc::channel(1);
+    let (fast_outbound, mut fast_rx) = mpsc::channel(8);
+
+    begin_named_client(
+        &handle.ingress_tx,
+        ClientId("slow".to_owned()),
+        slow_outbound,
+        verbose_all_tasks(),
+    )
+    .await;
+    begin_named_client(
+        &handle.ingress_tx,
+        ClientId("fast".to_owned()),
+        fast_outbound,
+        verbose_all_tasks(),
+    )
+    .await;
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("slow".to_owned())).await;
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("fast".to_owned())).await;
+
+    assert!(matches!(
+        recv_frame(&mut fast_rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::TaskChanged(
+            TaskChangedRawEvent {
+                task: task_projection("task-1", 1),
+            },
+        )))
+        .await
+        .expect("send raw event");
+
+    let fast_event = recv_frame(&mut fast_rx).await;
+    match fast_event {
+        ClientFrame::Event(frame) => {
+            assert_eq!(frame.delivery_seq.0, 2);
+            assert!(matches!(frame.event, ClientEvent::TaskChanged(_)));
+        }
+        _ => panic!("expected fast client event"),
+    }
+
+    let slow_snapshot = recv_frame(&mut slow_rx).await;
+    assert!(matches!(slow_snapshot, ClientFrame::Snapshot(_)));
+    let slow_closed = tokio::time::timeout(Duration::from_secs(1), slow_rx.recv())
+        .await
+        .expect("slow channel closes after full delivery attempt");
+    assert!(slow_closed.is_none());
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn stale_hydration_snapshot_is_ignored_after_replacement_begin() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (first_outbound, mut first_rx) = mpsc::channel(8);
+    let (second_outbound, mut second_rx) = mpsc::channel(8);
+
+    begin_client_with_command(
+        &handle.ingress_tx,
+        first_outbound,
+        ClientCommandId("attach-1".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+    begin_client_with_command(
+        &handle.ingress_tx,
+        second_outbound,
+        ClientCommandId("attach-2".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
+            DeliverSnapshot {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                snapshot: empty_snapshot(),
+            },
+        )))
+        .await
+        .expect("send stale snapshot");
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::TaskChanged(
+            TaskChangedRawEvent {
+                task: task_projection("task-1", 1),
+            },
+        )))
+        .await
+        .expect("send raw event");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), second_rx.recv())
+            .await
+            .is_err()
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), first_rx.recv())
+            .await
+            .expect("first channel closes when replaced")
+            .is_none()
+    );
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
+            DeliverSnapshot {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-2".to_owned()),
+                snapshot: empty_snapshot(),
+            },
+        )))
+        .await
+        .expect("send active snapshot");
+
+    let snapshot = recv_frame(&mut second_rx).await;
+    match snapshot {
+        ClientFrame::Snapshot(frame) => {
+            assert_eq!(frame.delivery_seq.0, 1);
+            assert_eq!(
+                frame.client_command_id,
+                ClientCommandId("attach-2".to_owned())
+            );
+        }
+        _ => panic!("expected active snapshot"),
+    }
+
+    let event = recv_frame(&mut second_rx).await;
+    match event {
+        ClientFrame::Event(frame) => {
+            assert_eq!(frame.delivery_seq.0, 2);
+            assert!(matches!(frame.event, ClientEvent::TaskChanged(_)));
+        }
+        _ => panic!("expected buffered event"),
+    }
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
 async fn recv_frame(rx: &mut mpsc::Receiver<ClientFrame>) -> ClientFrame {
     tokio::time::timeout(Duration::from_secs(1), rx.recv())
         .await
@@ -423,11 +583,59 @@ async fn begin_client(
     outbound: selvedge_command_model::ClientFrameSender,
     subscription: ClientSubscription,
 ) {
+    begin_client_with_command(
+        ingress_tx,
+        outbound,
+        ClientCommandId("attach-1".to_owned()),
+        subscription,
+    )
+    .await;
+}
+
+async fn begin_client_with_command(
+    ingress_tx: &selvedge_command_model::EventIngressSender,
+    outbound: selvedge_command_model::ClientFrameSender,
+    client_command_id: ClientCommandId,
+    subscription: ClientSubscription,
+) {
+    begin_named_client_with_command(
+        ingress_tx,
+        client_id(),
+        outbound,
+        client_command_id,
+        subscription,
+    )
+    .await;
+}
+
+async fn begin_named_client(
+    ingress_tx: &selvedge_command_model::EventIngressSender,
+    client_id: ClientId,
+    outbound: selvedge_command_model::ClientFrameSender,
+    subscription: ClientSubscription,
+) {
+    begin_named_client_with_command(
+        ingress_tx,
+        client_id,
+        outbound,
+        ClientCommandId("attach-1".to_owned()),
+        subscription,
+    )
+    .await;
+}
+
+async fn begin_named_client_with_command(
+    ingress_tx: &selvedge_command_model::EventIngressSender,
+    client_id: ClientId,
+    outbound: selvedge_command_model::ClientFrameSender,
+    client_command_id: ClientCommandId,
+    subscription: ClientSubscription,
+) {
     ingress_tx
         .send(EventIngress::Control(
             EventControlMessage::BeginClientHydration(BeginClientHydration {
-                client_id: client_id(),
-                client_command_id: ClientCommandId("attach-1".to_owned()),
+                client_id,
+                client_command_id,
                 outbound,
                 subscription,
             }),
@@ -437,22 +645,33 @@ async fn begin_client(
 }
 
 async fn deliver_empty_snapshot(ingress_tx: &selvedge_command_model::EventIngressSender) {
+    deliver_named_empty_snapshot(ingress_tx, client_id()).await;
+}
+
+async fn deliver_named_empty_snapshot(
+    ingress_tx: &selvedge_command_model::EventIngressSender,
+    client_id: ClientId,
+) {
     ingress_tx
         .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
             DeliverSnapshot {
-                client_id: client_id(),
+                client_id,
                 client_command_id: ClientCommandId("attach-1".to_owned()),
-                snapshot: ClientSnapshot {
-                    generated_at: UnixTs(100),
-                    tasks: Vec::new(),
-                    task_parent_edges: Vec::new(),
-                    history_nodes: Vec::new(),
-                    task_versions: Vec::new(),
-                },
+                snapshot: empty_snapshot(),
             },
         )))
         .await
         .expect("send snapshot");
+}
+
+fn empty_snapshot() -> ClientSnapshot {
+    ClientSnapshot {
+        generated_at: UnixTs(100),
+        tasks: Vec::new(),
+        task_parent_edges: Vec::new(),
+        history_nodes: Vec::new(),
+        task_versions: Vec::new(),
+    }
 }
 
 fn task_projection(task_id: &str, state_version: u64) -> TaskProjection {

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -1,0 +1,469 @@
+use std::{collections::BTreeSet, time::Duration};
+
+use selvedge_command_model::{
+    BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
+    ClientNoticeLevel, ClientSnapshot, ClientSubscription, DebugRawEvent, DeliverNotice,
+    DeliverSnapshot, DetailLevel, EventControlMessage, EventIngress, HistoryAppendedRawEvent,
+    RawEvent, SnapshotTaskVersion, TaskChangedRawEvent, TaskProjection, TaskProjectionStatus,
+    TaskScope, UpdateSubscription,
+};
+use selvedge_domain_model::{HistoryNodeId, ModelProfileKey, ReasoningEffort, TaskId, UnixTs};
+use selvedge_events::{EventsStartArgs, SpawnEventsError, spawn_events_task};
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn spawn_events_task_validates_capacities_and_stops_after_mailbox_close() {
+    assert_eq!(
+        spawn_events_task(EventsStartArgs {
+            ingress_capacity: 0,
+            client_registry_capacity: 1,
+            hydration_buffer_capacity: 1,
+        })
+        .expect_err("invalid ingress capacity"),
+        SpawnEventsError::InvalidIngressCapacity
+    );
+
+    assert_eq!(
+        spawn_events_task(EventsStartArgs {
+            ingress_capacity: 1,
+            client_registry_capacity: 0,
+            hydration_buffer_capacity: 1,
+        })
+        .expect_err("invalid registry capacity"),
+        SpawnEventsError::InvalidClientRegistryCapacity
+    );
+
+    assert_eq!(
+        spawn_events_task(EventsStartArgs {
+            ingress_capacity: 1,
+            client_registry_capacity: 1,
+            hydration_buffer_capacity: 0,
+        })
+        .expect_err("invalid buffer capacity"),
+        SpawnEventsError::InvalidHydrationBufferCapacity
+    );
+
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 4,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn hydrating_client_receives_snapshot_before_uncovered_buffered_events() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut outbound_rx) = mpsc::channel(8);
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(
+            EventControlMessage::BeginClientHydration(BeginClientHydration {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                outbound,
+                subscription: verbose_all_tasks(),
+            }),
+        ))
+        .await
+        .expect("send begin hydration");
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::TaskChanged(
+            TaskChangedRawEvent {
+                task: task_projection("task-1", 1),
+            },
+        )))
+        .await
+        .expect("send covered task event");
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::HistoryAppended(
+            HistoryAppendedRawEvent {
+                task_id: TaskId("task-1".to_owned()),
+                task_state_version: 3,
+                appended_nodes: Vec::new(),
+            },
+        )))
+        .await
+        .expect("send uncovered history event");
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
+            DeliverSnapshot {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                snapshot: ClientSnapshot {
+                    generated_at: UnixTs(100),
+                    tasks: vec![task_projection("task-1", 2)],
+                    task_parent_edges: Vec::new(),
+                    history_nodes: Vec::new(),
+                    task_versions: vec![SnapshotTaskVersion {
+                        task_id: TaskId("task-1".to_owned()),
+                        state_version: 2,
+                    }],
+                },
+            },
+        )))
+        .await
+        .expect("send snapshot");
+
+    let snapshot = recv_frame(&mut outbound_rx).await;
+    match snapshot {
+        ClientFrame::Snapshot(frame) => {
+            assert_eq!(frame.delivery_seq.0, 1);
+            assert_eq!(
+                frame.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+            assert_eq!(frame.snapshot.task_versions[0].state_version, 2);
+        }
+        _ => panic!("expected snapshot frame"),
+    }
+
+    let event = recv_frame(&mut outbound_rx).await;
+    match event {
+        ClientFrame::Event(frame) => {
+            assert_eq!(frame.delivery_seq.0, 2);
+            match frame.event {
+                ClientEvent::HistoryAppended(history) => {
+                    assert_eq!(history.task_id, TaskId("task-1".to_owned()));
+                    assert_eq!(history.task_state_version, 3);
+                }
+                _ => panic!("expected history event"),
+            }
+        }
+        _ => panic!("expected event frame"),
+    }
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), outbound_rx.recv())
+            .await
+            .is_err()
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn live_client_receives_only_events_allowed_by_subscription() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut outbound_rx) = mpsc::channel(8);
+
+    begin_client(
+        &handle.ingress_tx,
+        outbound,
+        summary_task_subscription("task-1"),
+    )
+    .await;
+    deliver_empty_snapshot(&handle.ingress_tx).await;
+    assert!(matches!(
+        recv_frame(&mut outbound_rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::HistoryAppended(
+            HistoryAppendedRawEvent {
+                task_id: TaskId("task-1".to_owned()),
+                task_state_version: 3,
+                appended_nodes: Vec::new(),
+            },
+        )))
+        .await
+        .expect("send verbose event filtered by summary detail");
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::TaskChanged(
+            TaskChangedRawEvent {
+                task: task_projection("task-2", 3),
+            },
+        )))
+        .await
+        .expect("send event filtered by task scope");
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::TaskChanged(
+            TaskChangedRawEvent {
+                task: task_projection("task-1", 4),
+            },
+        )))
+        .await
+        .expect("send allowed task event");
+
+    let task_changed = recv_frame(&mut outbound_rx).await;
+    match task_changed {
+        ClientFrame::Event(frame) => {
+            assert_eq!(frame.delivery_seq.0, 2);
+            assert!(matches!(frame.event, ClientEvent::TaskChanged(_)));
+        }
+        _ => panic!("expected task changed event"),
+    }
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::Debug(DebugRawEvent {
+            task_id: Some(TaskId("task-1".to_owned())),
+            message_text: "debug".to_owned(),
+        })))
+        .await
+        .expect("send allowed debug event");
+
+    let debug = recv_frame(&mut outbound_rx).await;
+    match debug {
+        ClientFrame::Event(frame) => {
+            assert_eq!(frame.delivery_seq.0, 3);
+            assert!(matches!(frame.event, ClientEvent::DebugNotice(_)));
+        }
+        _ => panic!("expected debug event"),
+    }
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), outbound_rx.recv())
+            .await
+            .is_err()
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn hydrating_subscription_update_rescreens_buffer_before_snapshot_flush() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut outbound_rx) = mpsc::channel(8);
+
+    begin_client(&handle.ingress_tx, outbound, verbose_all_tasks()).await;
+    handle
+        .ingress_tx
+        .send(EventIngress::Raw(RawEvent::HistoryAppended(
+            HistoryAppendedRawEvent {
+                task_id: TaskId("task-1".to_owned()),
+                task_state_version: 3,
+                appended_nodes: Vec::new(),
+            },
+        )))
+        .await
+        .expect("send buffered event");
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(
+            EventControlMessage::UpdateSubscription(UpdateSubscription {
+                client_id: client_id(),
+                subscription: summary_task_subscription("task-2"),
+            }),
+        ))
+        .await
+        .expect("send subscription update");
+
+    deliver_empty_snapshot(&handle.ingress_tx).await;
+    assert!(matches!(
+        recv_frame(&mut outbound_rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), outbound_rx.recv())
+            .await
+            .is_err()
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn hydrating_buffer_overflow_removes_client_session() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 1,
+    })
+    .expect("valid events task");
+    let (outbound, mut outbound_rx) = mpsc::channel(8);
+
+    begin_client(&handle.ingress_tx, outbound, verbose_all_tasks()).await;
+
+    for state_version in [1, 2] {
+        handle
+            .ingress_tx
+            .send(EventIngress::Raw(RawEvent::TaskChanged(
+                TaskChangedRawEvent {
+                    task: task_projection("task-1", state_version),
+                },
+            )))
+            .await
+            .expect("send raw event");
+    }
+
+    let closed = tokio::time::timeout(Duration::from_secs(1), outbound_rx.recv())
+        .await
+        .expect("client channel closes after overflow");
+    assert!(closed.is_none());
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn notice_during_hydration_uses_current_delivery_sequence() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 4,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut outbound_rx) = mpsc::channel(8);
+
+    begin_client(&handle.ingress_tx, outbound, verbose_all_tasks()).await;
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverNotice(
+            DeliverNotice {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("notice-1".to_owned()),
+                notice: ClientNotice {
+                    level: ClientNoticeLevel::Warning,
+                    message_text: "heads up".to_owned(),
+                },
+            },
+        )))
+        .await
+        .expect("send notice");
+    deliver_empty_snapshot(&handle.ingress_tx).await;
+
+    let notice = recv_frame(&mut outbound_rx).await;
+    match notice {
+        ClientFrame::Notice(frame) => {
+            assert_eq!(frame.delivery_seq.0, 1);
+            assert_eq!(
+                frame.client_command_id,
+                ClientCommandId("notice-1".to_owned())
+            );
+            assert_eq!(frame.notice.level, ClientNoticeLevel::Warning);
+        }
+        _ => panic!("expected notice frame"),
+    }
+
+    let snapshot = recv_frame(&mut outbound_rx).await;
+    match snapshot {
+        ClientFrame::Snapshot(frame) => {
+            assert_eq!(frame.delivery_seq.0, 2);
+            assert_eq!(
+                frame.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+        }
+        _ => panic!("expected snapshot frame"),
+    }
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+async fn recv_frame(rx: &mut mpsc::Receiver<ClientFrame>) -> ClientFrame {
+    tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("frame received before timeout")
+        .expect("client channel remains open")
+}
+
+fn client_id() -> ClientId {
+    ClientId("client-1".to_owned())
+}
+
+fn verbose_all_tasks() -> ClientSubscription {
+    ClientSubscription {
+        task_scope: TaskScope::AllTasks,
+        detail_level: DetailLevel::Verbose,
+        include_model_call_status: true,
+        include_tool_execution_status: true,
+        include_debug_notices: true,
+    }
+}
+
+fn summary_task_subscription(task_id: &str) -> ClientSubscription {
+    ClientSubscription {
+        task_scope: TaskScope::TaskIds(BTreeSet::from([TaskId(task_id.to_owned())])),
+        detail_level: DetailLevel::Summary,
+        include_model_call_status: true,
+        include_tool_execution_status: true,
+        include_debug_notices: true,
+    }
+}
+
+async fn begin_client(
+    ingress_tx: &selvedge_command_model::EventIngressSender,
+    outbound: selvedge_command_model::ClientFrameSender,
+    subscription: ClientSubscription,
+) {
+    ingress_tx
+        .send(EventIngress::Control(
+            EventControlMessage::BeginClientHydration(BeginClientHydration {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                outbound,
+                subscription,
+            }),
+        ))
+        .await
+        .expect("send begin hydration");
+}
+
+async fn deliver_empty_snapshot(ingress_tx: &selvedge_command_model::EventIngressSender) {
+    ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
+            DeliverSnapshot {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                snapshot: ClientSnapshot {
+                    generated_at: UnixTs(100),
+                    tasks: Vec::new(),
+                    task_parent_edges: Vec::new(),
+                    history_nodes: Vec::new(),
+                    task_versions: Vec::new(),
+                },
+            },
+        )))
+        .await
+        .expect("send snapshot");
+}
+
+fn task_projection(task_id: &str, state_version: u64) -> TaskProjection {
+    TaskProjection {
+        task_id: TaskId(task_id.to_owned()),
+        status: TaskProjectionStatus::Active,
+        cursor_node_id: HistoryNodeId(1),
+        model_profile_key: ModelProfileKey("default".to_owned()),
+        reasoning_effort: ReasoningEffort::Medium,
+        state_version,
+        created_at: UnixTs(10),
+        updated_at: UnixTs(20),
+    }
+}

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -347,7 +347,7 @@ async fn notice_during_hydration_uses_current_delivery_sequence() {
         .send(EventIngress::Control(EventControlMessage::DeliverNotice(
             DeliverNotice {
                 client_id: client_id(),
-                client_command_id: ClientCommandId("notice-1".to_owned()),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
                 notice: ClientNotice {
                     level: ClientNoticeLevel::Warning,
                     message_text: "heads up".to_owned(),
@@ -364,7 +364,7 @@ async fn notice_during_hydration_uses_current_delivery_sequence() {
             assert_eq!(frame.delivery_seq.0, 1);
             assert_eq!(
                 frame.client_command_id,
-                ClientCommandId("notice-1".to_owned())
+                ClientCommandId("attach-1".to_owned())
             );
             assert_eq!(frame.notice.level, ClientNoticeLevel::Warning);
         }
@@ -475,6 +475,26 @@ async fn stale_hydration_snapshot_is_ignored_after_replacement_begin() {
         verbose_all_tasks(),
     )
     .await;
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DeliverNotice(
+            DeliverNotice {
+                client_id: client_id(),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                notice: ClientNotice {
+                    level: ClientNoticeLevel::Warning,
+                    message_text: "stale".to_owned(),
+                },
+            },
+        )))
+        .await
+        .expect("send stale notice");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), second_rx.recv())
+            .await
+            .is_err()
+    );
 
     handle
         .ingress_tx

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -333,6 +333,47 @@ async fn hydrating_buffer_overflow_removes_client_session() {
 }
 
 #[tokio::test]
+async fn registry_capacity_rejects_new_clients_after_limit() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (first_outbound, mut first_rx) = mpsc::channel(8);
+    let (second_outbound, mut second_rx) = mpsc::channel(8);
+
+    begin_named_client(
+        &handle.ingress_tx,
+        ClientId("client-1".to_owned()),
+        first_outbound,
+        verbose_all_tasks(),
+    )
+    .await;
+    begin_named_client(
+        &handle.ingress_tx,
+        ClientId("client-2".to_owned()),
+        second_outbound,
+        verbose_all_tasks(),
+    )
+    .await;
+
+    let rejected = tokio::time::timeout(Duration::from_secs(1), second_rx.recv())
+        .await
+        .expect("rejected client channel closes");
+    assert!(rejected.is_none());
+
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("client-1".to_owned())).await;
+    assert!(matches!(
+        recv_frame(&mut first_rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
 async fn notice_during_hydration_uses_current_delivery_sequence() {
     let handle = spawn_events_task(EventsStartArgs {
         ingress_capacity: 8,


### PR DESCRIPTION
## What changed

- Added the `selvedge-events` crate with a router-mediated Tokio event task.
- Added command-model client event ingress, subscription, snapshot, raw event, notice, and outbound frame types.
- Implemented hydration buffering, snapshot-before-live delivery, subscription filtering, per-client delivery sequencing, client detach/cleanup, registry capacity enforcement, and stale command correlation checks.
- Added behavior tests covering hydration, live fanout, slow client isolation, stale snapshot/notice/control handling, registry capacity, and buffer overflow cleanup.

## Why

The router needs a dedicated events module to aggregate raw task/runtime observations into client outbound frames while keeping database, network, filesystem, task runtime, and tool execution responsibilities outside the events layer.

## Validation

- `cargo test -p selvedge-command-model`
- `cargo test -p selvedge-events`
- `just hooks`
- `codex-review-final main`