### PR TITLE
[codex] implement task runtime factory effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/,task-runtime-factory/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -105,6 +105,9 @@ This file is for coding agents working in this repository.
 |crates/events/tests:{events_contract.rs}
 |crates/logging:{src/,Cargo.toml,README.md}
 |crates/logging/src:{lib.rs}
+|crates/task-runtime-factory:{src/,tests/,Cargo.toml,README.md}
+|crates/task-runtime-factory/src:{lib.rs}
+|crates/task-runtime-factory/tests:{factory_contract.rs}
 |scripts:{bootstrap.sh,create-worktree.sh}
 |src:{lib.rs,main.rs}
 |tests:{config_integration.rs,stdout_stderr_integration.rs,worktree_tool_integration.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-task-runtime-factory"
+version = "0.0.0"
+dependencies = [
+ "selvedge-command-model",
+ "selvedge-core",
+ "selvedge-db",
+ "selvedge-domain-model",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/domain-model",
     "crates/events",
     "crates/logging",
+    "crates/task-runtime-factory",
     "xtask",
 ]
 resolver = "2"

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -10,4 +10,4 @@ This crate is not for network access, database access, filesystem access, provid
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 
-Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::RuntimeInventoryQuery` and return live plus pending task runtime task ids through a oneshot response.
+Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::QueryRuntimeInventory` and return live plus pending task runtime task ids through a oneshot response.

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -2,10 +2,12 @@
 
 This crate defines the Selvedge command model API slice used to dispatch model calls, return completed API outputs to the router, and describe router-mediated client event ingress.
 
-Use it to define model-call request correlation, dispatch request, output envelope, call error, router ingress API message types, event ingress messages, client subscriptions, client snapshots, raw events, and client outbound frames.
+Use it to define model-call request correlation, dispatch request, output envelope, call error, router ingress API message types, factory output and runtime inventory messages, event ingress messages, client subscriptions, client snapshots, raw events, and client outbound frames.
 
 This crate is not for network access, database access, filesystem access, provider execution, or task runtime mutation.
 
 `RuntimeReady` is only a readiness signal. The task runtime sender is returned by `selvedge-core::spawn_task_runtime` to the creator that owns router registration.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
+
+Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::RuntimeInventoryQuery` and return live plus pending task runtime task ids through a oneshot response.

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -160,6 +160,8 @@ pub enum FactoryFailureKind {
     TaskArchived,
     CursorNodeMissing,
     RuntimeInventoryUnavailable,
+    RuntimeAlreadyLive,
+    RuntimeCreationPending,
     CoreSpawnFailed,
 }
 

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -71,6 +71,8 @@ pub enum RouterIngressMessage {
     Core(CoreOutputEnvelope),
     Tool(ToolExecutionResult),
     RuntimeExit(TaskRuntimeExitNotice),
+    Factory(RouterIngressFactoryMessage),
+    RuntimeInventoryQuery(RuntimeInventoryQuery),
     QueryRuntimeInventory(RuntimeInventoryQuery),
     PublishToEvents(DomainEventPublishRequest),
 }
@@ -81,6 +83,86 @@ pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
 pub type ModelCallRequest = ModelCallDispatchRequest;
 pub type EventIngressSender = mpsc::Sender<EventIngress>;
 pub type ClientFrameSender = mpsc::Sender<ClientFrame>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FactoryEffectId(pub String);
+
+#[derive(Debug)]
+pub enum RouterIngressFactoryMessage {
+    Output(FactoryOutputEnvelope),
+}
+
+#[derive(Debug)]
+pub struct FactoryOutputEnvelope {
+    pub effect_id: FactoryEffectId,
+    pub output: FactoryOutput,
+}
+
+#[derive(Debug)]
+pub enum FactoryOutput {
+    RuntimeCreated(TaskRuntimeCreated),
+    ScanFinished(FactoryScanOutput),
+    Failed(FactoryFailure),
+}
+
+#[derive(Debug)]
+pub struct TaskRuntimeCreated {
+    pub task_id: TaskId,
+    pub task_runtime_tx: TaskRuntimeSender,
+    pub created_runtime_kind: CreatedRuntimeKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CreatedRuntimeKind {
+    ExistingTaskRuntime,
+    ChildTaskRuntime,
+}
+
+#[derive(Debug)]
+pub struct FactoryScanOutput {
+    pub created: Vec<TaskRuntimeCreated>,
+    pub skipped: Vec<FactorySkippedTask>,
+    pub failed: Vec<FactoryTaskFailure>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FactorySkippedTask {
+    pub task_id: TaskId,
+    pub reason: FactorySkipReason,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FactorySkipReason {
+    RuntimeAlreadyLive,
+    RuntimeCreationPending,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FactoryTaskFailure {
+    pub task_id: TaskId,
+    pub kind: FactoryFailureKind,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FactoryFailure {
+    pub task_id: Option<TaskId>,
+    pub kind: FactoryFailureKind,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FactoryFailureKind {
+    DbReadFailed,
+    DbWriteFailed,
+    ParentTaskMissing,
+    ParentTaskArchived,
+    TaskMissing,
+    TaskArchived,
+    CursorNodeMissing,
+    RuntimeInventoryUnavailable,
+    CoreSpawnFailed,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ClientId(pub String);

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -72,7 +72,6 @@ pub enum RouterIngressMessage {
     Tool(ToolExecutionResult),
     RuntimeExit(TaskRuntimeExitNotice),
     Factory(RouterIngressFactoryMessage),
-    RuntimeInventoryQuery(RuntimeInventoryQuery),
     QueryRuntimeInventory(RuntimeInventoryQuery),
     PublishToEvents(DomainEventPublishRequest),
 }

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -1,11 +1,14 @@
 use selvedge_command_model::{
     ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommandId,
     ClientEvent, ClientEventFrame, ClientFrame, ClientId, ClientSnapshot, ClientSnapshotFrame,
-    ClientSubscription, DeliverySeq, DetailLevel, EventControlMessage, EventIngress,
-    HistoryAppendedEvent, HistoryAppendedRawEvent, ModelCallDispatchRequest, ModelCallError,
-    ModelCallErrorKind, ModelRunId, RouterIngressApiMessage, SnapshotTaskVersion, TaskId,
-    TaskProjection, TaskProjectionStatus, TaskScope, validate_api_output_envelope,
-    validate_dispatch_request,
+    ClientSubscription, CreatedRuntimeKind, DeliverySeq, DetailLevel, EventControlMessage,
+    EventIngress, FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput,
+    FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason, FactorySkippedTask,
+    FactoryTaskFailure, HistoryAppendedEvent, HistoryAppendedRawEvent, ModelCallDispatchRequest,
+    ModelCallError, ModelCallErrorKind, ModelRunId, RouterIngressApiMessage,
+    RouterIngressFactoryMessage, RouterIngressMessage, RuntimeInventoryQuery,
+    RuntimeInventoryResponse, SnapshotTaskVersion, TaskId, TaskProjection, TaskProjectionStatus,
+    TaskRuntimeCreated, TaskScope, validate_api_output_envelope, validate_dispatch_request,
 };
 use selvedge_domain_model::{
     ConversationMessage, ConversationPath, HistoryNodeId, MessageContent, MessageRole,
@@ -162,6 +165,108 @@ fn event_ingress_and_client_frames_expose_router_events_contract() {
 
     assert!(matches!(snapshot_frame, ClientFrame::Snapshot(_)));
     assert!(matches!(event_frame, ClientFrame::Event(_)));
+}
+
+#[test]
+fn factory_output_envelope_exposes_runtime_created_scan_and_failure_contract() {
+    let (task_runtime_tx, _task_runtime_rx) = tokio::sync::mpsc::channel(4);
+
+    let runtime_created = TaskRuntimeCreated {
+        task_id: TaskId("task-1".to_owned()),
+        task_runtime_tx,
+        created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+    };
+    let created = FactoryOutputEnvelope {
+        effect_id: FactoryEffectId("factory-1".to_owned()),
+        output: FactoryOutput::RuntimeCreated(runtime_created),
+    };
+
+    match created.output {
+        FactoryOutput::RuntimeCreated(created) => {
+            assert_eq!(created.task_id, TaskId("task-1".to_owned()));
+            assert!(matches!(
+                created.created_runtime_kind,
+                CreatedRuntimeKind::ExistingTaskRuntime
+            ));
+        }
+        _ => panic!("unexpected factory output"),
+    }
+
+    let scan = FactoryOutput::ScanFinished(FactoryScanOutput {
+        created: Vec::new(),
+        skipped: vec![FactorySkippedTask {
+            task_id: TaskId("task-live".to_owned()),
+            reason: FactorySkipReason::RuntimeAlreadyLive,
+        }],
+        failed: vec![FactoryTaskFailure {
+            task_id: TaskId("task-failed".to_owned()),
+            kind: FactoryFailureKind::CoreSpawnFailed,
+            message: "spawn failed".to_owned(),
+        }],
+    });
+
+    match scan {
+        FactoryOutput::ScanFinished(scan) => {
+            assert_eq!(scan.skipped[0].task_id, TaskId("task-live".to_owned()));
+            assert!(matches!(
+                scan.skipped[0].reason,
+                FactorySkipReason::RuntimeAlreadyLive
+            ));
+            assert_eq!(scan.failed[0].kind, FactoryFailureKind::CoreSpawnFailed);
+        }
+        _ => panic!("unexpected factory output"),
+    }
+
+    let failed = FactoryOutput::Failed(FactoryFailure {
+        task_id: Some(TaskId("task-archived".to_owned())),
+        kind: FactoryFailureKind::TaskArchived,
+        message: "task is archived".to_owned(),
+    });
+
+    match failed {
+        FactoryOutput::Failed(failure) => {
+            assert_eq!(failure.task_id, Some(TaskId("task-archived".to_owned())));
+            assert_eq!(failure.kind, FactoryFailureKind::TaskArchived);
+        }
+        _ => panic!("unexpected factory output"),
+    }
+}
+
+#[test]
+fn router_ingress_exposes_factory_output_and_runtime_inventory_query() {
+    let envelope = FactoryOutputEnvelope {
+        effect_id: FactoryEffectId("factory-1".to_owned()),
+        output: FactoryOutput::Failed(FactoryFailure {
+            task_id: None,
+            kind: FactoryFailureKind::RuntimeInventoryUnavailable,
+            message: "inventory unavailable".to_owned(),
+        }),
+    };
+
+    let factory_message =
+        RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope));
+    match factory_message {
+        RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) => {
+            assert_eq!(envelope.effect_id, FactoryEffectId("factory-1".to_owned()));
+        }
+        _ => panic!("unexpected router ingress message"),
+    }
+
+    let (reply_to, _reply_rx) = tokio::sync::oneshot::channel();
+    let query = RouterIngressMessage::RuntimeInventoryQuery(RuntimeInventoryQuery { reply_to });
+
+    match query {
+        RouterIngressMessage::RuntimeInventoryQuery(query) => {
+            query
+                .reply_to
+                .send(RuntimeInventoryResponse {
+                    live_task_runtimes: vec![TaskId("live".to_owned())],
+                    pending_task_runtime_effects: vec![TaskId("pending".to_owned())],
+                })
+                .expect("send runtime inventory response");
+        }
+        _ => panic!("unexpected router ingress message"),
+    }
 }
 
 fn valid_dispatch_request() -> ModelCallDispatchRequest {

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -253,10 +253,10 @@ fn router_ingress_exposes_factory_output_and_runtime_inventory_query() {
     }
 
     let (reply_to, _reply_rx) = tokio::sync::oneshot::channel();
-    let query = RouterIngressMessage::RuntimeInventoryQuery(RuntimeInventoryQuery { reply_to });
+    let query = RouterIngressMessage::QueryRuntimeInventory(RuntimeInventoryQuery { reply_to });
 
     match query {
-        RouterIngressMessage::RuntimeInventoryQuery(query) => {
+        RouterIngressMessage::QueryRuntimeInventory(query) => {
             query
                 .reply_to
                 .send(RuntimeInventoryResponse {

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -227,6 +227,13 @@ fn factory_output_envelope_exposes_runtime_created_scan_and_failure_contract() {
         FactoryOutput::Failed(failure) => {
             assert_eq!(failure.task_id, Some(TaskId("task-archived".to_owned())));
             assert_eq!(failure.kind, FactoryFailureKind::TaskArchived);
+
+            let duplicate = FactoryFailure {
+                task_id: Some(TaskId("task-live".to_owned())),
+                kind: FactoryFailureKind::RuntimeAlreadyLive,
+                message: "task runtime is already live".to_owned(),
+            };
+            assert_eq!(duplicate.kind, FactoryFailureKind::RuntimeAlreadyLive);
         }
         _ => panic!("unexpected factory output"),
     }

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -7,3 +7,5 @@ Use it to spawn a task-local runtime that loads SQLite state through `selvedge-d
 This crate only talks to the router mailbox and the database package. Provider calls, tool execution, event fanout, runtime registry ownership, and direct client delivery live in other crates.
 
 On `Start`, the runtime reads the active task snapshot and classifies the concrete cursor tail. User/system/function-output tails request a model call; function-call tails request tool execution; assistant/developer tails await user input with an empty queue. The runtime keeps only in-flight correlation ids and pending tool-call identity in memory; the task cursor lives in SQLite.
+
+`TaskRuntimeSpawnDeps` wraps the runtime config and a `TaskRuntimeSpawner` implementation. Use `TaskRuntimeSpawnDeps::new` for the default Tokio-backed spawner and `with_spawner` for boundary tests.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use selvedge_command_model::{
@@ -29,6 +30,44 @@ use uuid::Uuid;
 pub struct TaskRuntimeConfig {
     pub mailbox_capacity: usize,
     pub model_profiles: HashMap<ModelProfileKey, ModelProviderProfile>,
+}
+
+#[derive(Clone)]
+pub struct TaskRuntimeSpawnDeps {
+    pub config: TaskRuntimeConfig,
+    pub spawner: Arc<dyn TaskRuntimeSpawner>,
+}
+
+impl TaskRuntimeSpawnDeps {
+    pub fn new(config: TaskRuntimeConfig) -> Self {
+        Self {
+            config,
+            spawner: Arc::new(DefaultTaskRuntimeSpawner),
+        }
+    }
+
+    pub fn with_spawner(config: TaskRuntimeConfig, spawner: Arc<dyn TaskRuntimeSpawner>) -> Self {
+        Self { config, spawner }
+    }
+}
+
+pub trait TaskRuntimeSpawner: Send + Sync {
+    fn spawn_task_runtime(
+        &self,
+        args: SpawnTaskRuntimeArgs,
+    ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError>;
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultTaskRuntimeSpawner;
+
+impl TaskRuntimeSpawner for DefaultTaskRuntimeSpawner {
+    fn spawn_task_runtime(
+        &self,
+        args: SpawnTaskRuntimeArgs,
+    ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
+        spawn_task_runtime(args)
+    }
 }
 
 #[derive(Clone)]

--- a/crates/db/README.md
+++ b/crates/db/README.md
@@ -11,6 +11,7 @@ Resource boundaries:
 - `create_history_node` inserts one history node. History parent links are a standalone graph.
 - `create_root_task` inserts one task row at a caller-provided existing `cursor_node_id`. Task parent links and history parent links are separate graphs.
 - `create_child_task` records a task-layer parent edge and a caller-provided existing `cursor_node_id`.
+- `read_task_parent_edges` returns durable task-layer parent edges for router snapshots and factory verification.
 - A task cursor is a pointer into history, with no ownership claim over the pointed node.
 
 Public transition writes keep cursor movement atomic with the history append they perform: user message commit, model reply with tool calls, assistant reply with queued-input drain, tool output with queued-input drain, queued input promotion, queue input, and archive.

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -937,6 +937,28 @@ pub fn list_active_tasks(db: &DbPool) -> Result<Vec<TaskRow>, DbError> {
     Ok(rows)
 }
 
+pub fn read_task_parent_edges(db: &DbPool) -> Result<Vec<TaskParentEdgeRow>, DbError> {
+    let connection = db.connection()?;
+    let mut statement = connection
+        .prepare(
+            "SELECT parent_task_id, child_task_id, created_at
+             FROM task_parent_edges
+             ORDER BY parent_task_id ASC, child_task_id ASC",
+        )
+        .map_err(map_error)?;
+    statement
+        .query_map([], |row| {
+            Ok(TaskParentEdgeRow {
+                parent_task_id: TaskId(row.get(0)?),
+                child_task_id: TaskId(row.get(1)?),
+                created_at: UnixTs(row.get(2)?),
+            })
+        })
+        .map_err(map_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_error)
+}
+
 pub fn read_tool_manifest_for_task(db: &DbPool, task_id: &TaskId) -> Result<ToolManifest, DbError> {
     let connection = db.connection()?;
     ensure_active_task(&connection, task_id)?;

--- a/crates/task-runtime-factory/Cargo.toml
+++ b/crates/task-runtime-factory/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "selvedge-task-runtime-factory"
+edition = "2024"
+publish = false
+
+[dependencies]
+selvedge-command-model = { path = "../command-model" }
+selvedge-core = { path = "../core" }
+selvedge-db = { path = "../db" }
+selvedge-domain-model = { path = "../domain-model" }
+tokio = { version = "1.42.0", features = ["rt", "sync"] }
+uuid = { version = "1.11.0", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/task-runtime-factory/README.md
+++ b/crates/task-runtime-factory/README.md
@@ -1,0 +1,7 @@
+# task-runtime-factory
+
+This crate runs one-shot factory effects for router-mediated task runtimes.
+
+Use it to create a runtime for an existing active task, scan active tasks and create missing runtimes, or create a child task then create its runtime. Each effect reports exactly one factory output envelope to the router ingress channel.
+
+This crate is not for runtime registry ownership, task-local commands, provider calls, tool execution, direct event delivery, root task creation, or filesystem access.

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -213,7 +213,7 @@ async fn query_runtime_inventory(
 ) -> Result<RuntimeInventoryResponse, String> {
     let (reply_to, reply_rx) = tokio::sync::oneshot::channel();
     router_tx
-        .send(RouterIngressMessage::RuntimeInventoryQuery(
+        .send(RouterIngressMessage::QueryRuntimeInventory(
             RuntimeInventoryQuery { reply_to },
         ))
         .await

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -1,0 +1,364 @@
+#![doc = include_str!("../README.md")]
+
+use std::collections::HashSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use selvedge_command_model::{
+    CreatedRuntimeKind, FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput,
+    FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason, FactorySkippedTask,
+    FactoryTaskFailure, RouterIngressFactoryMessage, RouterIngressMessage, RouterIngressSender,
+    RuntimeInventoryQuery, RuntimeInventoryResponse, TaskRuntimeCreated,
+};
+use selvedge_core::{SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, TaskRuntimeSpawnDeps};
+use selvedge_db::{
+    CreateChildTaskInput, DbError, DbPool, TaskId, UnixTs, create_child_task, list_active_tasks,
+    load_active_task,
+};
+use selvedge_domain_model::HistoryNodeId;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FactoryCommand {
+    EnsureTaskRuntime(EnsureTaskRuntimeCommand),
+    EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimesCommand),
+    CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnsureTaskRuntimeCommand {
+    pub effect_id: FactoryEffectId,
+    pub task_id: TaskId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnsureMissingTaskRuntimesCommand {
+    pub effect_id: FactoryEffectId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CreateChildTaskAndRuntimeCommand {
+    pub effect_id: FactoryEffectId,
+    pub parent_task_id: TaskId,
+    pub child_cursor_node_id: HistoryNodeId,
+}
+
+#[derive(Clone)]
+pub struct FactoryEffectArgs {
+    pub command: FactoryCommand,
+    pub db: DbPool,
+    pub router_tx: RouterIngressSender,
+    pub core_spawn_deps: TaskRuntimeSpawnDeps,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpawnFactoryEffectError {
+    MissingDbHandle,
+    MissingRouterSender,
+    MissingCoreSpawnDeps,
+    TokioSpawnFailed,
+}
+
+pub fn spawn_factory_effect(
+    args: FactoryEffectArgs,
+) -> Result<JoinHandle<()>, SpawnFactoryEffectError> {
+    Ok(tokio::spawn(async move {
+        run_factory_effect(args).await;
+    }))
+}
+
+async fn run_factory_effect(args: FactoryEffectArgs) {
+    match args.command {
+        FactoryCommand::EnsureTaskRuntime(command) => {
+            let output = ensure_task_runtime(
+                &args.db,
+                &args.router_tx,
+                &args.core_spawn_deps,
+                command.task_id,
+                CreatedRuntimeKind::ExistingTaskRuntime,
+            );
+            send_output(args.router_tx, command.effect_id, output).await;
+        }
+        FactoryCommand::EnsureMissingTaskRuntimes(command) => {
+            let output =
+                ensure_missing_task_runtimes(&args.db, &args.router_tx, &args.core_spawn_deps)
+                    .await;
+            send_output(args.router_tx, command.effect_id, output).await;
+        }
+        FactoryCommand::CreateChildTaskAndRuntime(command) => {
+            let output = create_child_task_and_runtime(
+                &args.db,
+                &args.router_tx,
+                &args.core_spawn_deps,
+                command.parent_task_id,
+                command.child_cursor_node_id,
+            );
+            send_output(args.router_tx, command.effect_id, output).await;
+        }
+    }
+}
+
+fn create_child_task_and_runtime(
+    db: &DbPool,
+    router_tx: &RouterIngressSender,
+    core_spawn_deps: &TaskRuntimeSpawnDeps,
+    parent_task_id: TaskId,
+    child_cursor_node_id: HistoryNodeId,
+) -> FactoryOutput {
+    let child_task_id = TaskId(format!("child-{}", Uuid::new_v4()));
+    let child = match create_child_task(
+        db,
+        CreateChildTaskInput {
+            parent_task_id: parent_task_id.clone(),
+            child_task_id,
+            cursor_node_id: child_cursor_node_id,
+            now: now(),
+        },
+    ) {
+        Ok(child) => child,
+        Err(error) => {
+            return FactoryOutput::Failed(map_create_child_failure(parent_task_id, error));
+        }
+    };
+    spawn_task_runtime(
+        db,
+        router_tx,
+        core_spawn_deps,
+        child.task_id,
+        CreatedRuntimeKind::ChildTaskRuntime,
+    )
+}
+
+async fn ensure_missing_task_runtimes(
+    db: &DbPool,
+    router_tx: &RouterIngressSender,
+    core_spawn_deps: &TaskRuntimeSpawnDeps,
+) -> FactoryOutput {
+    let inventory = match query_runtime_inventory(router_tx).await {
+        Ok(inventory) => inventory,
+        Err(message) => {
+            return FactoryOutput::Failed(FactoryFailure {
+                task_id: None,
+                kind: FactoryFailureKind::RuntimeInventoryUnavailable,
+                message,
+            });
+        }
+    };
+    let live_task_runtimes = inventory
+        .live_task_runtimes
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let pending_task_runtime_effects = inventory
+        .pending_task_runtime_effects
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let active_tasks = match list_active_tasks(db) {
+        Ok(active_tasks) => active_tasks,
+        Err(error) => {
+            return FactoryOutput::Failed(FactoryFailure {
+                task_id: None,
+                kind: FactoryFailureKind::DbReadFailed,
+                message: error.to_string(),
+            });
+        }
+    };
+
+    let mut created = Vec::new();
+    let mut skipped = Vec::new();
+    let mut failed = Vec::new();
+    for task in active_tasks {
+        if live_task_runtimes.contains(&task.task_id) {
+            skipped.push(FactorySkippedTask {
+                task_id: task.task_id,
+                reason: FactorySkipReason::RuntimeAlreadyLive,
+            });
+            continue;
+        }
+        if pending_task_runtime_effects.contains(&task.task_id) {
+            skipped.push(FactorySkippedTask {
+                task_id: task.task_id,
+                reason: FactorySkipReason::RuntimeCreationPending,
+            });
+            continue;
+        }
+        let task_id = task.task_id;
+        let failure_task_id = task_id.clone();
+        match spawn_task_runtime_created(
+            db,
+            router_tx,
+            core_spawn_deps,
+            task_id,
+            CreatedRuntimeKind::ExistingTaskRuntime,
+        ) {
+            Ok(runtime) => created.push(runtime),
+            Err(failure) => {
+                failed.push(FactoryTaskFailure {
+                    task_id: failure.task_id.unwrap_or(failure_task_id),
+                    kind: failure.kind,
+                    message: failure.message,
+                });
+            }
+        }
+    }
+
+    FactoryOutput::ScanFinished(FactoryScanOutput {
+        created,
+        skipped,
+        failed,
+    })
+}
+
+async fn query_runtime_inventory(
+    router_tx: &RouterIngressSender,
+) -> Result<RuntimeInventoryResponse, String> {
+    let (reply_to, reply_rx) = tokio::sync::oneshot::channel();
+    router_tx
+        .send(RouterIngressMessage::RuntimeInventoryQuery(
+            RuntimeInventoryQuery { reply_to },
+        ))
+        .await
+        .map_err(|_| "runtime inventory query could not be sent".to_owned())?;
+    reply_rx
+        .await
+        .map_err(|_| "runtime inventory response was not delivered".to_owned())
+}
+
+fn ensure_task_runtime(
+    db: &DbPool,
+    router_tx: &RouterIngressSender,
+    core_spawn_deps: &TaskRuntimeSpawnDeps,
+    task_id: TaskId,
+    created_runtime_kind: CreatedRuntimeKind,
+) -> FactoryOutput {
+    match load_active_task(db, &task_id) {
+        Ok(_) => spawn_task_runtime(
+            db,
+            router_tx,
+            core_spawn_deps,
+            task_id,
+            created_runtime_kind,
+        ),
+        Err(error) => FactoryOutput::Failed(map_load_task_failure(Some(task_id), error)),
+    }
+}
+
+fn spawn_task_runtime(
+    db: &DbPool,
+    router_tx: &RouterIngressSender,
+    core_spawn_deps: &TaskRuntimeSpawnDeps,
+    task_id: TaskId,
+    created_runtime_kind: CreatedRuntimeKind,
+) -> FactoryOutput {
+    match spawn_task_runtime_created(
+        db,
+        router_tx,
+        core_spawn_deps,
+        task_id,
+        created_runtime_kind,
+    ) {
+        Ok(created) => FactoryOutput::RuntimeCreated(created),
+        Err(failure) => FactoryOutput::Failed(failure),
+    }
+}
+
+fn spawn_task_runtime_created(
+    db: &DbPool,
+    router_tx: &RouterIngressSender,
+    core_spawn_deps: &TaskRuntimeSpawnDeps,
+    task_id: TaskId,
+    created_runtime_kind: CreatedRuntimeKind,
+) -> Result<TaskRuntimeCreated, FactoryFailure> {
+    match core_spawn_deps
+        .spawner
+        .spawn_task_runtime(SpawnTaskRuntimeArgs {
+            task_id: task_id.clone(),
+            db: db.clone(),
+            router_tx: router_tx.clone(),
+            config: core_spawn_deps.config.clone(),
+        }) {
+        Ok(spawned) => Ok(TaskRuntimeCreated {
+            task_id: spawned.task_id,
+            task_runtime_tx: spawned.task_runtime_tx,
+            created_runtime_kind,
+        }),
+        Err(error) => Err(FactoryFailure {
+            task_id: Some(task_id),
+            kind: FactoryFailureKind::CoreSpawnFailed,
+            message: spawn_error_message(error),
+        }),
+    }
+}
+
+async fn send_output(
+    router_tx: RouterIngressSender,
+    effect_id: FactoryEffectId,
+    output: FactoryOutput,
+) {
+    let _ = router_tx
+        .send(RouterIngressMessage::Factory(
+            RouterIngressFactoryMessage::Output(FactoryOutputEnvelope { effect_id, output }),
+        ))
+        .await;
+}
+
+fn map_load_task_failure(task_id: Option<TaskId>, error: DbError) -> FactoryFailure {
+    match error {
+        DbError::NotFound => FactoryFailure {
+            task_id,
+            kind: FactoryFailureKind::TaskMissing,
+            message: "task is missing".to_owned(),
+        },
+        DbError::TaskNotActive => FactoryFailure {
+            task_id,
+            kind: FactoryFailureKind::TaskArchived,
+            message: "task is archived".to_owned(),
+        },
+        error => FactoryFailure {
+            task_id,
+            kind: FactoryFailureKind::DbReadFailed,
+            message: error.to_string(),
+        },
+    }
+}
+
+fn map_create_child_failure(parent_task_id: TaskId, error: DbError) -> FactoryFailure {
+    match error {
+        DbError::NotFound => FactoryFailure {
+            task_id: Some(parent_task_id),
+            kind: FactoryFailureKind::ParentTaskMissing,
+            message: "parent task is missing".to_owned(),
+        },
+        DbError::TaskNotActive => FactoryFailure {
+            task_id: Some(parent_task_id),
+            kind: FactoryFailureKind::ParentTaskArchived,
+            message: "parent task is archived".to_owned(),
+        },
+        DbError::Constraint(message) => FactoryFailure {
+            task_id: Some(parent_task_id),
+            kind: FactoryFailureKind::CursorNodeMissing,
+            message,
+        },
+        error => FactoryFailure {
+            task_id: Some(parent_task_id),
+            kind: FactoryFailureKind::DbWriteFailed,
+            message: error.to_string(),
+        },
+    }
+}
+
+fn spawn_error_message(error: SpawnTaskRuntimeError) -> String {
+    match error {
+        SpawnTaskRuntimeError::MailboxCreateFailed => "task runtime mailbox create failed",
+        SpawnTaskRuntimeError::TokioSpawnFailed => "task runtime tokio spawn failed",
+    }
+    .to_owned()
+}
+
+fn now() -> UnixTs {
+    UnixTs(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0),
+    )
+}

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -76,7 +76,8 @@ async fn run_factory_effect(args: FactoryEffectArgs) {
                 &args.core_spawn_deps,
                 command.task_id,
                 CreatedRuntimeKind::ExistingTaskRuntime,
-            );
+            )
+            .await;
             send_output(args.router_tx, command.effect_id, output).await;
         }
         FactoryCommand::EnsureMissingTaskRuntimes(command) => {
@@ -223,7 +224,7 @@ async fn query_runtime_inventory(
         .map_err(|_| "runtime inventory response was not delivered".to_owned())
 }
 
-fn ensure_task_runtime(
+async fn ensure_task_runtime(
     db: &DbPool,
     router_tx: &RouterIngressSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
@@ -231,13 +232,39 @@ fn ensure_task_runtime(
     created_runtime_kind: CreatedRuntimeKind,
 ) -> FactoryOutput {
     match load_active_task(db, &task_id) {
-        Ok(_) => spawn_task_runtime(
-            db,
-            router_tx,
-            core_spawn_deps,
-            task_id,
-            created_runtime_kind,
-        ),
+        Ok(_) => {
+            let inventory = match query_runtime_inventory(router_tx).await {
+                Ok(inventory) => inventory,
+                Err(message) => {
+                    return FactoryOutput::Failed(FactoryFailure {
+                        task_id: Some(task_id),
+                        kind: FactoryFailureKind::RuntimeInventoryUnavailable,
+                        message,
+                    });
+                }
+            };
+            if inventory.live_task_runtimes.contains(&task_id) {
+                return FactoryOutput::Failed(FactoryFailure {
+                    task_id: Some(task_id),
+                    kind: FactoryFailureKind::RuntimeAlreadyLive,
+                    message: "task runtime is already live".to_owned(),
+                });
+            }
+            if inventory.pending_task_runtime_effects.contains(&task_id) {
+                return FactoryOutput::Failed(FactoryFailure {
+                    task_id: Some(task_id),
+                    kind: FactoryFailureKind::RuntimeCreationPending,
+                    message: "task runtime creation is already pending".to_owned(),
+                });
+            }
+            spawn_task_runtime(
+                db,
+                router_tx,
+                core_spawn_deps,
+                task_id,
+                created_runtime_kind,
+            )
+        }
         Err(error) => FactoryOutput::Failed(map_load_task_failure(Some(task_id), error)),
     }
 }

--- a/crates/task-runtime-factory/tests/factory_contract.rs
+++ b/crates/task-runtime-factory/tests/factory_contract.rs
@@ -41,6 +41,8 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
         }),
     })
     .expect("spawn factory effect");
+
+    answer_inventory(&mut router_rx, Vec::new(), Vec::new()).await;
     handle.await.expect("factory task joins");
 
     let message = router_rx.recv().await.expect("factory output");
@@ -61,6 +63,37 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
     tokio::time::timeout(Duration::from_millis(25), router_rx.recv())
         .await
         .expect_err("factory leaves runtime idle");
+}
+
+#[tokio::test]
+async fn ensure_task_runtime_reports_live_and_pending_inventory() {
+    let db = open_memory_db();
+    create_root(&db, "live");
+    let live = run_ensure_task_runtime_with_inventory(
+        db,
+        "live",
+        vec![TaskId("live".to_owned())],
+        Vec::new(),
+    )
+    .await;
+    let FactoryOutput::Failed(failure) = live else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.kind, FactoryFailureKind::RuntimeAlreadyLive);
+
+    let db = open_memory_db();
+    create_root(&db, "pending");
+    let pending = run_ensure_task_runtime_with_inventory(
+        db,
+        "pending",
+        Vec::new(),
+        vec![TaskId("pending".to_owned())],
+    )
+    .await;
+    let FactoryOutput::Failed(failure) = pending else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.kind, FactoryFailureKind::RuntimeCreationPending);
 }
 
 #[tokio::test]
@@ -404,6 +437,36 @@ async fn run_ensure_task_runtime(db: DbPool, task_id: &str) -> FactoryOutput {
     recv_factory_output(&mut router_rx).await
 }
 
+async fn run_ensure_task_runtime_with_inventory(
+    db: DbPool,
+    task_id: &str,
+    live_task_runtimes: Vec<TaskId>,
+    pending_task_runtime_effects: Vec<TaskId>,
+) -> FactoryOutput {
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
+            effect_id: FactoryEffectId("factory-1".to_owned()),
+            task_id: TaskId(task_id.to_owned()),
+        }),
+        db,
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn factory effect");
+    answer_inventory(
+        &mut router_rx,
+        live_task_runtimes,
+        pending_task_runtime_effects,
+    )
+    .await;
+    handle.await.expect("factory task joins");
+    recv_factory_output(&mut router_rx).await
+}
+
 async fn run_create_child(
     db: DbPool,
     parent_task_id: &str,
@@ -437,6 +500,24 @@ async fn recv_factory_output(
         panic!("unexpected router message");
     };
     envelope.output
+}
+
+async fn answer_inventory(
+    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    live_task_runtimes: Vec<TaskId>,
+    pending_task_runtime_effects: Vec<TaskId>,
+) {
+    let query = router_rx.recv().await.expect("runtime inventory query");
+    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
+        panic!("unexpected router message");
+    };
+    query
+        .reply_to
+        .send(RuntimeInventoryResponse {
+            live_task_runtimes,
+            pending_task_runtime_effects,
+        })
+        .expect("send runtime inventory");
 }
 
 struct FailingSpawner;

--- a/crates/task-runtime-factory/tests/factory_contract.rs
+++ b/crates/task-runtime-factory/tests/factory_contract.rs
@@ -109,7 +109,7 @@ async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
         .await
         .expect("runtime inventory query")
         .expect("runtime inventory message");
-    let RouterIngressMessage::RuntimeInventoryQuery(query) = query else {
+    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
         panic!("unexpected router message");
     };
     query
@@ -250,7 +250,7 @@ async fn ensure_missing_task_runtimes_reports_unavailable_inventory() {
     .expect("spawn factory effect");
 
     let query = router_rx.recv().await.expect("runtime inventory query");
-    let RouterIngressMessage::RuntimeInventoryQuery(query) = query else {
+    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
         panic!("unexpected router message");
     };
     drop(query);

--- a/crates/task-runtime-factory/tests/factory_contract.rs
+++ b/crates/task-runtime-factory/tests/factory_contract.rs
@@ -1,0 +1,451 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use selvedge_command_model::{
+    CreatedRuntimeKind, FactoryEffectId, FactoryFailureKind, FactoryOutput, FactorySkipReason,
+    RouterIngressFactoryMessage, RouterIngressMessage, RuntimeInventoryResponse,
+};
+use selvedge_core::{
+    SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
+    TaskRuntimeSpawnDeps, TaskRuntimeSpawner,
+};
+use selvedge_db::{
+    CreateRootTaskInput, DbPool, MessageRole, ModelProfileKey, NewHistoryNode,
+    NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId, ToolName,
+    ToolSpec, UnixTs, archive_task, create_history_node, create_root_task, load_active_task,
+    open_db, read_task_parent_edges, read_tool_manifest_for_task, register_tool,
+};
+use selvedge_domain_model::ModelProviderProfile;
+use selvedge_task_runtime_factory::{
+    CreateChildTaskAndRuntimeCommand, EnsureMissingTaskRuntimesCommand, EnsureTaskRuntimeCommand,
+    FactoryCommand, FactoryEffectArgs, spawn_factory_effect,
+};
+
+#[tokio::test]
+async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
+            effect_id: FactoryEffectId("factory-1".to_owned()),
+            task_id: TaskId("task-1".to_owned()),
+        }),
+        db,
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn factory effect");
+    handle.await.expect("factory task joins");
+
+    let message = router_rx.recv().await.expect("factory output");
+    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
+    else {
+        panic!("unexpected router message");
+    };
+    assert_eq!(envelope.effect_id, FactoryEffectId("factory-1".to_owned()));
+    let FactoryOutput::RuntimeCreated(created) = envelope.output else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(created.task_id, TaskId("task-1".to_owned()));
+    assert_eq!(
+        created.created_runtime_kind,
+        CreatedRuntimeKind::ExistingTaskRuntime
+    );
+
+    tokio::time::timeout(Duration::from_millis(25), router_rx.recv())
+        .await
+        .expect_err("factory leaves runtime idle");
+}
+
+#[tokio::test]
+async fn ensure_task_runtime_reports_missing_and_archived_tasks() {
+    let missing = run_ensure_task_runtime(open_memory_db(), "missing").await;
+    let FactoryOutput::Failed(failure) = missing else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.task_id, Some(TaskId("missing".to_owned())));
+    assert_eq!(failure.kind, FactoryFailureKind::TaskMissing);
+
+    let db = open_memory_db();
+    create_root(&db, "archived");
+    archive_task(&db, &TaskId("archived".to_owned()), UnixTs(2)).expect("archive task");
+
+    let archived = run_ensure_task_runtime(db, "archived").await;
+    let FactoryOutput::Failed(failure) = archived else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.task_id, Some(TaskId("archived".to_owned())));
+    assert_eq!(failure.kind, FactoryFailureKind::TaskArchived);
+}
+
+#[tokio::test]
+async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
+    let db = open_memory_db();
+    create_root(&db, "live");
+    create_root(&db, "pending");
+    create_root(&db, "missing");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimesCommand {
+            effect_id: FactoryEffectId("factory-scan".to_owned()),
+        }),
+        db,
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn factory effect");
+
+    let query = tokio::time::timeout(Duration::from_millis(50), router_rx.recv())
+        .await
+        .expect("runtime inventory query")
+        .expect("runtime inventory message");
+    let RouterIngressMessage::RuntimeInventoryQuery(query) = query else {
+        panic!("unexpected router message");
+    };
+    query
+        .reply_to
+        .send(RuntimeInventoryResponse {
+            live_task_runtimes: vec![TaskId("live".to_owned())],
+            pending_task_runtime_effects: vec![TaskId("pending".to_owned())],
+        })
+        .expect("send runtime inventory");
+
+    handle.await.expect("factory task joins");
+    let message = router_rx.recv().await.expect("factory output");
+    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
+    else {
+        panic!("unexpected router message");
+    };
+    assert_eq!(
+        envelope.effect_id,
+        FactoryEffectId("factory-scan".to_owned())
+    );
+    let FactoryOutput::ScanFinished(scan) = envelope.output else {
+        panic!("unexpected factory output");
+    };
+
+    assert_eq!(scan.created.len(), 1);
+    assert_eq!(scan.created[0].task_id, TaskId("missing".to_owned()));
+    assert_eq!(
+        scan.created[0].created_runtime_kind,
+        CreatedRuntimeKind::ExistingTaskRuntime
+    );
+    assert_eq!(scan.failed, Vec::new());
+    assert_eq!(scan.skipped.len(), 2);
+    assert!(scan.skipped.iter().any(|skipped| {
+        skipped.task_id == TaskId("live".to_owned())
+            && skipped.reason == FactorySkipReason::RuntimeAlreadyLive
+    }));
+    assert!(scan.skipped.iter().any(|skipped| {
+        skipped.task_id == TaskId("pending".to_owned())
+            && skipped.reason == FactorySkipReason::RuntimeCreationPending
+    }));
+}
+
+#[tokio::test]
+async fn create_child_task_and_runtime_persists_child_and_copies_parent_settings() {
+    let db = open_memory_db();
+    register_tool(
+        &db,
+        ToolSpec {
+            name: "search".to_owned(),
+            description: "search".to_owned(),
+            parameters: Vec::new(),
+        },
+    )
+    .expect("register tool");
+    let parent_cursor_node_id = create_message_node(&db, None, MessageRole::User, "parent");
+    create_root_task(
+        &db,
+        CreateRootTaskInput {
+            task_id: TaskId("parent".to_owned()),
+            cursor_node_id: parent_cursor_node_id,
+            model_profile_key: ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::High,
+            enabled_tools: vec![ToolName("search".to_owned())],
+            now: UnixTs(1),
+        },
+    )
+    .expect("create parent task");
+    let child_cursor_node_id = create_message_node(&db, None, MessageRole::User, "child cursor");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
+            effect_id: FactoryEffectId("factory-child".to_owned()),
+            parent_task_id: TaskId("parent".to_owned()),
+            child_cursor_node_id,
+        }),
+        db: db.clone(),
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn factory effect");
+    handle.await.expect("factory task joins");
+
+    let message = router_rx.recv().await.expect("factory output");
+    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
+    else {
+        panic!("unexpected router message");
+    };
+    assert_eq!(
+        envelope.effect_id,
+        FactoryEffectId("factory-child".to_owned())
+    );
+    let FactoryOutput::RuntimeCreated(created) = envelope.output else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(
+        created.created_runtime_kind,
+        CreatedRuntimeKind::ChildTaskRuntime
+    );
+
+    let child = load_active_task(&db, &created.task_id).expect("load child task");
+    assert_eq!(child.task.cursor_node_id, child_cursor_node_id);
+    assert_eq!(
+        child.task.model_profile_key,
+        ModelProfileKey("default".to_owned())
+    );
+    assert_eq!(child.task.reasoning_effort, ReasoningEffort::High);
+
+    let manifest = read_tool_manifest_for_task(&db, &created.task_id).expect("child manifest");
+    assert_eq!(manifest.tools[0].name, "search");
+
+    let edges = read_task_parent_edges(&db).expect("read task edges");
+    assert!(edges.iter().any(|edge| {
+        edge.parent_task_id == TaskId("parent".to_owned()) && edge.child_task_id == created.task_id
+    }));
+}
+
+#[tokio::test]
+async fn ensure_missing_task_runtimes_reports_unavailable_inventory() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimesCommand {
+            effect_id: FactoryEffectId("factory-scan".to_owned()),
+        }),
+        db,
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn factory effect");
+
+    let query = router_rx.recv().await.expect("runtime inventory query");
+    let RouterIngressMessage::RuntimeInventoryQuery(query) = query else {
+        panic!("unexpected router message");
+    };
+    drop(query);
+
+    handle.await.expect("factory task joins");
+    let output = recv_factory_output(&mut router_rx).await;
+    let FactoryOutput::Failed(failure) = output else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(
+        failure.kind,
+        FactoryFailureKind::RuntimeInventoryUnavailable
+    );
+}
+
+#[tokio::test]
+async fn create_child_task_and_runtime_reports_parent_and_cursor_failures() {
+    let missing_parent =
+        run_create_child(open_memory_db(), "missing", selvedge_db::HistoryNodeId(1)).await;
+    let FactoryOutput::Failed(failure) = missing_parent else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.kind, FactoryFailureKind::ParentTaskMissing);
+
+    let db = open_memory_db();
+    create_root(&db, "archived");
+    archive_task(&db, &TaskId("archived".to_owned()), UnixTs(2)).expect("archive task");
+    let archived_parent = run_create_child(db, "archived", selvedge_db::HistoryNodeId(1)).await;
+    let FactoryOutput::Failed(failure) = archived_parent else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.kind, FactoryFailureKind::ParentTaskArchived);
+
+    let db = open_memory_db();
+    create_root(&db, "parent");
+    let missing_cursor = run_create_child(db, "parent", selvedge_db::HistoryNodeId(9_999)).await;
+    let FactoryOutput::Failed(failure) = missing_cursor else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.kind, FactoryFailureKind::CursorNodeMissing);
+}
+
+#[tokio::test]
+async fn create_child_task_keeps_durable_child_when_runtime_spawn_fails() {
+    let db = open_memory_db();
+    create_root(&db, "parent");
+    let child_cursor_node_id = create_message_node(&db, None, MessageRole::User, "child cursor");
+
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
+            effect_id: FactoryEffectId("factory-child".to_owned()),
+            parent_task_id: TaskId("parent".to_owned()),
+            child_cursor_node_id,
+        }),
+        db: db.clone(),
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            Arc::new(FailingSpawner),
+        ),
+    })
+    .expect("spawn factory effect");
+    handle.await.expect("factory task joins");
+
+    let output = recv_factory_output(&mut router_rx).await;
+    let FactoryOutput::Failed(failure) = output else {
+        panic!("unexpected factory output");
+    };
+    assert_eq!(failure.kind, FactoryFailureKind::CoreSpawnFailed);
+    let child_task_id = failure.task_id.expect("child task id");
+    let child = load_active_task(&db, &child_task_id).expect("child remains durable");
+    assert_eq!(child.task.cursor_node_id, child_cursor_node_id);
+}
+
+fn create_root(db: &DbPool, task_id: &str) {
+    let cursor_node_id = create_message_node(db, None, MessageRole::User, "hello");
+    create_root_task(
+        db,
+        CreateRootTaskInput {
+            task_id: TaskId(task_id.to_owned()),
+            cursor_node_id,
+            model_profile_key: ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create root task");
+}
+
+fn create_message_node(
+    db: &DbPool,
+    parent_node_id: Option<selvedge_db::HistoryNodeId>,
+    message_role: MessageRole,
+    message_text: &str,
+) -> selvedge_db::HistoryNodeId {
+    create_history_node(
+        db,
+        NewHistoryNode {
+            parent_node_id,
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role,
+                message_text: message_text.to_owned(),
+            }),
+            created_at: UnixTs(1),
+        },
+    )
+    .expect("create message node")
+}
+
+fn model_profiles() -> HashMap<ModelProfileKey, ModelProviderProfile> {
+    HashMap::from([(
+        ModelProfileKey("default".to_owned()),
+        ModelProviderProfile {
+            provider_name: "provider".to_owned(),
+            model_name: "model".to_owned(),
+            temperature: None,
+            max_output_tokens: None,
+        },
+    )])
+}
+
+fn open_memory_db() -> DbPool {
+    open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db")
+}
+
+async fn run_ensure_task_runtime(db: DbPool, task_id: &str) -> FactoryOutput {
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
+            effect_id: FactoryEffectId("factory-1".to_owned()),
+            task_id: TaskId(task_id.to_owned()),
+        }),
+        db,
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn factory effect");
+    handle.await.expect("factory task joins");
+
+    recv_factory_output(&mut router_rx).await
+}
+
+async fn run_create_child(
+    db: DbPool,
+    parent_task_id: &str,
+    child_cursor_node_id: selvedge_db::HistoryNodeId,
+) -> FactoryOutput {
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_factory_effect(FactoryEffectArgs {
+        command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
+            effect_id: FactoryEffectId("factory-child".to_owned()),
+            parent_task_id: TaskId(parent_task_id.to_owned()),
+            child_cursor_node_id,
+        }),
+        db,
+        router_tx,
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn factory effect");
+    handle.await.expect("factory task joins");
+    recv_factory_output(&mut router_rx).await
+}
+
+async fn recv_factory_output(
+    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+) -> FactoryOutput {
+    let message = router_rx.recv().await.expect("factory output");
+    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
+    else {
+        panic!("unexpected router message");
+    };
+    envelope.output
+}
+
+struct FailingSpawner;
+
+impl TaskRuntimeSpawner for FailingSpawner {
+    fn spawn_task_runtime(
+        &self,
+        _args: SpawnTaskRuntimeArgs,
+    ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
+        Err(SpawnTaskRuntimeError::TokioSpawnFailed)
+    }
+}


### PR DESCRIPTION
## What changed

- Added the `selvedge-task-runtime-factory` crate for router-mediated one-shot factory effects.
- Added factory result, scan, failure, runtime-created, and runtime inventory message types to `selvedge-command-model`.
- Added `TaskRuntimeSpawnDeps` and `TaskRuntimeSpawner` in `selvedge-core` so factory effects can spawn runtimes through a testable boundary.
- Added `read_task_parent_edges` in `selvedge-db` for durable parent-child edge verification.
- Covered existing task runtime creation, scan skip behavior, child task creation, inventory failures, duplicate-runtime guards, and durable child retention after spawn failure.

## Why

The router needs a dedicated factory effect layer that can create task runtimes, repair missing runtime inventory, and create child tasks while keeping runtime registry ownership in the router.

## Validation

- `cargo test -p selvedge-task-runtime-factory`
- `cargo test -p selvedge-command-model factory`
- `cargo test --workspace --all-targets --all-features`
- `just hooks`
- `codex-review-final main`
