### PR TITLE
[codex] implement router-mediated runtime orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/,task-runtime-factory/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/,router/,task-runtime-factory/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -105,6 +105,9 @@ This file is for coding agents working in this repository.
 |crates/events/tests:{events_contract.rs}
 |crates/logging:{src/,Cargo.toml,README.md}
 |crates/logging/src:{lib.rs}
+|crates/router:{src/,tests/,Cargo.toml,README.md}
+|crates/router/src:{lib.rs}
+|crates/router/tests:{router_contract.rs}
 |crates/task-runtime-factory:{src/,tests/,Cargo.toml,README.md}
 |crates/task-runtime-factory/src:{lib.rs}
 |crates/task-runtime-factory/tests:{factory_contract.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,7 @@ dependencies = [
 name = "selvedge-router"
 version = "0.0.0"
 dependencies = [
+ "rusqlite",
  "selvedge-api",
  "selvedge-command-model",
  "selvedge-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-router"
+version = "0.0.0"
+dependencies = [
+ "selvedge-api",
+ "selvedge-command-model",
+ "selvedge-db",
+ "selvedge-domain-model",
+ "selvedge-task-runtime-factory",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "selvedge-task-runtime-factory"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/domain-model",
     "crates/events",
     "crates/logging",
+    "crates/router",
     "crates/task-runtime-factory",
     "xtask",
 ]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -182,10 +182,7 @@ async fn send_output(
     router_tx: RouterIngressSender,
     envelope: ApiOutputEnvelope,
 ) -> ApiCallTerminalStatus {
-    match router_tx
-        .send(RouterIngressApiMessage::ApiOutput(envelope))
-        .await
-    {
+    match router_tx.send(RouterIngressApiMessage::Api(envelope)).await {
         Ok(()) => ApiCallTerminalStatus::OutputSent,
         Err(_) => ApiCallTerminalStatus::RouterClosed,
     }

--- a/crates/api/tests/api_contract.rs
+++ b/crates/api/tests/api_contract.rs
@@ -47,7 +47,7 @@ async fn successful_provider_reply_is_sent_once_with_original_correlation() {
     assert!(router_rx.try_recv().is_err());
 
     match message {
-        RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Success { correlation, reply }) => {
+        RouterIngressApiMessage::Api(ApiOutputEnvelope::Success { correlation, reply }) => {
             assert_eq!(correlation.api_effect_id, request.correlation.api_effect_id);
             assert_eq!(correlation.task_id, request.correlation.task_id);
             assert_eq!(correlation.model_run_id, request.correlation.model_run_id);
@@ -121,7 +121,7 @@ async fn invalid_correlation_sends_validation_failure_that_satisfies_output_vali
     let message = router_rx.recv().await.expect("router message");
 
     match message {
-        RouterIngressApiMessage::ApiOutput(envelope) => {
+        RouterIngressApiMessage::Api(envelope) => {
             validate_api_output_envelope(&envelope).expect("valid output envelope");
             match envelope {
                 ApiOutputEnvelope::Failure { error, .. } => {
@@ -479,7 +479,7 @@ fn assert_failure(
     expected_kind: ModelCallErrorKind,
 ) {
     match message {
-        RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Failure { correlation, error }) => {
+        RouterIngressApiMessage::Api(ApiOutputEnvelope::Failure { correlation, error }) => {
             assert_eq!(
                 correlation.api_effect_id,
                 expected_correlation.api_effect_id

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -12,4 +12,6 @@ This crate is not for network access, database access, filesystem access, provid
 
 Client commands, factory outputs, API outputs, tool outputs, runtime exits, runtime inventory queries, and shutdown all enter through `RouterIngressMessage`.
 
+`CoreOutputEnvelope` includes the task id and runtime token. The router uses the token to discard stale output from a replaced runtime before it reaches external API or tool execution.
+
 Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::RuntimeInventoryQuery` and return live plus pending task runtime task ids through a oneshot response. A factory effect may include its own effect id so the router excludes that effect from the pending set returned to the requester.

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -12,4 +12,4 @@ This crate is not for network access, database access, filesystem access, provid
 
 Client commands, factory outputs, API outputs, tool outputs, runtime exits, runtime inventory queries, and shutdown all enter through `RouterIngressMessage`.
 
-Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::RuntimeInventoryQuery` and return live plus pending task runtime task ids through a oneshot response.
+Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::RuntimeInventoryQuery` and return live plus pending task runtime task ids through a oneshot response. A factory effect may include its own effect id so the router excludes that effect from the pending set returned to the requester.

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -10,4 +10,6 @@ This crate is not for network access, database access, filesystem access, provid
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 
-Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::QueryRuntimeInventory` and return live plus pending task runtime task ids through a oneshot response.
+Client commands, factory outputs, API outputs, tool outputs, runtime exits, runtime inventory queries, and shutdown all enter through `RouterIngressMessage`.
+
+Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::RuntimeInventoryQuery` and return live plus pending task runtime task ids through a oneshot response.

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -67,12 +67,14 @@ pub enum ModelCallErrorKind {
 
 #[derive(Debug)]
 pub enum RouterIngressMessage {
-    ApiOutput(ApiOutputEnvelope),
+    Client(ClientCommandEnvelope),
     Core(CoreOutputEnvelope),
+    Api(ApiOutputEnvelope),
     Tool(ToolExecutionResult),
+    Factory(FactoryOutputEnvelope),
     RuntimeExit(TaskRuntimeExitNotice),
-    Factory(RouterIngressFactoryMessage),
-    QueryRuntimeInventory(RuntimeInventoryQuery),
+    RuntimeInventoryQuery(RuntimeInventoryQuery),
+    Shutdown(RouterShutdown),
     PublishToEvents(DomainEventPublishRequest),
 }
 
@@ -85,11 +87,6 @@ pub type ClientFrameSender = mpsc::Sender<ClientFrame>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FactoryEffectId(pub String);
-
-#[derive(Debug)]
-pub enum RouterIngressFactoryMessage {
-    Output(FactoryOutputEnvelope),
-}
 
 #[derive(Debug)]
 pub struct FactoryOutputEnvelope {
@@ -107,7 +104,7 @@ pub enum FactoryOutput {
 #[derive(Debug)]
 pub struct TaskRuntimeCreated {
     pub task_id: TaskId,
-    pub task_runtime_tx: TaskRuntimeSender,
+    pub runtime: TaskRuntimeHandle,
     pub created_runtime_kind: CreatedRuntimeKind,
 }
 
@@ -170,6 +167,83 @@ pub struct ClientId(pub String);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ClientCommandId(pub String);
+
+#[derive(Debug)]
+pub struct RouterShutdown;
+
+#[derive(Debug)]
+pub struct ClientCommandEnvelope {
+    pub client_id: Option<ClientId>,
+    pub command_id: ClientCommandId,
+    pub command: ClientCommand,
+}
+
+#[derive(Debug)]
+pub enum ClientCommand {
+    SubmitUserInput(SubmitUserInput),
+    ArchiveTask(ArchiveTask),
+    StopTaskRuntime(StopTaskRuntime),
+    EnsureTaskRuntime(EnsureTaskRuntime),
+    EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimes),
+    CreateChildTaskAndRuntime(CreateChildTaskAndRuntime),
+    AttachClient(AttachClient),
+    RefreshClientSnapshot(RefreshClientSnapshot),
+    UpdateClientSubscription(UpdateClientSubscription),
+    DetachClient(DetachClientCommand),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubmitUserInput {
+    pub task_id: TaskId,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArchiveTask {
+    pub task_id: TaskId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StopTaskRuntime {
+    pub task_id: TaskId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnsureTaskRuntime {
+    pub task_id: TaskId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnsureMissingTaskRuntimes;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CreateChildTaskAndRuntime {
+    pub parent_task_id: TaskId,
+    pub child_cursor_node_id: HistoryNodeId,
+}
+
+#[derive(Debug)]
+pub struct AttachClient {
+    pub client_id: ClientId,
+    pub output_tx: ClientFrameSender,
+    pub subscription: ClientSubscription,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RefreshClientSnapshot {
+    pub client_id: ClientId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpdateClientSubscription {
+    pub client_id: ClientId,
+    pub subscription: ClientSubscription,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DetachClientCommand {
+    pub client_id: ClientId,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct DeliverySeq(pub u64);
@@ -470,6 +544,15 @@ pub enum DetachReason {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ToolExecutionRunId(pub String);
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TaskRuntimeToken(pub String);
+
+#[derive(Debug)]
+pub struct TaskRuntimeHandle {
+    pub runtime_token: TaskRuntimeToken,
+    pub task_runtime_tx: TaskRuntimeSender,
+}
+
 #[derive(Debug)]
 pub enum TaskRuntimeCommand {
     Start,
@@ -483,6 +566,7 @@ pub enum TaskRuntimeCommand {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TaskRuntimeExitNotice {
     pub task_id: TaskId,
+    pub runtime_token: TaskRuntimeToken,
     pub reason: TaskRuntimeExitReason,
 }
 

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -633,6 +633,7 @@ pub enum DomainEvent {
 
 #[derive(Debug)]
 pub struct RuntimeInventoryQuery {
+    pub requesting_effect_id: Option<FactoryEffectId>,
     pub reply_to: oneshot::Sender<RuntimeInventoryResponse>,
 }
 

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -581,6 +581,7 @@ pub enum TaskRuntimeExitReason {
 #[derive(Debug)]
 pub struct CoreOutputEnvelope {
     pub task_id: TaskId,
+    pub runtime_token: TaskRuntimeToken,
     pub message: CoreOutputMessage,
 }
 

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -1,14 +1,16 @@
 use selvedge_command_model::{
-    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommandId,
-    ClientEvent, ClientEventFrame, ClientFrame, ClientId, ClientSnapshot, ClientSnapshotFrame,
-    ClientSubscription, CreatedRuntimeKind, DeliverySeq, DetailLevel, EventControlMessage,
-    EventIngress, FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput,
-    FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason, FactorySkippedTask,
-    FactoryTaskFailure, HistoryAppendedEvent, HistoryAppendedRawEvent, ModelCallDispatchRequest,
-    ModelCallError, ModelCallErrorKind, ModelRunId, RouterIngressApiMessage,
-    RouterIngressFactoryMessage, RouterIngressMessage, RuntimeInventoryQuery,
-    RuntimeInventoryResponse, SnapshotTaskVersion, TaskId, TaskProjection, TaskProjectionStatus,
-    TaskRuntimeCreated, TaskScope, validate_api_output_envelope, validate_dispatch_request,
+    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommand,
+    ClientCommandEnvelope, ClientCommandId, ClientEvent, ClientEventFrame, ClientFrame, ClientId,
+    ClientSnapshot, ClientSnapshotFrame, ClientSubscription, CreatedRuntimeKind, DeliverySeq,
+    DetailLevel, EventControlMessage, EventIngress, FactoryEffectId, FactoryFailure,
+    FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason,
+    FactorySkippedTask, FactoryTaskFailure, HistoryAppendedEvent, HistoryAppendedRawEvent,
+    ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind, ModelRunId,
+    RouterIngressApiMessage, RouterIngressMessage, RouterShutdown, RuntimeInventoryQuery,
+    RuntimeInventoryResponse, SnapshotTaskVersion, SubmitUserInput, TaskId, TaskProjection,
+    TaskProjectionStatus, TaskRuntimeCreated, TaskRuntimeExitNotice, TaskRuntimeExitReason,
+    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, validate_api_output_envelope,
+    validate_dispatch_request,
 };
 use selvedge_domain_model::{
     ConversationMessage, ConversationPath, HistoryNodeId, MessageContent, MessageRole,
@@ -75,7 +77,7 @@ fn api_output_envelope_carries_exactly_success_or_failure_payload() {
 
 #[test]
 fn router_ingress_api_message_wraps_output_envelope() {
-    let message = RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Failure {
+    let message = RouterIngressApiMessage::Api(ApiOutputEnvelope::Failure {
         correlation: valid_correlation(),
         error: ModelCallError {
             kind: ModelCallErrorKind::Cancelled,
@@ -84,7 +86,7 @@ fn router_ingress_api_message_wraps_output_envelope() {
     });
 
     match message {
-        RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Failure { error, .. }) => {
+        RouterIngressApiMessage::Api(ApiOutputEnvelope::Failure { error, .. }) => {
             assert_eq!(error.kind, ModelCallErrorKind::Cancelled);
         }
         _ => panic!("unexpected message"),
@@ -173,7 +175,10 @@ fn factory_output_envelope_exposes_runtime_created_scan_and_failure_contract() {
 
     let runtime_created = TaskRuntimeCreated {
         task_id: TaskId("task-1".to_owned()),
-        task_runtime_tx,
+        runtime: TaskRuntimeHandle {
+            runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+            task_runtime_tx,
+        },
         created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
     };
     let created = FactoryOutputEnvelope {
@@ -250,20 +255,19 @@ fn router_ingress_exposes_factory_output_and_runtime_inventory_query() {
         }),
     };
 
-    let factory_message =
-        RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope));
+    let factory_message = RouterIngressMessage::Factory(envelope);
     match factory_message {
-        RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) => {
+        RouterIngressMessage::Factory(envelope) => {
             assert_eq!(envelope.effect_id, FactoryEffectId("factory-1".to_owned()));
         }
         _ => panic!("unexpected router ingress message"),
     }
 
     let (reply_to, _reply_rx) = tokio::sync::oneshot::channel();
-    let query = RouterIngressMessage::QueryRuntimeInventory(RuntimeInventoryQuery { reply_to });
+    let query = RouterIngressMessage::RuntimeInventoryQuery(RuntimeInventoryQuery { reply_to });
 
     match query {
-        RouterIngressMessage::QueryRuntimeInventory(query) => {
+        RouterIngressMessage::RuntimeInventoryQuery(query) => {
             query
                 .reply_to
                 .send(RuntimeInventoryResponse {
@@ -274,6 +278,53 @@ fn router_ingress_exposes_factory_output_and_runtime_inventory_query() {
         }
         _ => panic!("unexpected router ingress message"),
     }
+}
+
+#[test]
+fn router_ingress_exposes_client_shutdown_and_tokened_runtime_exit_contract() {
+    let client_command = ClientCommandEnvelope {
+        client_id: Some(ClientId("client-1".to_owned())),
+        command_id: ClientCommandId("command-1".to_owned()),
+        command: ClientCommand::SubmitUserInput(SubmitUserInput {
+            task_id: TaskId("task-1".to_owned()),
+            message_text: "hello".to_owned(),
+        }),
+    };
+    let message = RouterIngressMessage::Client(client_command);
+    match message {
+        RouterIngressMessage::Client(envelope) => {
+            assert_eq!(envelope.client_id, Some(ClientId("client-1".to_owned())));
+            assert_eq!(envelope.command_id, ClientCommandId("command-1".to_owned()));
+            match envelope.command {
+                ClientCommand::SubmitUserInput(input) => {
+                    assert_eq!(input.task_id, TaskId("task-1".to_owned()));
+                    assert_eq!(input.message_text, "hello");
+                }
+                _ => panic!("unexpected client command"),
+            }
+        }
+        _ => panic!("unexpected router ingress message"),
+    }
+
+    let exit = RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
+        task_id: TaskId("task-1".to_owned()),
+        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+        reason: TaskRuntimeExitReason::Stopped,
+    });
+    match exit {
+        RouterIngressMessage::RuntimeExit(notice) => {
+            assert_eq!(
+                notice.runtime_token,
+                TaskRuntimeToken("runtime-1".to_owned())
+            );
+        }
+        _ => panic!("unexpected router ingress message"),
+    }
+
+    assert!(matches!(
+        RouterIngressMessage::Shutdown(RouterShutdown),
+        RouterIngressMessage::Shutdown(_)
+    ));
 }
 
 fn valid_dispatch_request() -> ModelCallDispatchRequest {

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -264,10 +264,17 @@ fn router_ingress_exposes_factory_output_and_runtime_inventory_query() {
     }
 
     let (reply_to, _reply_rx) = tokio::sync::oneshot::channel();
-    let query = RouterIngressMessage::RuntimeInventoryQuery(RuntimeInventoryQuery { reply_to });
+    let query = RouterIngressMessage::RuntimeInventoryQuery(RuntimeInventoryQuery {
+        requesting_effect_id: Some(FactoryEffectId("factory-1".to_owned())),
+        reply_to,
+    });
 
     match query {
         RouterIngressMessage::RuntimeInventoryQuery(query) => {
+            assert_eq!(
+                query.requesting_effect_id,
+                Some(FactoryEffectId("factory-1".to_owned()))
+            );
             query
                 .reply_to
                 .send(RuntimeInventoryResponse {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -592,6 +592,7 @@ impl TaskRuntimeActor {
         self.router_tx
             .send(RouterIngressMessage::Core(CoreOutputEnvelope {
                 task_id: self.task_id.clone(),
+                runtime_token: self.runtime_token.clone(),
                 message,
             }))
             .await

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,7 +8,8 @@ use selvedge_command_model::{
     ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DomainEvent,
     DomainEventPublishRequest, ModelCallDispatchRequest, ModelRunId, RouterIngressMessage,
     RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+    TaskRuntimeSender, TaskRuntimeToken, ToolExecutionRequest, ToolExecutionResult,
+    ToolExecutionRunId,
 };
 use selvedge_db::{
     DbError, DbPool, FunctionCallId, HistoryNode, HistoryNodeId, MessageRole,
@@ -73,6 +74,7 @@ impl TaskRuntimeSpawner for DefaultTaskRuntimeSpawner {
 #[derive(Clone)]
 pub struct SpawnTaskRuntimeArgs {
     pub task_id: TaskId,
+    pub runtime_token: TaskRuntimeToken,
     pub db: DbPool,
     pub router_tx: RouterIngressSender,
     pub config: TaskRuntimeConfig,
@@ -81,6 +83,7 @@ pub struct SpawnTaskRuntimeArgs {
 #[derive(Debug)]
 pub struct SpawnedTaskRuntime {
     pub task_id: TaskId,
+    pub runtime_token: TaskRuntimeToken,
     pub task_runtime_tx: TaskRuntimeSender,
 }
 
@@ -97,11 +100,13 @@ pub fn spawn_task_runtime(
     let (task_runtime_tx, task_runtime_rx) = tokio::sync::mpsc::channel(capacity);
     let spawned = SpawnedTaskRuntime {
         task_id: args.task_id.clone(),
+        runtime_token: args.runtime_token.clone(),
         task_runtime_tx: task_runtime_tx.clone(),
     };
 
     let actor = TaskRuntimeActor {
         task_id: args.task_id,
+        runtime_token: args.runtime_token,
         db: args.db,
         router_tx: args.router_tx,
         rx: task_runtime_rx,
@@ -116,6 +121,7 @@ pub fn spawn_task_runtime(
 
 struct TaskRuntimeActor {
     task_id: TaskId,
+    runtime_token: TaskRuntimeToken,
     db: DbPool,
     router_tx: RouterIngressSender,
     rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
@@ -597,6 +603,7 @@ impl TaskRuntimeActor {
             .router_tx
             .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
                 task_id: self.task_id.clone(),
+                runtime_token: self.runtime_token.clone(),
                 reason,
             }))
             .await;

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -54,6 +54,7 @@ async fn task_runtime_starts_and_requests_model_call_from_system_cursor() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -130,6 +131,7 @@ async fn task_runtime_start_requests_model_from_user_cursor_without_draining_que
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db: db.clone(),
         router_tx,
         config: TaskRuntimeConfig {
@@ -211,6 +213,7 @@ async fn task_runtime_start_promotes_queue_before_awaiting_user_input() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db: db.clone(),
         router_tx,
         config: TaskRuntimeConfig {
@@ -300,6 +303,7 @@ async fn task_runtime_start_dispatches_tool_from_function_call_cursor() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -385,6 +389,7 @@ async fn task_runtime_start_reconstructs_open_batched_tool_calls_from_history() 
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -598,6 +603,7 @@ async fn task_runtime_ignores_tool_result_with_mismatched_call_identity() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db: db.clone(),
         router_tx,
         config: TaskRuntimeConfig {
@@ -812,6 +818,7 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -1094,6 +1101,7 @@ async fn task_runtime_rejects_empty_idle_user_input_before_append() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -1288,6 +1296,7 @@ async fn task_runtime_preserves_queued_input_when_append_fails() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db: db.clone(),
         router_tx,
         config: TaskRuntimeConfig {
@@ -1458,6 +1467,7 @@ async fn task_runtime_recovers_open_tool_call_before_model_dispatch() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -1559,6 +1569,7 @@ async fn task_runtime_allows_messages_between_tool_call_and_matching_output() {
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -1633,6 +1644,7 @@ async fn spawn_runtime_with_task(
     let (router_tx, router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {
@@ -1744,6 +1756,7 @@ async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> Mode
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
+        runtime_token: selvedge_command_model::TaskRuntimeToken("runtime-1".to_owned()),
         db,
         router_tx,
         config: TaskRuntimeConfig {

--- a/crates/db/README.md
+++ b/crates/db/README.md
@@ -2,7 +2,7 @@
 
 This crate owns SQLite persistence for router-mediated Selvedge tasks.
 
-Use it to open a schema-v4 SQLite database, register global tools, create tasks, commit task-runtime state transitions, queue user inputs, archive tasks, and read task-local model context.
+Use it to open a schema-v4 SQLite database, register global tools, create tasks, commit task-runtime state transitions, queue user inputs, archive tasks, and read task-local model context or router event projections.
 
 This crate is for SQLite persistence only. Runtime wait state, provider calls, tool execution, router registries, and event delivery live in other crates.
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1080,7 +1080,7 @@ fn database_is_empty(connection: &Connection) -> Result<bool, DbError> {
     Ok(count == 0)
 }
 
-fn read_task(db: &DbPool, task_id: &TaskId) -> Result<TaskRow, DbError> {
+pub fn read_task(db: &DbPool, task_id: &TaskId) -> Result<TaskRow, DbError> {
     let connection = db.connection()?;
     connection
         .query_row(
@@ -1182,7 +1182,7 @@ fn ensure_current_path_contains_open_function_call(
     }
 }
 
-fn read_history_node(db: &DbPool, node_id: &HistoryNodeId) -> Result<HistoryNode, DbError> {
+pub fn read_history_node(db: &DbPool, node_id: &HistoryNodeId) -> Result<HistoryNode, DbError> {
     let connection = db.connection()?;
     read_history_node_concrete_in_connection(&connection, node_id)
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -460,9 +460,16 @@ pub fn read_history_path_for_task(
     task_id: &TaskId,
 ) -> Result<Vec<HistoryNode>, DbError> {
     let task = read_task(db, task_id)?;
+    read_history_path_from_cursor(db, task.cursor_node_id)
+}
+
+pub fn read_history_path_from_cursor(
+    db: &DbPool,
+    cursor_node_id: HistoryNodeId,
+) -> Result<Vec<HistoryNode>, DbError> {
     let connection = db.connection()?;
     let mut nodes = Vec::new();
-    let mut next_node_id = Some(task.cursor_node_id);
+    let mut next_node_id = Some(cursor_node_id);
     while let Some(node_id) = next_node_id {
         let node = read_history_node_concrete_in_connection(&connection, &node_id)?;
         next_node_id = match &node {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -455,6 +455,28 @@ pub fn load_active_task(db: &DbPool, task_id: &TaskId) -> Result<LoadedActiveTas
     })
 }
 
+pub fn read_history_path_for_task(
+    db: &DbPool,
+    task_id: &TaskId,
+) -> Result<Vec<HistoryNode>, DbError> {
+    let task = read_task(db, task_id)?;
+    let connection = db.connection()?;
+    let mut nodes = Vec::new();
+    let mut next_node_id = Some(task.cursor_node_id);
+    while let Some(node_id) = next_node_id {
+        let node = read_history_node_concrete_in_connection(&connection, &node_id)?;
+        next_node_id = match &node {
+            HistoryNode::Message { parent_node_id, .. }
+            | HistoryNode::Reasoning { parent_node_id, .. }
+            | HistoryNode::FunctionCall { parent_node_id, .. }
+            | HistoryNode::FunctionOutput { parent_node_id, .. } => *parent_node_id,
+        };
+        nodes.push(node);
+    }
+    nodes.reverse();
+    Ok(nodes)
+}
+
 pub fn append_user_message_and_move_cursor(
     db: &DbPool,
     task_id: &TaskId,

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "selvedge-router"
+edition = "2024"
+publish = false
+
+[dependencies]
+selvedge-api = { path = "../api" }
+selvedge-command-model = { path = "../command-model" }
+selvedge-db = { path = "../db" }
+selvedge-domain-model = { path = "../domain-model" }
+selvedge-task-runtime-factory = { path = "../task-runtime-factory" }
+tokio = { version = "1.42.0", features = ["rt", "sync"] }
+uuid = { version = "1.11.0", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3.14.0"
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.42.0", features = ["rt", "sync"] }
 uuid = { version = "1.11.0", features = ["v4"] }
 
 [dev-dependencies]
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 tempfile = "3.14.0"
 tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
 

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -6,4 +6,4 @@ Use it to spawn the router mailbox, register task runtime handles returned by th
 
 The router keeps runtime registry, lifecycle effect registry, and waiting task commands in memory. Factory, API, tool execution, events, and task runtimes interact with the router through command-model messages and executor traits.
 
-Core output is accepted only when the envelope runtime token matches the registered live runtime for that task. Model-call and tool-execution requests are additionally discarded while the runtime is in removal.
+Core output is accepted only when the envelope runtime token matches the registered live runtime for that task. Model-call and tool-execution requests are additionally discarded while the runtime is in removal. External request results are routed through an in-flight registry keyed by task plus run id, so stale API or tool replies from replaced runtimes are dropped before status publication.

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -2,6 +2,6 @@
 
 This crate owns the in-memory Selvedge router actor.
 
-Use it to spawn the router mailbox, register task runtime handles returned by the factory, route task-local commands to live runtimes, coordinate runtime lifecycle effects, answer runtime inventory queries, and forward router-mediated event ingress.
+Use it to spawn the router mailbox, register task runtime handles returned by the factory, route task-local commands to live runtimes, coordinate runtime lifecycle effects, answer runtime inventory queries, project domain events into typed raw events, and forward router-mediated event ingress.
 
 The router keeps runtime registry, lifecycle effect registry, and waiting task commands in memory. Factory, API, tool execution, events, and task runtimes interact with the router through command-model messages and executor traits.

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -1,0 +1,7 @@
+# router
+
+This crate owns the in-memory Selvedge router actor.
+
+Use it to spawn the router mailbox, register task runtime handles returned by the factory, route task-local commands to live runtimes, coordinate runtime lifecycle effects, answer runtime inventory queries, and forward router-mediated event ingress.
+
+The router keeps runtime registry, lifecycle effect registry, and waiting task commands in memory. Factory, API, tool execution, events, and task runtimes interact with the router through command-model messages and executor traits.

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -5,3 +5,5 @@ This crate owns the in-memory Selvedge router actor.
 Use it to spawn the router mailbox, register task runtime handles returned by the factory, route task-local commands to live runtimes, coordinate runtime lifecycle effects, answer runtime inventory queries, project domain events into typed raw events, and forward router-mediated event ingress.
 
 The router keeps runtime registry, lifecycle effect registry, and waiting task commands in memory. Factory, API, tool execution, events, and task runtimes interact with the router through command-model messages and executor traits.
+
+Core output is accepted only when the envelope runtime token matches the registered live runtime for that task. Model-call and tool-execution requests are additionally discarded while the runtime is in removal.

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -7,10 +7,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use selvedge_api::ModelProviderRegistry;
 use selvedge_command_model::{
     ApiOutputEnvelope, ArchiveTask, ClientCommand, ClientCommandEnvelope, ClientCommandId,
-    ClientNotice, ClientNoticeLevel, ClientSnapshot, CoreOutputEnvelope, CoreOutputMessage,
-    DeliverNotice, DeliverSnapshot, DomainEvent, DomainEventPublishRequest, EventControlMessage,
-    EventIngress, EventIngressSender, FactoryEffectId, FactoryFailure, FactoryOutput,
-    FactoryOutputEnvelope, HistoryNodeProjection, HistoryNodeProjectionBody,
+    ClientId, ClientNotice, ClientNoticeLevel, ClientSnapshot, CoreOutputEnvelope,
+    CoreOutputMessage, DeliverNotice, DeliverSnapshot, DomainEvent, DomainEventPublishRequest,
+    EventControlMessage, EventIngress, EventIngressSender, FactoryEffectId, FactoryFailure,
+    FactoryOutput, FactoryOutputEnvelope, HistoryNodeProjection, HistoryNodeProjectionBody,
     ModelCallDispatchRequest, RawEvent, RouterIngressMessage, RouterIngressSender, RouterShutdown,
     RuntimeInventoryQuery, RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime,
     SubmitUserInput, TaskId, TaskParentProjection, TaskProjection, TaskProjectionStatus,
@@ -137,6 +137,7 @@ pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterEr
         pending_creations_by_task: BTreeMap::new(),
         effects: HashMap::new(),
         waiting_task_commands: BTreeMap::new(),
+        client_sessions: HashMap::new(),
     };
     let join_handle = tokio::spawn(actor.run());
 
@@ -159,6 +160,7 @@ struct RouterActor {
     pending_creations_by_task: BTreeMap<TaskId, FactoryEffectId>,
     effects: HashMap<FactoryEffectId, LifecycleEffect>,
     waiting_task_commands: BTreeMap<TaskId, VecDeque<PendingTaskCommand>>,
+    client_sessions: HashMap<ClientId, ClientCommandId>,
 }
 
 struct RuntimeEntry {
@@ -248,6 +250,8 @@ impl RouterActor {
             }
             ClientCommand::AttachClient(input) => {
                 let client_id = input.client_id.clone();
+                self.client_sessions
+                    .insert(client_id.clone(), envelope.command_id.clone());
                 let _ = self
                     .events_tx
                     .send(EventIngress::Control(
@@ -264,17 +268,18 @@ impl RouterActor {
                 self.deliver_snapshot(client_id, envelope.command_id).await;
             }
             ClientCommand::RefreshClientSnapshot(input) => {
-                self.deliver_snapshot(input.client_id, envelope.command_id)
-                    .await;
+                let command_id = self.session_command_id(&input.client_id, envelope.command_id);
+                self.deliver_snapshot(input.client_id, command_id).await;
             }
             ClientCommand::UpdateClientSubscription(input) => {
+                let command_id = self.session_command_id(&input.client_id, envelope.command_id);
                 let _ = self
                     .events_tx
                     .send(EventIngress::Control(
                         EventControlMessage::UpdateSubscription(
                             selvedge_command_model::UpdateSubscription {
                                 client_id: input.client_id,
-                                client_command_id: envelope.command_id,
+                                client_command_id: command_id,
                                 subscription: input.subscription,
                             },
                         ),
@@ -282,16 +287,18 @@ impl RouterActor {
                     .await;
             }
             ClientCommand::DetachClient(input) => {
+                let command_id = self.session_command_id(&input.client_id, envelope.command_id);
                 let _ = self
                     .events_tx
                     .send(EventIngress::Control(EventControlMessage::DetachClient(
                         selvedge_command_model::DetachClient {
-                            client_id: input.client_id,
-                            client_command_id: envelope.command_id,
+                            client_id: input.client_id.clone(),
+                            client_command_id: command_id,
                             reason: selvedge_command_model::DetachReason::ClientRequested,
                         },
                     )))
                     .await;
+                self.client_sessions.remove(&input.client_id);
             }
         }
     }
@@ -458,13 +465,14 @@ impl RouterActor {
     }
 
     fn spawn_factory(&mut self, command: FactoryCommand) {
+        let cleanup_command = command.clone();
         let request = FactorySpawnRequest {
             command,
             db: self.db.clone(),
             router_tx: self.router_tx.clone(),
         };
         if self.factory_executor.spawn_factory_effect(request).is_err() {
-            self.clear_failed_factory_spawn();
+            self.clear_failed_factory_spawn(cleanup_command);
         }
     }
 
@@ -520,17 +528,28 @@ impl RouterActor {
         };
         self.runtimes.insert(task_id.clone(), entry);
 
-        if self
-            .route_to_runtime(&task_id, TaskRuntimeCommand::Start)
-            .await
-            .is_err()
-        {
+        let start_failed = self.should_start_before_waiting_commands(&task_id)
+            && self
+                .route_to_runtime(&task_id, TaskRuntimeCommand::Start)
+                .await
+                .is_err();
+        if start_failed {
             self.runtimes.remove(&task_id);
             self.waiting_task_commands.remove(&task_id);
             return;
         }
 
         self.flush_waiting_commands(task_id).await;
+    }
+
+    fn should_start_before_waiting_commands(&self, task_id: &TaskId) -> bool {
+        self.waiting_task_commands
+            .get(task_id)
+            .is_none_or(|commands| {
+                commands
+                    .iter()
+                    .any(|command| matches!(command, PendingTaskCommand::UserInput { .. }))
+            })
     }
 
     async fn flush_waiting_commands(&mut self, task_id: TaskId) {
@@ -680,10 +699,31 @@ impl RouterActor {
         });
     }
 
-    fn clear_failed_factory_spawn(&mut self) {
-        self.effects.clear();
-        self.pending_creations_by_task.clear();
-        self.waiting_task_commands.clear();
+    fn clear_failed_factory_spawn(&mut self, command: FactoryCommand) {
+        match command {
+            FactoryCommand::EnsureTaskRuntime(command) => {
+                self.effects.remove(&command.effect_id);
+                self.pending_creations_by_task.remove(&command.task_id);
+                self.waiting_task_commands.remove(&command.task_id);
+            }
+            FactoryCommand::EnsureMissingTaskRuntimes(command) => {
+                self.effects.remove(&command.effect_id);
+            }
+            FactoryCommand::CreateChildTaskAndRuntime(command) => {
+                self.effects.remove(&command.effect_id);
+            }
+        }
+    }
+
+    fn session_command_id(
+        &self,
+        client_id: &ClientId,
+        fallback: ClientCommandId,
+    ) -> ClientCommandId {
+        self.client_sessions
+            .get(client_id)
+            .cloned()
+            .unwrap_or(fallback)
     }
 
     async fn send_failure_notice(&mut self, failure: FactoryFailure) {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -464,6 +464,14 @@ impl RouterActor {
     }
 
     fn ensure_task_runtime(&mut self, task_id: TaskId) {
+        if self
+            .runtimes
+            .get(&task_id)
+            .is_some_and(|entry| entry.removing)
+        {
+            self.deferred_ensures.insert(task_id);
+            return;
+        }
         if self.runtimes.contains_key(&task_id)
             || self.pending_creations_by_task.contains_key(&task_id)
         {
@@ -676,15 +684,28 @@ impl RouterActor {
             .get(&notice.task_id)
             .is_some_and(|entry| entry.runtime_token == notice.runtime_token);
         if should_remove {
-            if matches!(
-                notice.reason,
-                selvedge_command_model::TaskRuntimeExitReason::Archived
-            ) {
-                let raw = self.task_changed_raw_event(notice.task_id.clone());
-                let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
+            match &notice.reason {
+                selvedge_command_model::TaskRuntimeExitReason::Archived => {
+                    let raw = self.task_changed_raw_event(notice.task_id.clone());
+                    let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
+                }
+                selvedge_command_model::TaskRuntimeExitReason::DbError(message)
+                | selvedge_command_model::TaskRuntimeExitReason::InternalError(message) => {
+                    let _ = self
+                        .events_tx
+                        .send(EventIngress::Raw(RawEvent::Debug(
+                            selvedge_command_model::DebugRawEvent {
+                                task_id: Some(notice.task_id.clone()),
+                                message_text: message.clone(),
+                            },
+                        )))
+                        .await;
+                }
+                selvedge_command_model::TaskRuntimeExitReason::Stopped => {}
             }
             self.runtimes.remove(&notice.task_id);
             self.clear_removal_effects_for_task(&notice.task_id);
+            self.retry_deferred_ensures();
         }
     }
 
@@ -944,7 +965,9 @@ impl RouterActor {
             let mut seen_node_ids = HashSet::new();
             let mut history_nodes = Vec::new();
             for task in &tasks {
-                for node in selvedge_db::read_history_path_for_task(&self.db, &task.task_id)? {
+                for node in
+                    selvedge_db::read_history_path_from_cursor(&self.db, task.cursor_node_id)?
+                {
                     if seen_node_ids.insert(node.node_id()) {
                         history_nodes.push(history_node_projection(node));
                     }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -842,6 +842,9 @@ impl RouterActor {
                     return;
                 }
                 let correlation = request.correlation.clone();
+                if correlation.task_id != task_id {
+                    return;
+                }
                 self.in_flight_model_calls.insert(
                     (
                         correlation.task_id.clone(),
@@ -872,6 +875,9 @@ impl RouterActor {
             }
             CoreOutputMessage::RequestToolExecution(request) => {
                 if !self.runtime_accepts_external_requests(&task_id) {
+                    return;
+                }
+                if request.task_id != task_id {
                     return;
                 }
                 self.in_flight_tool_executions.insert(

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -12,11 +12,13 @@ use selvedge_command_model::{
     DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
     FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope,
     HistoryNodeProjection, HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelCallError,
-    ModelCallErrorKind, RawEvent, RouterIngressMessage, RouterIngressSender, RouterShutdown,
-    RuntimeInventoryQuery, RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime,
-    SubmitUserInput, TaskId, TaskParentProjection, TaskProjection, TaskProjectionStatus,
-    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender,
-    TaskRuntimeToken, TaskScope, ToolExecutionRequest, ToolExecutionResult,
+    ModelCallErrorKind, ModelCallStatusPhase, ModelCallStatusRawEvent, RawEvent,
+    RouterIngressMessage, RouterIngressSender, RouterShutdown, RuntimeInventoryQuery,
+    RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime, SubmitUserInput, TaskId,
+    TaskParentProjection, TaskProjection, TaskProjectionStatus, TaskRuntimeCommand,
+    TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender, TaskRuntimeToken, TaskScope,
+    ToolExecutionRequest, ToolExecutionResult, ToolExecutionStatusPhase,
+    ToolExecutionStatusRawEvent,
 };
 use selvedge_db::{DbPool, HistoryNode, TaskRow, TaskStatusRow, UnixTs};
 use selvedge_domain_model::HistoryNodeId;
@@ -690,20 +692,58 @@ impl RouterActor {
     }
 
     async fn route_api_output(&mut self, envelope: ApiOutputEnvelope) {
-        let task_id = match &envelope {
-            ApiOutputEnvelope::Success { correlation, .. }
-            | ApiOutputEnvelope::Failure { correlation, .. } => correlation.task_id.clone(),
+        let (task_id, model_call_id, phase) = match &envelope {
+            ApiOutputEnvelope::Success { correlation, .. } => (
+                correlation.task_id.clone(),
+                correlation.model_run_id.clone(),
+                ModelCallStatusPhase::Completed,
+            ),
+            ApiOutputEnvelope::Failure { correlation, .. } => (
+                correlation.task_id.clone(),
+                correlation.model_run_id.clone(),
+                ModelCallStatusPhase::Failed,
+            ),
         };
-        let _ = self
+        let routed = self
             .route_to_runtime(&task_id, TaskRuntimeCommand::ApiModelReply(envelope))
             .await;
+        self.send_model_call_status(
+            task_id,
+            model_call_id,
+            if routed.is_ok() {
+                phase
+            } else {
+                ModelCallStatusPhase::Discarded
+            },
+        )
+        .await;
     }
 
     async fn route_tool_output(&mut self, result: ToolExecutionResult) {
         let task_id = result.task_id.clone();
-        let _ = self
+        let status = ToolExecutionStatusRawEvent {
+            task_id: result.task_id.clone(),
+            tool_execution_run_id: result.tool_execution_run_id.clone(),
+            function_call_node_id: result.function_call_node_id,
+            tool_name: result.tool_name.clone(),
+            phase: if result.is_error {
+                ToolExecutionStatusPhase::Failed
+            } else {
+                ToolExecutionStatusPhase::Completed
+            },
+        };
+        let routed = self
             .route_to_runtime(&task_id, TaskRuntimeCommand::ToolResult(result))
             .await;
+        self.send_tool_execution_status(ToolExecutionStatusRawEvent {
+            phase: if routed.is_ok() {
+                status.phase
+            } else {
+                ToolExecutionStatusPhase::Discarded
+            },
+            ..status
+        })
+        .await;
     }
 
     async fn route_to_runtime(
@@ -775,6 +815,12 @@ impl RouterActor {
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
                 let correlation = request.correlation.clone();
+                self.send_model_call_status(
+                    correlation.task_id.clone(),
+                    correlation.model_run_id.clone(),
+                    ModelCallStatusPhase::Requested,
+                )
+                .await;
                 if self
                     .api_executor
                     .spawn_model_call(request, self.router_tx.clone())
@@ -791,6 +837,14 @@ impl RouterActor {
                 }
             }
             CoreOutputMessage::RequestToolExecution(request) => {
+                self.send_tool_execution_status(ToolExecutionStatusRawEvent {
+                    task_id: request.task_id.clone(),
+                    tool_execution_run_id: request.tool_execution_run_id.clone(),
+                    function_call_node_id: request.function_call_node_id,
+                    tool_name: request.tool_name.clone(),
+                    phase: ToolExecutionStatusPhase::Requested,
+                })
+                .await;
                 let failure = ToolExecutionResult {
                     task_id: request.task_id.clone(),
                     tool_execution_run_id: request.tool_execution_run_id.clone(),
@@ -972,6 +1026,31 @@ impl RouterActor {
             self.deferred_scan = false;
             self.ensure_missing_task_runtimes();
         }
+    }
+
+    async fn send_model_call_status(
+        &mut self,
+        task_id: TaskId,
+        model_call_id: selvedge_command_model::ModelCallId,
+        phase: ModelCallStatusPhase,
+    ) {
+        let _ = self
+            .events_tx
+            .send(EventIngress::Raw(RawEvent::ModelCallStatus(
+                ModelCallStatusRawEvent {
+                    task_id,
+                    model_call_id,
+                    phase,
+                },
+            )))
+            .await;
+    }
+
+    async fn send_tool_execution_status(&mut self, event: ToolExecutionStatusRawEvent) {
+        let _ = self
+            .events_tx
+            .send(EventIngress::Raw(RawEvent::ToolExecutionStatus(event)))
+            .await;
     }
 
     fn requeue_failed_flush(

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -597,7 +597,15 @@ impl RouterActor {
                 self.send_failure_notice(failure).await;
             }
             (LifecycleEffect::CreateChildTaskRuntime, FactoryOutput::Failed(failure)) => {
+                let retry_task_id = if retryable_creation_failure(&failure.kind) {
+                    failure.task_id.clone()
+                } else {
+                    None
+                };
                 self.send_failure_notice(failure).await;
+                if let Some(task_id) = retry_task_id {
+                    self.ensure_task_runtime(task_id);
+                }
             }
             (_, FactoryOutput::Failed(failure)) => {
                 self.send_failure_notice(failure).await;
@@ -631,7 +639,7 @@ impl RouterActor {
                 .is_err();
         if start_failed {
             self.runtimes.remove(&task_id);
-            self.waiting_task_commands.remove(&task_id);
+            self.ensure_task_runtime(task_id);
             return;
         }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -139,6 +139,7 @@ pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterEr
         effects: HashMap::new(),
         waiting_task_commands: BTreeMap::new(),
         client_sessions: HashMap::new(),
+        deferred_ensures: BTreeSet::new(),
     };
     let join_handle = tokio::spawn(actor.run());
 
@@ -162,6 +163,7 @@ struct RouterActor {
     effects: HashMap<FactoryEffectId, LifecycleEffect>,
     waiting_task_commands: BTreeMap<TaskId, VecDeque<PendingTaskCommand>>,
     client_sessions: HashMap<ClientId, ClientSession>,
+    deferred_ensures: BTreeSet<TaskId>,
 }
 
 struct RuntimeEntry {
@@ -444,6 +446,12 @@ impl RouterActor {
             return;
         }
 
+        if matches!(pending, PendingTaskCommand::Archive) {
+            self.enqueue_waiting_command(task_id.clone(), pending);
+            self.ensure_task_runtime(task_id);
+            return;
+        }
+
         if let Some(client_id) = client_id {
             self.send_notice(
                 client_id,
@@ -458,10 +466,14 @@ impl RouterActor {
     fn ensure_task_runtime(&mut self, task_id: TaskId) {
         if self.runtimes.contains_key(&task_id)
             || self.pending_creations_by_task.contains_key(&task_id)
-            || self.scan_in_flight()
         {
             return;
         }
+        if self.scan_in_flight() {
+            self.deferred_ensures.insert(task_id);
+            return;
+        }
+        self.deferred_ensures.remove(&task_id);
         let effect_id = FactoryEffectId(format!("router-create-{}", Uuid::new_v4()));
         self.pending_creations_by_task
             .insert(task_id.clone(), effect_id.clone());
@@ -528,6 +540,7 @@ impl RouterActor {
                     })
                     .await;
                 }
+                self.retry_deferred_ensures();
                 self.retry_waiting_tasks_without_runtime();
             }
             (LifecycleEffect::CreateTaskRuntime { task_id }, FactoryOutput::Failed(failure)) => {
@@ -541,6 +554,7 @@ impl RouterActor {
             (_, FactoryOutput::Failed(failure)) => {
                 self.send_failure_notice(failure).await;
                 if matches!(effect, LifecycleEffect::ScanMissingTaskRuntimes) {
+                    self.retry_deferred_ensures();
                     self.retry_waiting_tasks_without_runtime();
                 }
             }
@@ -549,6 +563,7 @@ impl RouterActor {
 
     async fn register_created_runtime(&mut self, task_id: TaskId, runtime: TaskRuntimeHandle) {
         self.pending_creations_by_task.remove(&task_id);
+        self.deferred_ensures.remove(&task_id);
         if self.runtimes.contains_key(&task_id) {
             return;
         }
@@ -775,6 +790,7 @@ impl RouterActor {
                 self.effects.remove(&command.effect_id);
                 self.pending_creations_by_task.remove(&command.task_id);
                 self.waiting_task_commands.remove(&command.task_id);
+                self.deferred_ensures.remove(&command.task_id);
             }
             FactoryCommand::EnsureMissingTaskRuntimes(command) => {
                 self.effects.remove(&command.effect_id);
@@ -805,6 +821,19 @@ impl RouterActor {
             .waiting_task_commands
             .keys()
             .cloned()
+            .collect::<Vec<_>>();
+        for task_id in task_ids {
+            if !self.runtimes.contains_key(&task_id)
+                && !self.pending_creations_by_task.contains_key(&task_id)
+            {
+                self.ensure_task_runtime(task_id);
+            }
+        }
+    }
+
+    fn retry_deferred_ensures(&mut self) {
+        let task_ids = std::mem::take(&mut self.deferred_ensures)
+            .into_iter()
             .collect::<Vec<_>>();
         for task_id in task_ids {
             if !self.runtimes.contains_key(&task_id)
@@ -1002,6 +1031,7 @@ impl RouterActor {
         self.pending_creations_by_task.clear();
         self.effects.clear();
         self.waiting_task_commands.clear();
+        self.deferred_ensures.clear();
     }
 }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -7,16 +7,16 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use selvedge_api::ModelProviderRegistry;
 use selvedge_command_model::{
     ApiOutputEnvelope, ArchiveTask, ClientCommand, ClientCommandEnvelope, ClientCommandId,
-    ClientId, ClientNotice, ClientNoticeLevel, ClientSnapshot, CoreOutputEnvelope,
-    CoreOutputMessage, DeliverNotice, DeliverSnapshot, DomainEvent, DomainEventPublishRequest,
-    EventControlMessage, EventIngress, EventIngressSender, FactoryEffectId, FactoryFailure,
-    FactoryOutput, FactoryOutputEnvelope, HistoryNodeProjection, HistoryNodeProjectionBody,
-    ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind, RawEvent, RouterIngressMessage,
-    RouterIngressSender, RouterShutdown, RuntimeInventoryQuery, RuntimeInventoryResponse,
-    SnapshotTaskVersion, StopTaskRuntime, SubmitUserInput, TaskId, TaskParentProjection,
-    TaskProjection, TaskProjectionStatus, TaskRuntimeCommand, TaskRuntimeExitNotice,
-    TaskRuntimeHandle, TaskRuntimeSender, TaskRuntimeToken, ToolExecutionRequest,
-    ToolExecutionResult,
+    ClientId, ClientNotice, ClientNoticeLevel, ClientSnapshot, ClientSubscription,
+    CoreOutputEnvelope, CoreOutputMessage, DeliverNotice, DeliverSnapshot, DomainEvent,
+    DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
+    FactoryEffectId, FactoryFailure, FactoryOutput, FactoryOutputEnvelope, HistoryNodeProjection,
+    HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind,
+    RawEvent, RouterIngressMessage, RouterIngressSender, RouterShutdown, RuntimeInventoryQuery,
+    RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime, SubmitUserInput, TaskId,
+    TaskParentProjection, TaskProjection, TaskProjectionStatus, TaskRuntimeCommand,
+    TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender, TaskRuntimeToken, TaskScope,
+    ToolExecutionRequest, ToolExecutionResult,
 };
 use selvedge_db::{DbPool, HistoryNode, TaskRow, TaskStatusRow, UnixTs};
 use selvedge_domain_model::HistoryNodeId;
@@ -161,7 +161,7 @@ struct RouterActor {
     pending_creations_by_task: BTreeMap<TaskId, FactoryEffectId>,
     effects: HashMap<FactoryEffectId, LifecycleEffect>,
     waiting_task_commands: BTreeMap<TaskId, VecDeque<PendingTaskCommand>>,
-    client_sessions: HashMap<ClientId, ClientCommandId>,
+    client_sessions: HashMap<ClientId, ClientSession>,
 }
 
 struct RuntimeEntry {
@@ -182,6 +182,12 @@ enum PendingTaskCommand {
     UserInput { message_text: String },
     Archive,
     Stop,
+}
+
+#[derive(Clone)]
+struct ClientSession {
+    command_id: ClientCommandId,
+    subscription: ClientSubscription,
 }
 
 impl RouterActor {
@@ -251,8 +257,14 @@ impl RouterActor {
             }
             ClientCommand::AttachClient(input) => {
                 let client_id = input.client_id.clone();
-                self.client_sessions
-                    .insert(client_id.clone(), envelope.command_id.clone());
+                let subscription = input.subscription.clone();
+                self.client_sessions.insert(
+                    client_id.clone(),
+                    ClientSession {
+                        command_id: envelope.command_id.clone(),
+                        subscription: subscription.clone(),
+                    },
+                );
                 let _ = self
                     .events_tx
                     .send(EventIngress::Control(
@@ -261,19 +273,29 @@ impl RouterActor {
                                 client_id: input.client_id,
                                 client_command_id: envelope.command_id.clone(),
                                 outbound: input.output_tx,
-                                subscription: input.subscription,
+                                subscription: subscription.clone(),
                             },
                         ),
                     ))
                     .await;
-                self.deliver_snapshot(client_id, envelope.command_id).await;
+                self.deliver_snapshot(client_id, envelope.command_id, Some(subscription))
+                    .await;
             }
             ClientCommand::RefreshClientSnapshot(input) => {
-                let command_id = self.session_command_id(&input.client_id, envelope.command_id);
-                self.deliver_snapshot(input.client_id, command_id).await;
+                let session = self.client_session(&input.client_id);
+                let command_id = session
+                    .as_ref()
+                    .map(|session| session.command_id.clone())
+                    .unwrap_or(envelope.command_id);
+                let subscription = session.map(|session| session.subscription);
+                self.deliver_snapshot(input.client_id, command_id, subscription)
+                    .await;
             }
             ClientCommand::UpdateClientSubscription(input) => {
                 let command_id = self.session_command_id(&input.client_id, envelope.command_id);
+                if let Some(session) = self.client_sessions.get_mut(&input.client_id) {
+                    session.subscription = input.subscription.clone();
+                }
                 let _ = self
                     .events_tx
                     .send(EventIngress::Control(
@@ -409,6 +431,10 @@ impl RouterActor {
             {
                 self.runtimes.remove(&task_id);
                 self.clear_removal_effects_for_task(&task_id);
+                if matches!(pending, PendingTaskCommand::Archive) {
+                    self.enqueue_waiting_command(task_id.clone(), pending);
+                    self.ensure_task_runtime(task_id);
+                }
             }
             return;
         }
@@ -502,6 +528,7 @@ impl RouterActor {
                     })
                     .await;
                 }
+                self.retry_waiting_tasks_without_runtime();
             }
             (LifecycleEffect::CreateTaskRuntime { task_id }, FactoryOutput::Failed(failure)) => {
                 self.pending_creations_by_task.remove(task_id);
@@ -513,6 +540,9 @@ impl RouterActor {
             }
             (_, FactoryOutput::Failed(failure)) => {
                 self.send_failure_notice(failure).await;
+                if matches!(effect, LifecycleEffect::ScanMissingTaskRuntimes) {
+                    self.retry_waiting_tasks_without_runtime();
+                }
             }
         }
     }
@@ -762,8 +792,27 @@ impl RouterActor {
     ) -> ClientCommandId {
         self.client_sessions
             .get(client_id)
-            .cloned()
+            .map(|session| session.command_id.clone())
             .unwrap_or(fallback)
+    }
+
+    fn client_session(&self, client_id: &ClientId) -> Option<ClientSession> {
+        self.client_sessions.get(client_id).cloned()
+    }
+
+    fn retry_waiting_tasks_without_runtime(&mut self) {
+        let task_ids = self
+            .waiting_task_commands
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for task_id in task_ids {
+            if !self.runtimes.contains_key(&task_id)
+                && !self.pending_creations_by_task.contains_key(&task_id)
+            {
+                self.ensure_task_runtime(task_id);
+            }
+        }
     }
 
     async fn send_failure_notice(&mut self, failure: FactoryFailure) {
@@ -806,8 +855,9 @@ impl RouterActor {
         &mut self,
         client_id: selvedge_command_model::ClientId,
         command_id: ClientCommandId,
+        subscription: Option<ClientSubscription>,
     ) {
-        match self.build_snapshot() {
+        match self.build_snapshot(subscription.as_ref()) {
             Ok(snapshot) => {
                 let _ = self
                     .events_tx
@@ -832,8 +882,22 @@ impl RouterActor {
         }
     }
 
-    fn build_snapshot(&self) -> Result<ClientSnapshot, selvedge_db::DbError> {
-        let tasks = selvedge_db::list_active_tasks(&self.db)?;
+    fn build_snapshot(
+        &self,
+        subscription: Option<&ClientSubscription>,
+    ) -> Result<ClientSnapshot, selvedge_db::DbError> {
+        let mut tasks = selvedge_db::list_active_tasks(&self.db)?;
+        if let Some(ClientSubscription {
+            task_scope: TaskScope::TaskIds(task_ids),
+            ..
+        }) = subscription
+        {
+            tasks.retain(|task| task_ids.contains(&task.task_id));
+        }
+        let included_task_ids = tasks
+            .iter()
+            .map(|task| task.task_id.clone())
+            .collect::<std::collections::BTreeSet<_>>();
         let task_parent_edges = selvedge_db::read_task_parent_edges(&self.db)?;
         let task_versions = tasks
             .iter()
@@ -860,6 +924,10 @@ impl RouterActor {
             .collect();
         let task_parent_edges = task_parent_edges
             .into_iter()
+            .filter(|edge| {
+                included_task_ids.contains(&edge.parent_task_id)
+                    && included_task_ids.contains(&edge.child_task_id)
+            })
             .map(|edge| TaskParentProjection {
                 parent_task_id: edge.parent_task_id,
                 child_task_id: edge.child_task_id,

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -8,15 +8,17 @@ use selvedge_api::ModelProviderRegistry;
 use selvedge_command_model::{
     ApiOutputEnvelope, ArchiveTask, ClientCommand, ClientCommandEnvelope, ClientCommandId,
     ClientNotice, ClientNoticeLevel, ClientSnapshot, CoreOutputEnvelope, CoreOutputMessage,
-    DeliverNotice, DeliverSnapshot, EventControlMessage, EventIngress, EventIngressSender,
-    FactoryEffectId, FactoryFailure, FactoryOutput, FactoryOutputEnvelope, HistoryNodeProjection,
-    ModelCallDispatchRequest, RouterIngressMessage, RouterIngressSender, RouterShutdown,
+    DeliverNotice, DeliverSnapshot, DomainEvent, DomainEventPublishRequest, EventControlMessage,
+    EventIngress, EventIngressSender, FactoryEffectId, FactoryFailure, FactoryOutput,
+    FactoryOutputEnvelope, HistoryNodeProjection, HistoryNodeProjectionBody,
+    ModelCallDispatchRequest, RawEvent, RouterIngressMessage, RouterIngressSender, RouterShutdown,
     RuntimeInventoryQuery, RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime,
     SubmitUserInput, TaskId, TaskParentProjection, TaskProjection, TaskProjectionStatus,
     TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender,
     TaskRuntimeToken, ToolExecutionRequest, ToolExecutionResult,
 };
-use selvedge_db::{DbPool, TaskStatusRow, UnixTs};
+use selvedge_db::{DbPool, HistoryNode, TaskRow, TaskStatusRow, UnixTs};
+use selvedge_domain_model::HistoryNodeId;
 use selvedge_task_runtime_factory::{
     CreateChildTaskAndRuntimeCommand, EnsureMissingTaskRuntimesCommand, EnsureTaskRuntimeCommand,
     FactoryCommand, SpawnFactoryEffectError,
@@ -202,10 +204,8 @@ impl RouterActor {
             RouterIngressMessage::RuntimeExit(notice) => self.handle_runtime_exit(notice),
             RouterIngressMessage::Core(envelope) => self.handle_core_output(envelope).await,
             RouterIngressMessage::PublishToEvents(event) => {
-                let _ = self
-                    .events_tx
-                    .send(EventIngress::Raw(domain_event_to_raw(event)))
-                    .await;
+                let raw = self.domain_event_to_raw(event);
+                let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
             }
             RouterIngressMessage::Shutdown(_) => {}
         }
@@ -484,6 +484,14 @@ impl RouterActor {
                     self.register_created_runtime(created.task_id, created.runtime)
                         .await;
                 }
+                for failure in scan.failed {
+                    self.send_failure_notice(FactoryFailure {
+                        task_id: Some(failure.task_id),
+                        kind: failure.kind,
+                        message: failure.message,
+                    })
+                    .await;
+                }
             }
             (LifecycleEffect::CreateTaskRuntime { task_id }, FactoryOutput::Failed(failure)) => {
                 self.pending_creations_by_task.remove(task_id);
@@ -617,10 +625,8 @@ impl RouterActor {
                     .spawn_tool_execution(request, self.router_tx.clone());
             }
             CoreOutputMessage::PublishDomainEvent(event) => {
-                let _ = self
-                    .events_tx
-                    .send(EventIngress::Raw(domain_event_to_raw(event)))
-                    .await;
+                let raw = self.domain_event_to_raw(event);
+                let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
             }
             CoreOutputMessage::RuntimeReady => {}
         }
@@ -629,7 +635,17 @@ impl RouterActor {
     fn answer_runtime_inventory(&mut self, query: RuntimeInventoryQuery) {
         let response = RuntimeInventoryResponse {
             live_task_runtimes: self.runtimes.keys().cloned().collect(),
-            pending_task_runtime_effects: self.pending_creations_by_task.keys().cloned().collect(),
+            pending_task_runtime_effects: self
+                .pending_creations_by_task
+                .iter()
+                .filter(|(_, effect_id)| {
+                    query
+                        .requesting_effect_id
+                        .as_ref()
+                        .is_none_or(|requesting_effect_id| requesting_effect_id != *effect_id)
+                })
+                .map(|(task_id, _)| task_id.clone())
+                .collect(),
         };
         let _ = query.reply_to.send(response);
     }
@@ -779,6 +795,60 @@ impl RouterActor {
         })
     }
 
+    fn domain_event_to_raw(&self, event: DomainEventPublishRequest) -> RawEvent {
+        match event.event {
+            DomainEvent::TaskRuntimeReady | DomainEvent::TaskArchived => {
+                self.task_changed_raw_event(event.task_id)
+            }
+            DomainEvent::UserMessageCommitted { node_id }
+            | DomainEvent::AssistantMessageCommitted { node_id }
+            | DomainEvent::ReasoningCommitted { node_id }
+            | DomainEvent::FunctionCallCommitted { node_id }
+            | DomainEvent::FunctionOutputCommitted { node_id } => {
+                self.history_appended_raw_event(event.task_id, node_id)
+            }
+            DomainEvent::ErrorNotice { message } => {
+                RawEvent::Debug(selvedge_command_model::DebugRawEvent {
+                    task_id: Some(event.task_id),
+                    message_text: message,
+                })
+            }
+        }
+    }
+
+    fn task_changed_raw_event(&self, task_id: TaskId) -> RawEvent {
+        match selvedge_db::read_task(&self.db, &task_id) {
+            Ok(task) => RawEvent::TaskChanged(selvedge_command_model::TaskChangedRawEvent {
+                task: task_projection(task),
+            }),
+            Err(error) => RawEvent::Debug(selvedge_command_model::DebugRawEvent {
+                task_id: Some(task_id),
+                message_text: format!("task event projection failed: {error}"),
+            }),
+        }
+    }
+
+    fn history_appended_raw_event(&self, task_id: TaskId, node_id: HistoryNodeId) -> RawEvent {
+        match (
+            selvedge_db::read_task(&self.db, &task_id),
+            selvedge_db::read_history_node(&self.db, &node_id),
+        ) {
+            (Ok(task), Ok(node)) => {
+                RawEvent::HistoryAppended(selvedge_command_model::HistoryAppendedRawEvent {
+                    task_id,
+                    task_state_version: task.state_version,
+                    appended_nodes: vec![history_node_projection(node)],
+                })
+            }
+            (Err(error), _) | (_, Err(error)) => {
+                RawEvent::Debug(selvedge_command_model::DebugRawEvent {
+                    task_id: Some(task_id),
+                    message_text: format!("history event projection failed: {error}"),
+                })
+            }
+        }
+    }
+
     fn stop(&mut self) {
         self.runtimes.clear();
         self.pending_creations_by_task.clear();
@@ -796,19 +866,89 @@ fn now() -> UnixTs {
     )
 }
 
-fn domain_event_to_raw(
-    event: selvedge_command_model::DomainEventPublishRequest,
-) -> selvedge_command_model::RawEvent {
-    match event.event {
-        selvedge_command_model::DomainEvent::ErrorNotice { message } => {
-            selvedge_command_model::RawEvent::Debug(selvedge_command_model::DebugRawEvent {
-                task_id: Some(event.task_id),
-                message_text: message,
-            })
-        }
-        other => selvedge_command_model::RawEvent::Debug(selvedge_command_model::DebugRawEvent {
-            task_id: Some(event.task_id),
-            message_text: format!("{other:?}"),
-        }),
+fn task_projection(task: TaskRow) -> TaskProjection {
+    TaskProjection {
+        task_id: task.task_id,
+        status: match task.task_status {
+            TaskStatusRow::Active => TaskProjectionStatus::Active,
+            TaskStatusRow::Archived => TaskProjectionStatus::Archived,
+        },
+        cursor_node_id: task.cursor_node_id,
+        model_profile_key: task.model_profile_key,
+        reasoning_effort: task.reasoning_effort,
+        state_version: task.state_version,
+        created_at: task.created_at,
+        updated_at: task.updated_at,
+    }
+}
+
+fn history_node_projection(node: HistoryNode) -> HistoryNodeProjection {
+    match node {
+        HistoryNode::Message {
+            node_id,
+            parent_node_id,
+            created_at,
+            message_role,
+            message_text,
+        } => HistoryNodeProjection {
+            node_id,
+            parent_node_id,
+            created_at,
+            body: HistoryNodeProjectionBody::Message {
+                role: message_role,
+                text: message_text,
+            },
+        },
+        HistoryNode::Reasoning {
+            node_id,
+            parent_node_id,
+            created_at,
+            reasoning_text,
+        } => HistoryNodeProjection {
+            node_id,
+            parent_node_id,
+            created_at,
+            body: HistoryNodeProjectionBody::Reasoning {
+                text: reasoning_text,
+            },
+        },
+        HistoryNode::FunctionCall {
+            node_id,
+            parent_node_id,
+            created_at,
+            function_call_id,
+            tool_name,
+            arguments,
+        } => HistoryNodeProjection {
+            node_id,
+            parent_node_id,
+            created_at,
+            body: HistoryNodeProjectionBody::FunctionCall {
+                function_call_id,
+                tool_name,
+                arguments,
+            },
+        },
+        HistoryNode::FunctionOutput {
+            node_id,
+            parent_node_id,
+            created_at,
+            function_call_node_id,
+            function_call_id,
+            tool_name,
+            output_text,
+            is_error,
+        } => HistoryNodeProjection {
+            node_id,
+            parent_node_id,
+            created_at,
+            body: HistoryNodeProjectionBody::FunctionOutput {
+                function_call_node_id,
+                function_call_id,
+                tool_name,
+                output_text,
+                is_error,
+            },
+        },
     }
 }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -710,6 +710,7 @@ impl RouterActor {
     }
 
     async fn handle_core_output(&mut self, envelope: CoreOutputEnvelope) {
+        let task_id = envelope.task_id;
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
                 let correlation = request.correlation.clone();
@@ -750,7 +751,10 @@ impl RouterActor {
                 let raw = self.domain_event_to_raw(event);
                 let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
             }
-            CoreOutputMessage::RuntimeReady => {}
+            CoreOutputMessage::RuntimeReady => {
+                let raw = self.task_changed_raw_event(task_id);
+                let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
+            }
         }
     }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -416,6 +416,20 @@ impl RouterActor {
         runtime_command: TaskRuntimeCommand,
     ) {
         if self.runtime_is_removing(&task_id) {
+            if matches!(pending, PendingTaskCommand::Archive) {
+                self.enqueue_waiting_command(task_id.clone(), pending);
+                self.deferred_ensures.insert(task_id);
+                return;
+            }
+            if let Some(client_id) = client_id {
+                self.send_notice(
+                    client_id,
+                    command_id,
+                    ClientNoticeLevel::Warning,
+                    "task runtime is stopping",
+                )
+                .await;
+            }
             return;
         }
 
@@ -911,6 +925,7 @@ impl RouterActor {
         level: ClientNoticeLevel,
         message_text: &str,
     ) {
+        let command_id = self.session_command_id(&client_id, command_id);
         let _ = self
             .events_tx
             .send(EventIngress::Control(EventControlMessage::DeliverNotice(

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -12,12 +12,12 @@ use selvedge_command_model::{
     DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
     FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope,
     HistoryNodeProjection, HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelCallError,
-    ModelCallErrorKind, ModelCallStatusPhase, ModelCallStatusRawEvent, RawEvent,
+    ModelCallErrorKind, ModelCallStatusPhase, ModelCallStatusRawEvent, ModelRunId, RawEvent,
     RouterIngressMessage, RouterIngressSender, RouterShutdown, RuntimeInventoryQuery,
     RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime, SubmitUserInput, TaskId,
     TaskParentProjection, TaskProjection, TaskProjectionStatus, TaskRuntimeCommand,
     TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender, TaskRuntimeToken, TaskScope,
-    ToolExecutionRequest, ToolExecutionResult, ToolExecutionStatusPhase,
+    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId, ToolExecutionStatusPhase,
     ToolExecutionStatusRawEvent,
 };
 use selvedge_db::{DbPool, HistoryNode, TaskRow, TaskStatusRow, UnixTs};
@@ -143,6 +143,8 @@ pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterEr
         client_sessions: HashMap::new(),
         deferred_ensures: BTreeSet::new(),
         deferred_scan: false,
+        in_flight_model_calls: HashMap::new(),
+        in_flight_tool_executions: HashMap::new(),
     };
     let join_handle = tokio::spawn(actor.run());
 
@@ -168,6 +170,8 @@ struct RouterActor {
     client_sessions: HashMap<ClientId, ClientSession>,
     deferred_ensures: BTreeSet<TaskId>,
     deferred_scan: bool,
+    in_flight_model_calls: HashMap<(TaskId, ModelRunId), TaskRuntimeToken>,
+    in_flight_tool_executions: HashMap<(TaskId, ToolExecutionRunId), TaskRuntimeToken>,
 }
 
 struct RuntimeEntry {
@@ -712,6 +716,9 @@ impl RouterActor {
                 ModelCallStatusPhase::Failed,
             ),
         };
+        if !self.take_matching_model_call(&task_id, &model_call_id) {
+            return;
+        }
         let routed = self
             .route_to_runtime(&task_id, TaskRuntimeCommand::ApiModelReply(envelope))
             .await;
@@ -729,6 +736,9 @@ impl RouterActor {
 
     async fn route_tool_output(&mut self, result: ToolExecutionResult) {
         let task_id = result.task_id.clone();
+        if !self.take_matching_tool_execution(&task_id, &result.tool_execution_run_id) {
+            return;
+        }
         let status = ToolExecutionStatusRawEvent {
             task_id: result.task_id.clone(),
             tool_execution_run_id: result.tool_execution_run_id.clone(),
@@ -776,6 +786,7 @@ impl RouterActor {
                 return Err(());
             }
             self.runtimes.remove(task_id);
+            self.clear_in_flight_for_task(task_id);
             if removing {
                 self.clear_removal_effects_for_task(task_id);
                 self.retry_deferred_ensures();
@@ -812,6 +823,7 @@ impl RouterActor {
                 selvedge_command_model::TaskRuntimeExitReason::Stopped => {}
             }
             self.runtimes.remove(&notice.task_id);
+            self.clear_in_flight_for_task(&notice.task_id);
             self.clear_removal_effects_for_task(&notice.task_id);
             self.retry_deferred_ensures();
             self.retry_deferred_scan();
@@ -823,12 +835,20 @@ impl RouterActor {
         if !self.runtime_token_matches(&task_id, &envelope.runtime_token) {
             return;
         }
+        let runtime_token = envelope.runtime_token;
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
                 if !self.runtime_accepts_external_requests(&task_id) {
                     return;
                 }
                 let correlation = request.correlation.clone();
+                self.in_flight_model_calls.insert(
+                    (
+                        correlation.task_id.clone(),
+                        correlation.model_run_id.clone(),
+                    ),
+                    runtime_token.clone(),
+                );
                 self.send_model_call_status(
                     correlation.task_id.clone(),
                     correlation.model_run_id.clone(),
@@ -854,6 +874,13 @@ impl RouterActor {
                 if !self.runtime_accepts_external_requests(&task_id) {
                     return;
                 }
+                self.in_flight_tool_executions.insert(
+                    (
+                        request.task_id.clone(),
+                        request.tool_execution_run_id.clone(),
+                    ),
+                    runtime_token.clone(),
+                );
                 self.send_tool_execution_status(ToolExecutionStatusRawEvent {
                     task_id: request.task_id.clone(),
                     tool_execution_run_id: request.tool_execution_run_id.clone(),
@@ -954,6 +981,37 @@ impl RouterActor {
         self.runtimes
             .get(task_id)
             .is_some_and(|entry| &entry.runtime_token == runtime_token)
+    }
+
+    fn take_matching_model_call(&mut self, task_id: &TaskId, model_call_id: &ModelRunId) -> bool {
+        let key = (task_id.clone(), model_call_id.clone());
+        let Some(runtime_token) = self.in_flight_model_calls.remove(&key) else {
+            return false;
+        };
+        self.runtimes
+            .get(task_id)
+            .is_some_and(|entry| entry.runtime_token == runtime_token && !entry.removing)
+    }
+
+    fn take_matching_tool_execution(
+        &mut self,
+        task_id: &TaskId,
+        tool_execution_run_id: &ToolExecutionRunId,
+    ) -> bool {
+        let key = (task_id.clone(), tool_execution_run_id.clone());
+        let Some(runtime_token) = self.in_flight_tool_executions.remove(&key) else {
+            return false;
+        };
+        self.runtimes
+            .get(task_id)
+            .is_some_and(|entry| entry.runtime_token == runtime_token && !entry.removing)
+    }
+
+    fn clear_in_flight_for_task(&mut self, task_id: &TaskId) {
+        self.in_flight_model_calls
+            .retain(|(in_flight_task_id, _), _| in_flight_task_id != task_id);
+        self.in_flight_tool_executions
+            .retain(|(in_flight_task_id, _), _| in_flight_task_id != task_id);
     }
 
     fn finish_task_creation_effect(&mut self, effect: &LifecycleEffect) {
@@ -1303,6 +1361,8 @@ impl RouterActor {
         self.waiting_task_commands.clear();
         self.deferred_ensures.clear();
         self.deferred_scan = false;
+        self.in_flight_model_calls.clear();
+        self.in_flight_tool_executions.clear();
     }
 }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -820,6 +820,9 @@ impl RouterActor {
 
     async fn handle_core_output(&mut self, envelope: CoreOutputEnvelope) {
         let task_id = envelope.task_id;
+        if !self.runtime_token_matches(&task_id, &envelope.runtime_token) {
+            return;
+        }
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
                 if !self.runtime_accepts_external_requests(&task_id) {
@@ -945,6 +948,12 @@ impl RouterActor {
         self.runtimes
             .get(task_id)
             .is_some_and(|entry| !entry.removing)
+    }
+
+    fn runtime_token_matches(&self, task_id: &TaskId, runtime_token: &TaskRuntimeToken) -> bool {
+        self.runtimes
+            .get(task_id)
+            .is_some_and(|entry| &entry.runtime_token == runtime_token)
     }
 
     fn finish_task_creation_effect(&mut self, effect: &LifecycleEffect) {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -570,6 +570,7 @@ impl RouterActor {
                 }
                 self.retry_deferred_ensures();
                 self.retry_waiting_tasks_without_runtime();
+                self.retry_deferred_scan();
             }
             (LifecycleEffect::CreateTaskRuntime { task_id }, FactoryOutput::Failed(failure)) => {
                 let retryable = retryable_creation_failure(&failure.kind);
@@ -587,6 +588,7 @@ impl RouterActor {
                 if matches!(effect, LifecycleEffect::ScanMissingTaskRuntimes) {
                     self.retry_deferred_ensures();
                     self.retry_waiting_tasks_without_runtime();
+                    self.retry_deferred_scan();
                 }
             }
         }
@@ -898,7 +900,7 @@ impl RouterActor {
     }
 
     fn retry_deferred_scan(&mut self) {
-        if self.deferred_scan && !self.runtime_removal_in_flight() {
+        if self.deferred_scan && !self.runtime_removal_in_flight() && !self.scan_in_flight() {
             self.deferred_scan = false;
             self.ensure_missing_task_runtimes();
         }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -644,6 +644,7 @@ impl RouterActor {
                 .iter()
                 .any(|command| matches!(command, PendingTaskCommand::Archive));
             let is_stop = matches!(command, PendingTaskCommand::Stop);
+            let pending_command = command.clone();
             let runtime_command = match command {
                 PendingTaskCommand::UserInput { message_text } => {
                     TaskRuntimeCommand::UserInput { message_text }
@@ -664,6 +665,7 @@ impl RouterActor {
                 .is_err()
             {
                 self.runtimes.remove(&task_id);
+                self.requeue_failed_flush(task_id.clone(), pending_command, commands);
                 break;
             }
             if is_stop && has_later_archive {
@@ -867,7 +869,6 @@ impl RouterActor {
             FactoryCommand::EnsureTaskRuntime(command) => {
                 self.effects.remove(&command.effect_id);
                 self.pending_creations_by_task.remove(&command.task_id);
-                self.waiting_task_commands.remove(&command.task_id);
                 self.deferred_ensures.remove(&command.task_id);
                 self.try_send_debug_notice(
                     Some(command.task_id),
@@ -945,6 +946,19 @@ impl RouterActor {
             self.deferred_scan = false;
             self.ensure_missing_task_runtimes();
         }
+    }
+
+    fn requeue_failed_flush(
+        &mut self,
+        task_id: TaskId,
+        command: PendingTaskCommand,
+        mut remaining: VecDeque<PendingTaskCommand>,
+    ) {
+        let mut commands = VecDeque::new();
+        commands.push_back(command);
+        commands.append(&mut remaining);
+        self.waiting_task_commands.insert(task_id.clone(), commands);
+        self.ensure_task_runtime(task_id);
     }
 
     async fn send_failure_notice(&mut self, failure: FactoryFailure) {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -140,6 +140,7 @@ pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterEr
         waiting_task_commands: BTreeMap::new(),
         client_sessions: HashMap::new(),
         deferred_ensures: BTreeSet::new(),
+        deferred_scan: false,
     };
     let join_handle = tokio::spawn(actor.run());
 
@@ -164,6 +165,7 @@ struct RouterActor {
     waiting_task_commands: BTreeMap<TaskId, VecDeque<PendingTaskCommand>>,
     client_sessions: HashMap<ClientId, ClientSession>,
     deferred_ensures: BTreeSet<TaskId>,
+    deferred_scan: bool,
 }
 
 struct RuntimeEntry {
@@ -497,6 +499,10 @@ impl RouterActor {
     }
 
     fn ensure_missing_task_runtimes(&mut self) {
+        if self.runtime_removal_in_flight() {
+            self.deferred_scan = true;
+            return;
+        }
         let has_scan = self
             .effects
             .values()
@@ -706,6 +712,7 @@ impl RouterActor {
             self.runtimes.remove(&notice.task_id);
             self.clear_removal_effects_for_task(&notice.task_id);
             self.retry_deferred_ensures();
+            self.retry_deferred_scan();
         }
     }
 
@@ -795,6 +802,10 @@ impl RouterActor {
             .any(|effect| matches!(effect, LifecycleEffect::ScanMissingTaskRuntimes))
     }
 
+    fn runtime_removal_in_flight(&self) -> bool {
+        self.runtimes.values().any(|entry| entry.removing)
+    }
+
     fn finish_task_creation_effect(&mut self, effect: &LifecycleEffect) {
         if let LifecycleEffect::CreateTaskRuntime { task_id } = effect {
             self.pending_creations_by_task.remove(task_id);
@@ -869,6 +880,13 @@ impl RouterActor {
             {
                 self.ensure_task_runtime(task_id);
             }
+        }
+    }
+
+    fn retry_deferred_scan(&mut self) {
+        if self.deferred_scan && !self.runtime_removal_in_flight() {
+            self.deferred_scan = false;
+            self.ensure_missing_task_runtimes();
         }
     }
 
@@ -1078,6 +1096,7 @@ impl RouterActor {
         self.effects.clear();
         self.waiting_task_commands.clear();
         self.deferred_ensures.clear();
+        self.deferred_scan = false;
     }
 }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -822,6 +822,9 @@ impl RouterActor {
         let task_id = envelope.task_id;
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
+                if !self.runtime_accepts_external_requests(&task_id) {
+                    return;
+                }
                 let correlation = request.correlation.clone();
                 self.send_model_call_status(
                     correlation.task_id.clone(),
@@ -845,6 +848,9 @@ impl RouterActor {
                 }
             }
             CoreOutputMessage::RequestToolExecution(request) => {
+                if !self.runtime_accepts_external_requests(&task_id) {
+                    return;
+                }
                 self.send_tool_execution_status(ToolExecutionStatusRawEvent {
                     task_id: request.task_id.clone(),
                     tool_execution_run_id: request.tool_execution_run_id.clone(),
@@ -933,6 +939,12 @@ impl RouterActor {
 
     fn runtime_removal_in_flight(&self) -> bool {
         self.runtimes.values().any(|entry| entry.removing)
+    }
+
+    fn runtime_accepts_external_requests(&self, task_id: &TaskId) -> bool {
+        self.runtimes
+            .get(task_id)
+            .is_some_and(|entry| !entry.removing)
     }
 
     fn finish_task_creation_effect(&mut self, effect: &LifecycleEffect) {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -1,0 +1,814 @@
+#![doc = include_str!("../README.md")]
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use selvedge_api::ModelProviderRegistry;
+use selvedge_command_model::{
+    ApiOutputEnvelope, ArchiveTask, ClientCommand, ClientCommandEnvelope, ClientCommandId,
+    ClientNotice, ClientNoticeLevel, ClientSnapshot, CoreOutputEnvelope, CoreOutputMessage,
+    DeliverNotice, DeliverSnapshot, EventControlMessage, EventIngress, EventIngressSender,
+    FactoryEffectId, FactoryFailure, FactoryOutput, FactoryOutputEnvelope, HistoryNodeProjection,
+    ModelCallDispatchRequest, RouterIngressMessage, RouterIngressSender, RouterShutdown,
+    RuntimeInventoryQuery, RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime,
+    SubmitUserInput, TaskId, TaskParentProjection, TaskProjection, TaskProjectionStatus,
+    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender,
+    TaskRuntimeToken, ToolExecutionRequest, ToolExecutionResult,
+};
+use selvedge_db::{DbPool, TaskStatusRow, UnixTs};
+use selvedge_task_runtime_factory::{
+    CreateChildTaskAndRuntimeCommand, EnsureMissingTaskRuntimesCommand, EnsureTaskRuntimeCommand,
+    FactoryCommand, SpawnFactoryEffectError,
+};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct RouterStartArgs {
+    pub db: DbPool,
+    pub events_tx: EventIngressSender,
+    pub factory_executor: Arc<dyn FactoryExecutor>,
+    pub api_executor: Arc<dyn ApiExecutor>,
+    pub tool_executor: Arc<dyn ToolExecutor>,
+    pub ingress_capacity: usize,
+    pub pending_task_command_limit: usize,
+}
+
+#[derive(Debug)]
+pub struct RouterHandle {
+    pub router_tx: RouterIngressSender,
+    pub join_handle: JoinHandle<()>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpawnRouterError {
+    MissingDbHandle,
+    MissingEventsSender,
+    MissingFactoryExecutor,
+    MissingApiExecutor,
+    MissingToolExecutor,
+    InvalidIngressCapacity,
+    InvalidPendingTaskCommandLimit,
+    TokioSpawnFailed,
+}
+
+#[derive(Clone)]
+pub struct FactorySpawnRequest {
+    pub command: FactoryCommand,
+    pub db: DbPool,
+    pub router_tx: RouterIngressSender,
+}
+
+pub trait FactoryExecutor: Send + Sync {
+    fn spawn_factory_effect(
+        &self,
+        request: FactorySpawnRequest,
+    ) -> Result<JoinHandle<()>, SpawnFactoryEffectError>;
+}
+
+pub trait ApiExecutor: Send + Sync {
+    fn spawn_model_call(
+        &self,
+        request: ModelCallDispatchRequest,
+        router_tx: RouterIngressSender,
+    ) -> Result<JoinHandle<()>, SpawnApiEffectError>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpawnApiEffectError {
+    TokioSpawnFailed,
+}
+
+pub trait ToolExecutor: Send + Sync {
+    fn spawn_tool_execution(
+        &self,
+        request: ToolExecutionRequest,
+        router_tx: RouterIngressSender,
+    ) -> Result<JoinHandle<()>, SpawnToolEffectError>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpawnToolEffectError {
+    TokioSpawnFailed,
+}
+
+pub struct TokioApiExecutor {
+    pub provider_registry: Arc<dyn ModelProviderRegistry>,
+    pub config: selvedge_api::ApiExecutorConfig,
+}
+
+impl ApiExecutor for TokioApiExecutor {
+    fn spawn_model_call(
+        &self,
+        request: ModelCallDispatchRequest,
+        router_tx: RouterIngressSender,
+    ) -> Result<JoinHandle<()>, SpawnApiEffectError> {
+        let provider_registry = self.provider_registry.clone();
+        let config = self.config.clone();
+        Ok(tokio::spawn(async move {
+            selvedge_api::execute_model_call(request, router_tx, provider_registry, config).await;
+        }))
+    }
+}
+
+pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterError> {
+    if args.ingress_capacity == 0 {
+        return Err(SpawnRouterError::InvalidIngressCapacity);
+    }
+    if args.pending_task_command_limit == 0 {
+        return Err(SpawnRouterError::InvalidPendingTaskCommandLimit);
+    }
+
+    let (router_tx, router_rx) = mpsc::channel(args.ingress_capacity);
+    let actor = RouterActor {
+        db: args.db,
+        events_tx: args.events_tx,
+        factory_executor: args.factory_executor,
+        api_executor: args.api_executor,
+        tool_executor: args.tool_executor,
+        router_tx: router_tx.clone(),
+        router_rx,
+        pending_task_command_limit: args.pending_task_command_limit,
+        runtimes: BTreeMap::new(),
+        pending_creations_by_task: BTreeMap::new(),
+        effects: HashMap::new(),
+        waiting_task_commands: BTreeMap::new(),
+    };
+    let join_handle = tokio::spawn(actor.run());
+
+    Ok(RouterHandle {
+        router_tx,
+        join_handle,
+    })
+}
+
+struct RouterActor {
+    db: DbPool,
+    events_tx: EventIngressSender,
+    factory_executor: Arc<dyn FactoryExecutor>,
+    api_executor: Arc<dyn ApiExecutor>,
+    tool_executor: Arc<dyn ToolExecutor>,
+    router_tx: RouterIngressSender,
+    router_rx: mpsc::Receiver<RouterIngressMessage>,
+    pending_task_command_limit: usize,
+    runtimes: BTreeMap<TaskId, RuntimeEntry>,
+    pending_creations_by_task: BTreeMap<TaskId, FactoryEffectId>,
+    effects: HashMap<FactoryEffectId, LifecycleEffect>,
+    waiting_task_commands: BTreeMap<TaskId, VecDeque<PendingTaskCommand>>,
+}
+
+struct RuntimeEntry {
+    runtime_token: TaskRuntimeToken,
+    task_runtime_tx: TaskRuntimeSender,
+    removing: bool,
+}
+
+enum LifecycleEffect {
+    CreateTaskRuntime { task_id: TaskId },
+    CreateChildTaskRuntime,
+    ScanMissingTaskRuntimes,
+    RemoveTaskRuntime { task_id: TaskId },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PendingTaskCommand {
+    UserInput { message_text: String },
+    Archive,
+    Stop,
+}
+
+impl RouterActor {
+    async fn run(mut self) {
+        while let Some(message) = self.router_rx.recv().await {
+            if matches!(message, RouterIngressMessage::Shutdown(RouterShutdown)) {
+                self.stop();
+                break;
+            }
+            self.handle_message(message).await;
+        }
+    }
+
+    async fn handle_message(&mut self, message: RouterIngressMessage) {
+        match message {
+            RouterIngressMessage::Client(envelope) => self.handle_client_command(envelope).await,
+            RouterIngressMessage::Factory(envelope) => self.handle_factory_output(envelope).await,
+            RouterIngressMessage::RuntimeInventoryQuery(query) => {
+                self.answer_runtime_inventory(query);
+            }
+            RouterIngressMessage::Api(envelope) => self.route_api_output(envelope).await,
+            RouterIngressMessage::Tool(result) => self.route_tool_output(result).await,
+            RouterIngressMessage::RuntimeExit(notice) => self.handle_runtime_exit(notice),
+            RouterIngressMessage::Core(envelope) => self.handle_core_output(envelope).await,
+            RouterIngressMessage::PublishToEvents(event) => {
+                let _ = self
+                    .events_tx
+                    .send(EventIngress::Raw(domain_event_to_raw(event)))
+                    .await;
+            }
+            RouterIngressMessage::Shutdown(_) => {}
+        }
+    }
+
+    async fn handle_client_command(&mut self, envelope: ClientCommandEnvelope) {
+        match envelope.command {
+            ClientCommand::SubmitUserInput(input) => {
+                self.handle_submit_user_input(envelope.client_id, envelope.command_id, input)
+                    .await;
+            }
+            ClientCommand::ArchiveTask(input) => {
+                self.handle_archive_task(envelope.client_id, envelope.command_id, input)
+                    .await;
+            }
+            ClientCommand::StopTaskRuntime(input) => {
+                self.handle_stop_task_runtime(envelope.client_id, envelope.command_id, input)
+                    .await;
+            }
+            ClientCommand::EnsureTaskRuntime(input) => {
+                self.ensure_task_runtime(input.task_id);
+            }
+            ClientCommand::EnsureMissingTaskRuntimes(_) => {
+                self.ensure_missing_task_runtimes();
+            }
+            ClientCommand::CreateChildTaskAndRuntime(input) => {
+                let effect_id = FactoryEffectId(format!("router-child-{}", Uuid::new_v4()));
+                if self.effects.contains_key(&effect_id) {
+                    return;
+                }
+                self.effects
+                    .insert(effect_id.clone(), LifecycleEffect::CreateChildTaskRuntime);
+                let command =
+                    FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
+                        effect_id,
+                        parent_task_id: input.parent_task_id,
+                        child_cursor_node_id: input.child_cursor_node_id,
+                    });
+                self.spawn_factory(command);
+            }
+            ClientCommand::AttachClient(input) => {
+                let client_id = input.client_id.clone();
+                let _ = self
+                    .events_tx
+                    .send(EventIngress::Control(
+                        EventControlMessage::BeginClientHydration(
+                            selvedge_command_model::BeginClientHydration {
+                                client_id: input.client_id,
+                                client_command_id: envelope.command_id.clone(),
+                                outbound: input.output_tx,
+                                subscription: input.subscription,
+                            },
+                        ),
+                    ))
+                    .await;
+                self.deliver_snapshot(client_id, envelope.command_id).await;
+            }
+            ClientCommand::RefreshClientSnapshot(input) => {
+                self.deliver_snapshot(input.client_id, envelope.command_id)
+                    .await;
+            }
+            ClientCommand::UpdateClientSubscription(input) => {
+                let _ = self
+                    .events_tx
+                    .send(EventIngress::Control(
+                        EventControlMessage::UpdateSubscription(
+                            selvedge_command_model::UpdateSubscription {
+                                client_id: input.client_id,
+                                client_command_id: envelope.command_id,
+                                subscription: input.subscription,
+                            },
+                        ),
+                    ))
+                    .await;
+            }
+            ClientCommand::DetachClient(input) => {
+                let _ = self
+                    .events_tx
+                    .send(EventIngress::Control(EventControlMessage::DetachClient(
+                        selvedge_command_model::DetachClient {
+                            client_id: input.client_id,
+                            client_command_id: envelope.command_id,
+                            reason: selvedge_command_model::DetachReason::ClientRequested,
+                        },
+                    )))
+                    .await;
+            }
+        }
+    }
+
+    async fn handle_submit_user_input(
+        &mut self,
+        client_id: Option<selvedge_command_model::ClientId>,
+        command_id: ClientCommandId,
+        input: SubmitUserInput,
+    ) {
+        let task_id = input.task_id;
+        if self.runtime_is_removing(&task_id) {
+            if let Some(client_id) = client_id {
+                self.send_notice(
+                    client_id,
+                    command_id,
+                    ClientNoticeLevel::Warning,
+                    "task runtime is stopping",
+                )
+                .await;
+            }
+            return;
+        }
+
+        if self.runtimes.contains_key(&task_id) {
+            let command = TaskRuntimeCommand::UserInput {
+                message_text: input.message_text.clone(),
+            };
+            if self.route_to_runtime(&task_id, command).await.is_err() {
+                self.enqueue_waiting_command(
+                    task_id.clone(),
+                    PendingTaskCommand::UserInput {
+                        message_text: input.message_text,
+                    },
+                );
+                self.ensure_task_runtime(task_id);
+            }
+            return;
+        }
+
+        self.enqueue_waiting_command(
+            task_id.clone(),
+            PendingTaskCommand::UserInput {
+                message_text: input.message_text,
+            },
+        );
+        self.ensure_task_runtime(task_id);
+    }
+
+    async fn handle_archive_task(
+        &mut self,
+        client_id: Option<selvedge_command_model::ClientId>,
+        command_id: ClientCommandId,
+        input: ArchiveTask,
+    ) {
+        self.handle_removal_command(
+            client_id,
+            command_id,
+            input.task_id,
+            PendingTaskCommand::Archive,
+            TaskRuntimeCommand::Archive,
+        )
+        .await;
+    }
+
+    async fn handle_stop_task_runtime(
+        &mut self,
+        client_id: Option<selvedge_command_model::ClientId>,
+        command_id: ClientCommandId,
+        input: StopTaskRuntime,
+    ) {
+        self.handle_removal_command(
+            client_id,
+            command_id,
+            input.task_id,
+            PendingTaskCommand::Stop,
+            TaskRuntimeCommand::Stop,
+        )
+        .await;
+    }
+
+    async fn handle_removal_command(
+        &mut self,
+        client_id: Option<selvedge_command_model::ClientId>,
+        command_id: ClientCommandId,
+        task_id: TaskId,
+        pending: PendingTaskCommand,
+        runtime_command: TaskRuntimeCommand,
+    ) {
+        if self.runtime_is_removing(&task_id) {
+            return;
+        }
+
+        if let Some(entry) = self.runtimes.get_mut(&task_id) {
+            entry.removing = true;
+            let effect_id = FactoryEffectId(format!("router-remove-{}", Uuid::new_v4()));
+            self.effects.insert(
+                effect_id,
+                LifecycleEffect::RemoveTaskRuntime {
+                    task_id: task_id.clone(),
+                },
+            );
+            if self
+                .route_to_runtime(&task_id, runtime_command)
+                .await
+                .is_err()
+            {
+                self.runtimes.remove(&task_id);
+                self.clear_removal_effects_for_task(&task_id);
+            }
+            return;
+        }
+
+        if self.pending_creations_by_task.contains_key(&task_id) {
+            self.enqueue_waiting_command(task_id, pending);
+            return;
+        }
+
+        if let Some(client_id) = client_id {
+            self.send_notice(
+                client_id,
+                command_id,
+                ClientNoticeLevel::Warning,
+                "task runtime is not live",
+            )
+            .await;
+        }
+    }
+
+    fn ensure_task_runtime(&mut self, task_id: TaskId) {
+        if self.runtimes.contains_key(&task_id)
+            || self.pending_creations_by_task.contains_key(&task_id)
+        {
+            return;
+        }
+        let effect_id = FactoryEffectId(format!("router-create-{}", Uuid::new_v4()));
+        self.pending_creations_by_task
+            .insert(task_id.clone(), effect_id.clone());
+        self.effects.insert(
+            effect_id.clone(),
+            LifecycleEffect::CreateTaskRuntime {
+                task_id: task_id.clone(),
+            },
+        );
+        self.spawn_factory(FactoryCommand::EnsureTaskRuntime(
+            EnsureTaskRuntimeCommand { effect_id, task_id },
+        ));
+    }
+
+    fn ensure_missing_task_runtimes(&mut self) {
+        let has_scan = self
+            .effects
+            .values()
+            .any(|effect| matches!(effect, LifecycleEffect::ScanMissingTaskRuntimes));
+        if has_scan {
+            return;
+        }
+        let effect_id = FactoryEffectId(format!("router-scan-{}", Uuid::new_v4()));
+        self.effects
+            .insert(effect_id.clone(), LifecycleEffect::ScanMissingTaskRuntimes);
+        self.spawn_factory(FactoryCommand::EnsureMissingTaskRuntimes(
+            EnsureMissingTaskRuntimesCommand { effect_id },
+        ));
+    }
+
+    fn spawn_factory(&mut self, command: FactoryCommand) {
+        let request = FactorySpawnRequest {
+            command,
+            db: self.db.clone(),
+            router_tx: self.router_tx.clone(),
+        };
+        if self.factory_executor.spawn_factory_effect(request).is_err() {
+            self.clear_failed_factory_spawn();
+        }
+    }
+
+    async fn handle_factory_output(&mut self, envelope: FactoryOutputEnvelope) {
+        let Some(effect) = self.effects.remove(&envelope.effect_id) else {
+            return;
+        };
+
+        match (&effect, envelope.output) {
+            (_, FactoryOutput::RuntimeCreated(created)) => {
+                self.finish_task_creation_effect(&effect);
+                self.register_created_runtime(created.task_id, created.runtime)
+                    .await;
+            }
+            (_, FactoryOutput::ScanFinished(scan)) => {
+                for created in scan.created {
+                    self.register_created_runtime(created.task_id, created.runtime)
+                        .await;
+                }
+            }
+            (LifecycleEffect::CreateTaskRuntime { task_id }, FactoryOutput::Failed(failure)) => {
+                self.pending_creations_by_task.remove(task_id);
+                self.waiting_task_commands.remove(task_id);
+                self.send_failure_notice(failure).await;
+            }
+            (LifecycleEffect::CreateChildTaskRuntime, FactoryOutput::Failed(failure)) => {
+                self.send_failure_notice(failure).await;
+            }
+            (_, FactoryOutput::Failed(failure)) => {
+                self.send_failure_notice(failure).await;
+            }
+        }
+    }
+
+    async fn register_created_runtime(&mut self, task_id: TaskId, runtime: TaskRuntimeHandle) {
+        self.pending_creations_by_task.remove(&task_id);
+        if self.runtimes.contains_key(&task_id) {
+            return;
+        }
+
+        let entry = RuntimeEntry {
+            runtime_token: runtime.runtime_token,
+            task_runtime_tx: runtime.task_runtime_tx,
+            removing: false,
+        };
+        self.runtimes.insert(task_id.clone(), entry);
+
+        if self
+            .route_to_runtime(&task_id, TaskRuntimeCommand::Start)
+            .await
+            .is_err()
+        {
+            self.runtimes.remove(&task_id);
+            self.waiting_task_commands.remove(&task_id);
+            return;
+        }
+
+        self.flush_waiting_commands(task_id).await;
+    }
+
+    async fn flush_waiting_commands(&mut self, task_id: TaskId) {
+        let Some(commands) = self.waiting_task_commands.remove(&task_id) else {
+            return;
+        };
+
+        for command in commands {
+            let runtime_command = match command {
+                PendingTaskCommand::UserInput { message_text } => {
+                    TaskRuntimeCommand::UserInput { message_text }
+                }
+                PendingTaskCommand::Archive => TaskRuntimeCommand::Archive,
+                PendingTaskCommand::Stop => TaskRuntimeCommand::Stop,
+            };
+            if matches!(
+                runtime_command,
+                TaskRuntimeCommand::Archive | TaskRuntimeCommand::Stop
+            ) && let Some(entry) = self.runtimes.get_mut(&task_id)
+            {
+                entry.removing = true;
+            }
+            if self
+                .route_to_runtime(&task_id, runtime_command)
+                .await
+                .is_err()
+            {
+                self.runtimes.remove(&task_id);
+                break;
+            }
+        }
+    }
+
+    async fn route_api_output(&mut self, envelope: ApiOutputEnvelope) {
+        let task_id = match &envelope {
+            ApiOutputEnvelope::Success { correlation, .. }
+            | ApiOutputEnvelope::Failure { correlation, .. } => correlation.task_id.clone(),
+        };
+        let _ = self
+            .route_to_runtime(&task_id, TaskRuntimeCommand::ApiModelReply(envelope))
+            .await;
+    }
+
+    async fn route_tool_output(&mut self, result: ToolExecutionResult) {
+        let task_id = result.task_id.clone();
+        let _ = self
+            .route_to_runtime(&task_id, TaskRuntimeCommand::ToolResult(result))
+            .await;
+    }
+
+    async fn route_to_runtime(
+        &mut self,
+        task_id: &TaskId,
+        command: TaskRuntimeCommand,
+    ) -> Result<(), ()> {
+        let Some(sender) = self
+            .runtimes
+            .get(task_id)
+            .map(|entry| entry.task_runtime_tx.clone())
+        else {
+            return Err(());
+        };
+
+        if sender.send(command).await.is_err() {
+            self.runtimes.remove(task_id);
+            return Err(());
+        }
+        Ok(())
+    }
+
+    fn handle_runtime_exit(&mut self, notice: TaskRuntimeExitNotice) {
+        let should_remove = self
+            .runtimes
+            .get(&notice.task_id)
+            .is_some_and(|entry| entry.runtime_token == notice.runtime_token);
+        if should_remove {
+            self.runtimes.remove(&notice.task_id);
+            self.clear_removal_effects_for_task(&notice.task_id);
+        }
+    }
+
+    async fn handle_core_output(&mut self, envelope: CoreOutputEnvelope) {
+        match envelope.message {
+            CoreOutputMessage::RequestModelCall(request) => {
+                let _ = self
+                    .api_executor
+                    .spawn_model_call(request, self.router_tx.clone());
+            }
+            CoreOutputMessage::RequestToolExecution(request) => {
+                let _ = self
+                    .tool_executor
+                    .spawn_tool_execution(request, self.router_tx.clone());
+            }
+            CoreOutputMessage::PublishDomainEvent(event) => {
+                let _ = self
+                    .events_tx
+                    .send(EventIngress::Raw(domain_event_to_raw(event)))
+                    .await;
+            }
+            CoreOutputMessage::RuntimeReady => {}
+        }
+    }
+
+    fn answer_runtime_inventory(&mut self, query: RuntimeInventoryQuery) {
+        let response = RuntimeInventoryResponse {
+            live_task_runtimes: self.runtimes.keys().cloned().collect(),
+            pending_task_runtime_effects: self.pending_creations_by_task.keys().cloned().collect(),
+        };
+        let _ = query.reply_to.send(response);
+    }
+
+    fn enqueue_waiting_command(&mut self, task_id: TaskId, command: PendingTaskCommand) {
+        let queue = self.waiting_task_commands.entry(task_id).or_default();
+        if queue.len() < self.pending_task_command_limit {
+            queue.push_back(command);
+        }
+    }
+
+    fn runtime_is_removing(&self, task_id: &TaskId) -> bool {
+        self.runtimes
+            .get(task_id)
+            .is_some_and(|entry| entry.removing)
+    }
+
+    fn finish_task_creation_effect(&mut self, effect: &LifecycleEffect) {
+        if let LifecycleEffect::CreateTaskRuntime { task_id } = effect {
+            self.pending_creations_by_task.remove(task_id);
+        }
+    }
+
+    fn clear_removal_effects_for_task(&mut self, task_id: &TaskId) {
+        self.effects.retain(|_, effect| {
+            !matches!(
+                effect,
+                LifecycleEffect::RemoveTaskRuntime {
+                    task_id: effect_task_id,
+                } if effect_task_id == task_id
+            )
+        });
+    }
+
+    fn clear_failed_factory_spawn(&mut self) {
+        self.effects.clear();
+        self.pending_creations_by_task.clear();
+        self.waiting_task_commands.clear();
+    }
+
+    async fn send_failure_notice(&mut self, failure: FactoryFailure) {
+        let task_id = failure.task_id;
+        let message_text = format!("{:?}: {}", failure.kind, failure.message);
+        let _ = self
+            .events_tx
+            .send(EventIngress::Raw(selvedge_command_model::RawEvent::Debug(
+                selvedge_command_model::DebugRawEvent {
+                    task_id,
+                    message_text,
+                },
+            )))
+            .await;
+    }
+
+    async fn send_notice(
+        &mut self,
+        client_id: selvedge_command_model::ClientId,
+        command_id: ClientCommandId,
+        level: ClientNoticeLevel,
+        message_text: &str,
+    ) {
+        let _ = self
+            .events_tx
+            .send(EventIngress::Control(EventControlMessage::DeliverNotice(
+                DeliverNotice {
+                    client_id,
+                    client_command_id: command_id,
+                    notice: ClientNotice {
+                        level,
+                        message_text: message_text.to_owned(),
+                    },
+                },
+            )))
+            .await;
+    }
+
+    async fn deliver_snapshot(
+        &mut self,
+        client_id: selvedge_command_model::ClientId,
+        command_id: ClientCommandId,
+    ) {
+        match self.build_snapshot() {
+            Ok(snapshot) => {
+                let _ = self
+                    .events_tx
+                    .send(EventIngress::Control(EventControlMessage::DeliverSnapshot(
+                        DeliverSnapshot {
+                            client_id,
+                            client_command_id: command_id,
+                            snapshot,
+                        },
+                    )))
+                    .await;
+            }
+            Err(error) => {
+                self.send_notice(
+                    client_id,
+                    command_id,
+                    ClientNoticeLevel::Error,
+                    &format!("snapshot read failed: {error}"),
+                )
+                .await;
+            }
+        }
+    }
+
+    fn build_snapshot(&self) -> Result<ClientSnapshot, selvedge_db::DbError> {
+        let tasks = selvedge_db::list_active_tasks(&self.db)?;
+        let task_parent_edges = selvedge_db::read_task_parent_edges(&self.db)?;
+        let task_versions = tasks
+            .iter()
+            .map(|task| SnapshotTaskVersion {
+                task_id: task.task_id.clone(),
+                state_version: task.state_version,
+            })
+            .collect();
+        let tasks = tasks
+            .into_iter()
+            .map(|task| TaskProjection {
+                task_id: task.task_id,
+                status: match task.task_status {
+                    TaskStatusRow::Active => TaskProjectionStatus::Active,
+                    TaskStatusRow::Archived => TaskProjectionStatus::Archived,
+                },
+                cursor_node_id: task.cursor_node_id,
+                model_profile_key: task.model_profile_key,
+                reasoning_effort: task.reasoning_effort,
+                state_version: task.state_version,
+                created_at: task.created_at,
+                updated_at: task.updated_at,
+            })
+            .collect();
+        let task_parent_edges = task_parent_edges
+            .into_iter()
+            .map(|edge| TaskParentProjection {
+                parent_task_id: edge.parent_task_id,
+                child_task_id: edge.child_task_id,
+            })
+            .collect();
+
+        Ok(ClientSnapshot {
+            generated_at: now(),
+            tasks,
+            task_parent_edges,
+            history_nodes: Vec::<HistoryNodeProjection>::new(),
+            task_versions,
+        })
+    }
+
+    fn stop(&mut self) {
+        self.runtimes.clear();
+        self.pending_creations_by_task.clear();
+        self.effects.clear();
+        self.waiting_task_commands.clear();
+    }
+}
+
+fn now() -> UnixTs {
+    UnixTs(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0),
+    )
+}
+
+fn domain_event_to_raw(
+    event: selvedge_command_model::DomainEventPublishRequest,
+) -> selvedge_command_model::RawEvent {
+    match event.event {
+        selvedge_command_model::DomainEvent::ErrorNotice { message } => {
+            selvedge_command_model::RawEvent::Debug(selvedge_command_model::DebugRawEvent {
+                task_id: Some(event.task_id),
+                message_text: message,
+            })
+        }
+        other => selvedge_command_model::RawEvent::Debug(selvedge_command_model::DebugRawEvent {
+            task_id: Some(event.task_id),
+            message_text: format!("{other:?}"),
+        }),
+    }
+}

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -288,7 +288,7 @@ impl RouterActor {
                         ),
                     ))
                     .await;
-                self.deliver_snapshot(client_id, envelope.command_id, Some(subscription))
+                self.deliver_snapshot(client_id, envelope.command_id, Some(subscription), true)
                     .await;
             }
             ClientCommand::RefreshClientSnapshot(input) => {
@@ -298,7 +298,7 @@ impl RouterActor {
                     .map(|session| session.command_id.clone())
                     .unwrap_or(envelope.command_id);
                 let subscription = session.map(|session| session.subscription);
-                self.deliver_snapshot(input.client_id, command_id, subscription)
+                self.deliver_snapshot(input.client_id, command_id, subscription, false)
                     .await;
             }
             ClientCommand::UpdateClientSubscription(input) => {
@@ -913,6 +913,9 @@ impl RouterActor {
                 }
             }
             CoreOutputMessage::PublishDomainEvent(event) => {
+                if event.task_id != task_id {
+                    return;
+                }
                 let raw = self.domain_event_to_raw(event);
                 let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
             }
@@ -1201,6 +1204,7 @@ impl RouterActor {
         client_id: selvedge_command_model::ClientId,
         command_id: ClientCommandId,
         subscription: Option<ClientSubscription>,
+        detach_on_failure: bool,
     ) {
         match self.build_snapshot(subscription.as_ref()) {
             Ok(snapshot) => {
@@ -1217,12 +1221,25 @@ impl RouterActor {
             }
             Err(error) => {
                 self.send_notice(
-                    client_id,
-                    command_id,
+                    client_id.clone(),
+                    command_id.clone(),
                     ClientNoticeLevel::Error,
                     &format!("snapshot read failed: {error}"),
                 )
                 .await;
+                if detach_on_failure {
+                    let _ = self
+                        .events_tx
+                        .send(EventIngress::Control(EventControlMessage::DetachClient(
+                            selvedge_command_model::DetachClient {
+                                client_id: client_id.clone(),
+                                client_command_id: command_id,
+                                reason: selvedge_command_model::DetachReason::DeliveryFailed,
+                            },
+                        )))
+                        .await;
+                    self.client_sessions.remove(&client_id);
+                }
             }
         }
     }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -628,8 +628,8 @@ impl RouterActor {
             .get(task_id)
             .is_none_or(|commands| {
                 commands
-                    .iter()
-                    .any(|command| matches!(command, PendingTaskCommand::UserInput { .. }))
+                    .front()
+                    .is_some_and(|command| matches!(command, PendingTaskCommand::UserInput { .. }))
             })
     }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -8,15 +8,15 @@ use selvedge_api::ModelProviderRegistry;
 use selvedge_command_model::{
     ApiOutputEnvelope, ArchiveTask, ClientCommand, ClientCommandEnvelope, ClientCommandId,
     ClientId, ClientNotice, ClientNoticeLevel, ClientSnapshot, ClientSubscription,
-    CoreOutputEnvelope, CoreOutputMessage, DeliverNotice, DeliverSnapshot, DomainEvent,
-    DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
-    FactoryEffectId, FactoryFailure, FactoryOutput, FactoryOutputEnvelope, HistoryNodeProjection,
-    HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind,
-    RawEvent, RouterIngressMessage, RouterIngressSender, RouterShutdown, RuntimeInventoryQuery,
-    RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime, SubmitUserInput, TaskId,
-    TaskParentProjection, TaskProjection, TaskProjectionStatus, TaskRuntimeCommand,
-    TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender, TaskRuntimeToken, TaskScope,
-    ToolExecutionRequest, ToolExecutionResult,
+    CoreOutputEnvelope, CoreOutputMessage, DeliverNotice, DeliverSnapshot, DetailLevel,
+    DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
+    FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope,
+    HistoryNodeProjection, HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelCallError,
+    ModelCallErrorKind, RawEvent, RouterIngressMessage, RouterIngressSender, RouterShutdown,
+    RuntimeInventoryQuery, RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime,
+    SubmitUserInput, TaskId, TaskParentProjection, TaskProjection, TaskProjectionStatus,
+    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender,
+    TaskRuntimeToken, TaskScope, ToolExecutionRequest, ToolExecutionResult,
 };
 use selvedge_db::{DbPool, HistoryNode, TaskRow, TaskStatusRow, UnixTs};
 use selvedge_domain_model::HistoryNodeId;
@@ -544,8 +544,11 @@ impl RouterActor {
                 self.retry_waiting_tasks_without_runtime();
             }
             (LifecycleEffect::CreateTaskRuntime { task_id }, FactoryOutput::Failed(failure)) => {
+                let retryable = retryable_creation_failure(&failure.kind);
                 self.pending_creations_by_task.remove(task_id);
-                self.waiting_task_commands.remove(task_id);
+                if !retryable {
+                    self.waiting_task_commands.remove(task_id);
+                }
                 self.send_failure_notice(failure).await;
             }
             (LifecycleEffect::CreateChildTaskRuntime, FactoryOutput::Failed(failure)) => {
@@ -935,6 +938,22 @@ impl RouterActor {
                 state_version: task.state_version,
             })
             .collect();
+        let history_nodes = if subscription
+            .is_some_and(|subscription| subscription.detail_level == DetailLevel::Verbose)
+        {
+            let mut seen_node_ids = HashSet::new();
+            let mut history_nodes = Vec::new();
+            for task in &tasks {
+                for node in selvedge_db::read_history_path_for_task(&self.db, &task.task_id)? {
+                    if seen_node_ids.insert(node.node_id()) {
+                        history_nodes.push(history_node_projection(node));
+                    }
+                }
+            }
+            history_nodes
+        } else {
+            Vec::new()
+        };
         let tasks = tasks
             .into_iter()
             .map(|task| TaskProjection {
@@ -967,7 +986,7 @@ impl RouterActor {
             generated_at: now(),
             tasks,
             task_parent_edges,
-            history_nodes: Vec::<HistoryNodeProjection>::new(),
+            history_nodes,
             task_versions,
         })
     }
@@ -1041,6 +1060,13 @@ fn now() -> UnixTs {
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_secs() as i64)
             .unwrap_or(0),
+    )
+}
+
+fn retryable_creation_failure(kind: &FactoryFailureKind) -> bool {
+    matches!(
+        kind,
+        FactoryFailureKind::RuntimeInventoryUnavailable | FactoryFailureKind::CoreSpawnFailed
     )
 }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -350,6 +350,19 @@ impl RouterActor {
             return;
         }
 
+        if self.waiting_queue_has_removal(&task_id) {
+            if let Some(client_id) = client_id {
+                self.send_notice(
+                    client_id,
+                    command_id,
+                    ClientNoticeLevel::Warning,
+                    "task runtime is stopping",
+                )
+                .await;
+            }
+            return;
+        }
+
         if self.runtimes.contains_key(&task_id) {
             let command = TaskRuntimeCommand::UserInput {
                 message_text: input.message_text.clone(),
@@ -835,6 +848,19 @@ impl RouterActor {
         self.runtimes
             .get(task_id)
             .is_some_and(|entry| entry.removing)
+    }
+
+    fn waiting_queue_has_removal(&self, task_id: &TaskId) -> bool {
+        self.waiting_task_commands
+            .get(task_id)
+            .is_some_and(|commands| {
+                commands.iter().any(|command| {
+                    matches!(
+                        command,
+                        PendingTaskCommand::Archive | PendingTaskCommand::Stop
+                    )
+                })
+            })
     }
 
     fn scan_in_flight(&self) -> bool {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -637,7 +637,12 @@ impl RouterActor {
             return;
         };
 
-        for command in commands {
+        let mut commands = commands;
+        while let Some(command) = commands.pop_front() {
+            let has_later_archive = commands
+                .iter()
+                .any(|command| matches!(command, PendingTaskCommand::Archive));
+            let is_stop = matches!(command, PendingTaskCommand::Stop);
             let runtime_command = match command {
                 PendingTaskCommand::UserInput { message_text } => {
                     TaskRuntimeCommand::UserInput { message_text }
@@ -658,6 +663,11 @@ impl RouterActor {
                 .is_err()
             {
                 self.runtimes.remove(&task_id);
+                break;
+            }
+            if is_stop && has_later_archive {
+                self.enqueue_waiting_command(task_id.clone(), PendingTaskCommand::Archive);
+                self.deferred_ensures.insert(task_id.clone());
                 break;
             }
         }
@@ -685,16 +695,21 @@ impl RouterActor {
         task_id: &TaskId,
         command: TaskRuntimeCommand,
     ) -> Result<(), ()> {
-        let Some(sender) = self
+        let Some((sender, removing)) = self
             .runtimes
             .get(task_id)
-            .map(|entry| entry.task_runtime_tx.clone())
+            .map(|entry| (entry.task_runtime_tx.clone(), entry.removing))
         else {
             return Err(());
         };
 
         if sender.send(command).await.is_err() {
             self.runtimes.remove(task_id);
+            if removing {
+                self.clear_removal_effects_for_task(task_id);
+                self.retry_deferred_ensures();
+                self.retry_deferred_scan();
+            }
             return Err(());
         }
         Ok(())

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -522,6 +522,7 @@ impl RouterActor {
             .values()
             .any(|effect| matches!(effect, LifecycleEffect::ScanMissingTaskRuntimes));
         if has_scan {
+            self.deferred_scan = true;
             return;
         }
         let effect_id = FactoryEffectId(format!("router-scan-{}", Uuid::new_v4()));
@@ -695,6 +696,10 @@ impl RouterActor {
         task_id: &TaskId,
         command: TaskRuntimeCommand,
     ) -> Result<(), ()> {
+        let is_removal_command = matches!(
+            command,
+            TaskRuntimeCommand::Archive | TaskRuntimeCommand::Stop
+        );
         let Some((sender, removing)) = self
             .runtimes
             .get(task_id)
@@ -704,6 +709,9 @@ impl RouterActor {
         };
 
         if sender.send(command).await.is_err() {
+            if removing && !is_removal_command {
+                return Err(());
+            }
             self.runtimes.remove(task_id);
             if removing {
                 self.clear_removal_effects_for_task(task_id);
@@ -859,7 +867,6 @@ impl RouterActor {
             FactoryCommand::EnsureTaskRuntime(command) => {
                 self.effects.remove(&command.effect_id);
                 self.pending_creations_by_task.remove(&command.task_id);
-                self.waiting_task_commands.remove(&command.task_id);
                 self.deferred_ensures.remove(&command.task_id);
             }
             FactoryCommand::EnsureMissingTaskRuntimes(command) => {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -11,11 +11,12 @@ use selvedge_command_model::{
     CoreOutputMessage, DeliverNotice, DeliverSnapshot, DomainEvent, DomainEventPublishRequest,
     EventControlMessage, EventIngress, EventIngressSender, FactoryEffectId, FactoryFailure,
     FactoryOutput, FactoryOutputEnvelope, HistoryNodeProjection, HistoryNodeProjectionBody,
-    ModelCallDispatchRequest, RawEvent, RouterIngressMessage, RouterIngressSender, RouterShutdown,
-    RuntimeInventoryQuery, RuntimeInventoryResponse, SnapshotTaskVersion, StopTaskRuntime,
-    SubmitUserInput, TaskId, TaskParentProjection, TaskProjection, TaskProjectionStatus,
-    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeHandle, TaskRuntimeSender,
-    TaskRuntimeToken, ToolExecutionRequest, ToolExecutionResult,
+    ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind, RawEvent, RouterIngressMessage,
+    RouterIngressSender, RouterShutdown, RuntimeInventoryQuery, RuntimeInventoryResponse,
+    SnapshotTaskVersion, StopTaskRuntime, SubmitUserInput, TaskId, TaskParentProjection,
+    TaskProjection, TaskProjectionStatus, TaskRuntimeCommand, TaskRuntimeExitNotice,
+    TaskRuntimeHandle, TaskRuntimeSender, TaskRuntimeToken, ToolExecutionRequest,
+    ToolExecutionResult,
 };
 use selvedge_db::{DbPool, HistoryNode, TaskRow, TaskStatusRow, UnixTs};
 use selvedge_domain_model::HistoryNodeId;
@@ -203,7 +204,7 @@ impl RouterActor {
             }
             RouterIngressMessage::Api(envelope) => self.route_api_output(envelope).await,
             RouterIngressMessage::Tool(result) => self.route_tool_output(result).await,
-            RouterIngressMessage::RuntimeExit(notice) => self.handle_runtime_exit(notice),
+            RouterIngressMessage::RuntimeExit(notice) => self.handle_runtime_exit(notice).await,
             RouterIngressMessage::Core(envelope) => self.handle_core_output(envelope).await,
             RouterIngressMessage::PublishToEvents(event) => {
                 let raw = self.domain_event_to_raw(event);
@@ -431,6 +432,7 @@ impl RouterActor {
     fn ensure_task_runtime(&mut self, task_id: TaskId) {
         if self.runtimes.contains_key(&task_id)
             || self.pending_creations_by_task.contains_key(&task_id)
+            || self.scan_in_flight()
         {
             return;
         }
@@ -620,12 +622,19 @@ impl RouterActor {
         Ok(())
     }
 
-    fn handle_runtime_exit(&mut self, notice: TaskRuntimeExitNotice) {
+    async fn handle_runtime_exit(&mut self, notice: TaskRuntimeExitNotice) {
         let should_remove = self
             .runtimes
             .get(&notice.task_id)
             .is_some_and(|entry| entry.runtime_token == notice.runtime_token);
         if should_remove {
+            if matches!(
+                notice.reason,
+                selvedge_command_model::TaskRuntimeExitReason::Archived
+            ) {
+                let raw = self.task_changed_raw_event(notice.task_id.clone());
+                let _ = self.events_tx.send(EventIngress::Raw(raw)).await;
+            }
             self.runtimes.remove(&notice.task_id);
             self.clear_removal_effects_for_task(&notice.task_id);
         }
@@ -634,14 +643,39 @@ impl RouterActor {
     async fn handle_core_output(&mut self, envelope: CoreOutputEnvelope) {
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
-                let _ = self
+                let correlation = request.correlation.clone();
+                if self
                     .api_executor
-                    .spawn_model_call(request, self.router_tx.clone());
+                    .spawn_model_call(request, self.router_tx.clone())
+                    .is_err()
+                {
+                    self.route_api_output(ApiOutputEnvelope::Failure {
+                        correlation,
+                        error: ModelCallError {
+                            kind: ModelCallErrorKind::ProviderRequest,
+                            message: "api executor spawn failed".to_owned(),
+                        },
+                    })
+                    .await;
+                }
             }
             CoreOutputMessage::RequestToolExecution(request) => {
-                let _ = self
+                let failure = ToolExecutionResult {
+                    task_id: request.task_id.clone(),
+                    tool_execution_run_id: request.tool_execution_run_id.clone(),
+                    function_call_node_id: request.function_call_node_id,
+                    function_call_id: request.function_call_id.clone(),
+                    tool_name: request.tool_name.clone(),
+                    output_text: "tool executor spawn failed".to_owned(),
+                    is_error: true,
+                };
+                if self
                     .tool_executor
-                    .spawn_tool_execution(request, self.router_tx.clone());
+                    .spawn_tool_execution(request, self.router_tx.clone())
+                    .is_err()
+                {
+                    self.route_tool_output(failure).await;
+                }
             }
             CoreOutputMessage::PublishDomainEvent(event) => {
                 let raw = self.domain_event_to_raw(event);
@@ -680,6 +714,12 @@ impl RouterActor {
         self.runtimes
             .get(task_id)
             .is_some_and(|entry| entry.removing)
+    }
+
+    fn scan_in_flight(&self) -> bool {
+        self.effects
+            .values()
+            .any(|effect| matches!(effect, LifecycleEffect::ScanMissingTaskRuntimes))
     }
 
     fn finish_task_creation_effect(&mut self, effect: &LifecycleEffect) {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -867,15 +867,34 @@ impl RouterActor {
             FactoryCommand::EnsureTaskRuntime(command) => {
                 self.effects.remove(&command.effect_id);
                 self.pending_creations_by_task.remove(&command.task_id);
+                self.waiting_task_commands.remove(&command.task_id);
                 self.deferred_ensures.remove(&command.task_id);
+                self.try_send_debug_notice(
+                    Some(command.task_id),
+                    "factory spawn failed before runtime creation output",
+                );
             }
             FactoryCommand::EnsureMissingTaskRuntimes(command) => {
                 self.effects.remove(&command.effect_id);
+                self.try_send_debug_notice(None, "factory spawn failed before scan output");
             }
             FactoryCommand::CreateChildTaskAndRuntime(command) => {
                 self.effects.remove(&command.effect_id);
+                self.try_send_debug_notice(
+                    Some(command.parent_task_id),
+                    "factory spawn failed before child runtime output",
+                );
             }
         }
+    }
+
+    fn try_send_debug_notice(&self, task_id: Option<TaskId>, message_text: &str) {
+        let _ = self.events_tx.try_send(EventIngress::Raw(RawEvent::Debug(
+            selvedge_command_model::DebugRawEvent {
+                task_id,
+                message_text: message_text.to_owned(),
+            },
+        )));
     }
 
     fn session_command_id(

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -4,14 +4,14 @@ use std::sync::{Arc, Mutex};
 use selvedge_command_model::{
     ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ArchiveTask, ClientCommand,
     ClientCommandEnvelope, ClientCommandId, ClientId, ClientSubscription, CoreOutputEnvelope,
-    CoreOutputMessage, CreatedRuntimeKind, DetailLevel, DomainEvent, DomainEventPublishRequest,
-    EventControlMessage, EventIngress, FactoryFailure, FactoryFailureKind, FactoryOutput,
-    FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure, HistoryNodeProjectionBody,
-    ModelCallDispatchRequest, ModelRunId, RawEvent, RefreshClientSnapshot, RuntimeInventoryQuery,
-    RuntimeInventoryResponse, StopTaskRuntime, SubmitUserInput, TaskId, TaskProjectionStatus,
-    TaskRuntimeCommand, TaskRuntimeCreated, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest, ToolExecutionResult,
-    ToolExecutionRunId,
+    CoreOutputMessage, CreatedRuntimeKind, DetachReason, DetailLevel, DomainEvent,
+    DomainEventPublishRequest, EventControlMessage, EventIngress, FactoryFailure,
+    FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput,
+    FactoryTaskFailure, HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelRunId, RawEvent,
+    RefreshClientSnapshot, RuntimeInventoryQuery, RuntimeInventoryResponse, StopTaskRuntime,
+    SubmitUserInput, TaskId, TaskProjectionStatus, TaskRuntimeCommand, TaskRuntimeCreated,
+    TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskRuntimeHandle, TaskRuntimeToken, TaskScope,
+    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
@@ -1882,6 +1882,59 @@ async fn domain_history_commit_emits_typed_history_event() {
 }
 
 #[tokio::test]
+async fn core_domain_events_with_mismatched_task_ids_are_discarded() {
+    let db = open_test_db();
+    create_root(&db, "task-1");
+    create_root(&db, "task-2");
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        factory_executor: factory.clone(),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                message: CoreOutputMessage::PublishDomainEvent(DomainEventPublishRequest {
+                    task_id: TaskId("task-2".to_owned()),
+                    event: DomainEvent::TaskRuntimeReady,
+                }),
+            },
+        ))
+        .await
+        .expect("send mismatched domain event");
+
+    tokio::time::timeout(std::time::Duration::from_millis(25), events_rx.recv())
+        .await
+        .expect_err("no raw event");
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn runtime_ready_emits_task_changed_event() {
     let db = open_test_db();
     create_root(&db, "task-1");
@@ -2029,6 +2082,63 @@ async fn attach_client_begins_hydration_and_delivers_snapshot() {
                 snapshot.client_command_id,
                 ClientCommandId("attach-1".to_owned())
             );
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn attach_snapshot_failure_detaches_hydrating_client() {
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db: open_corrupted_test_db(),
+        events_tx,
+        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (output_tx, _output_rx) = tokio::sync::mpsc::channel(8);
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("attach-1".to_owned()),
+                command: ClientCommand::AttachClient(selvedge_command_model::AttachClient {
+                    client_id: ClientId("client-1".to_owned()),
+                    output_tx,
+                    subscription: subscription(),
+                }),
+            },
+        ))
+        .await
+        .expect("send attach");
+
+    let begin = events_rx.recv().await.expect("begin hydration");
+    assert!(matches!(
+        begin,
+        EventIngress::Control(EventControlMessage::BeginClientHydration(_))
+    ));
+    let notice = events_rx.recv().await.expect("snapshot failure notice");
+    assert!(matches!(
+        notice,
+        EventIngress::Control(EventControlMessage::DeliverNotice(_))
+    ));
+    let detach = events_rx.recv().await.expect("detach client");
+    match detach {
+        EventIngress::Control(EventControlMessage::DetachClient(detach)) => {
+            assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+            assert_eq!(
+                detach.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+            assert_eq!(detach.reason, DetachReason::DeliveryFailed);
         }
         _ => panic!("unexpected event ingress"),
     }
@@ -2336,6 +2446,20 @@ fn open_test_db() -> selvedge_db::DbPool {
         sqlite_path: ":memory:".to_owned(),
     })
     .expect("open db")
+}
+
+fn open_corrupted_test_db() -> selvedge_db::DbPool {
+    let file = tempfile::NamedTempFile::new().expect("create temp db file");
+    let path = file.path().to_string_lossy().to_string();
+    let db = open_db(OpenDbOptions {
+        sqlite_path: path.clone(),
+    })
+    .expect("open db");
+    let connection = rusqlite::Connection::open(path).expect("open raw db");
+    connection
+        .execute_batch("DROP TABLE tasks;")
+        .expect("drop tasks table");
+    db
 }
 
 fn create_root(db: &selvedge_db::DbPool, task_id: &str) {

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -227,6 +227,68 @@ async fn removing_runtime_discards_late_core_external_requests() {
 }
 
 #[tokio::test]
+async fn core_external_requests_with_mismatched_task_ids_are_discarded() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let api = Arc::new(RecordingApiExecutor::default());
+    let tool = Arc::new(RecordingToolExecutor::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx,
+        factory_executor: factory.clone(),
+        api_executor: api.clone(),
+        tool_executor: tool.clone(),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                message: CoreOutputMessage::RequestModelCall(valid_model_request("task-2")),
+            },
+        ))
+        .await
+        .expect("send mismatched model request");
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                message: CoreOutputMessage::RequestToolExecution(valid_tool_request("task-2")),
+            },
+        ))
+        .await
+        .expect("send mismatched tool request");
+
+    api.expect_no_request().await;
+    tool.expect_no_request().await;
+    tokio::time::timeout(std::time::Duration::from_millis(25), events_rx.recv())
+        .await
+        .expect_err("no status events");
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn replaced_runtime_discards_stale_core_external_requests() {
     let factory = Arc::new(RecordingFactoryExecutor::default());
     let api = Arc::new(RecordingApiExecutor::default());

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -1,16 +1,16 @@
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use selvedge_command_model::{
-    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ClientCommand, ClientCommandEnvelope,
-    ClientCommandId, ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage,
-    CreatedRuntimeKind, DetailLevel, DomainEvent, DomainEventPublishRequest, EventControlMessage,
-    EventIngress, FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput,
-    FactoryTaskFailure, HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelRunId, RawEvent,
-    RefreshClientSnapshot, RuntimeInventoryQuery, RuntimeInventoryResponse, StopTaskRuntime,
-    SubmitUserInput, TaskId, TaskProjectionStatus, TaskRuntimeCommand, TaskRuntimeCreated,
-    TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskRuntimeHandle, TaskRuntimeToken, TaskScope,
-    ToolExecutionRequest,
+    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ArchiveTask, ClientCommand,
+    ClientCommandEnvelope, ClientCommandId, ClientId, ClientSubscription, CoreOutputEnvelope,
+    CoreOutputMessage, CreatedRuntimeKind, DetailLevel, DomainEvent, DomainEventPublishRequest,
+    EventControlMessage, EventIngress, FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope,
+    FactoryScanOutput, FactoryTaskFailure, HistoryNodeProjectionBody, ModelCallDispatchRequest,
+    ModelRunId, RawEvent, RefreshClientSnapshot, RuntimeInventoryQuery, RuntimeInventoryResponse,
+    StopTaskRuntime, SubmitUserInput, TaskId, TaskProjectionStatus, TaskRuntimeCommand,
+    TaskRuntimeCreated, TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskRuntimeHandle,
+    TaskRuntimeToken, TaskScope, ToolExecutionRequest,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
@@ -275,6 +275,135 @@ async fn scan_in_flight_blocks_duplicate_task_specific_creation() {
     assert!(matches!(
         task_runtime_rx.recv().await.expect("waiting input"),
         TaskRuntimeCommand::UserInput { .. }
+    ));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn scan_miss_retries_waiting_task_creation() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("scan-1".to_owned()),
+                command: ClientCommand::EnsureMissingTaskRuntimes(
+                    selvedge_command_model::EnsureMissingTaskRuntimes,
+                ),
+            },
+        ))
+        .await
+        .expect("send scan");
+    let scan = factory.take_one_command().await;
+    let FactoryCommand::EnsureMissingTaskRuntimes(scan) = scan else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("input-1".to_owned()),
+                command: ClientCommand::SubmitUserInput(SubmitUserInput {
+                    task_id: TaskId("task-1".to_owned()),
+                    message_text: "hello".to_owned(),
+                }),
+            },
+        ))
+        .await
+        .expect("send input");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: scan.effect_id,
+                output: FactoryOutput::ScanFinished(FactoryScanOutput {
+                    created: Vec::new(),
+                    skipped: Vec::new(),
+                    failed: Vec::new(),
+                }),
+            },
+        ))
+        .await
+        .expect("send scan output");
+
+    let retry = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(retry) = retry else {
+        panic!("unexpected factory command");
+    };
+    assert_eq!(retry.task_id, TaskId("task-1".to_owned()));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn archive_send_failure_requeues_archive_for_recreated_runtime() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+    let (stale_tx, mut stale_rx) = tokio::sync::mpsc::channel(1);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        stale_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-stale".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        stale_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+    drop(stale_rx);
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("archive-1".to_owned()),
+                command: ClientCommand::ArchiveTask(ArchiveTask {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send archive");
+
+    let recreate = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(recreate) = recreate else {
+        panic!("unexpected factory command");
+    };
+    assert_eq!(recreate.task_id, TaskId("task-1".to_owned()));
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: recreate.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send factory output");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("archive command"),
+        TaskRuntimeCommand::Archive
     ));
 
     shutdown(handle).await;
@@ -711,6 +840,69 @@ async fn attach_client_begins_hydration_and_delivers_snapshot() {
     shutdown(handle).await;
 }
 
+#[tokio::test]
+async fn attach_snapshot_respects_task_scope() {
+    let db = open_test_db();
+    create_root(&db, "task-1");
+    create_root(&db, "task-2");
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (output_tx, _output_rx) = tokio::sync::mpsc::channel(8);
+    let mut scoped_tasks = BTreeSet::new();
+    scoped_tasks.insert(TaskId("task-1".to_owned()));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("attach-1".to_owned()),
+                command: ClientCommand::AttachClient(selvedge_command_model::AttachClient {
+                    client_id: ClientId("client-1".to_owned()),
+                    output_tx,
+                    subscription: ClientSubscription {
+                        task_scope: TaskScope::TaskIds(scoped_tasks),
+                        detail_level: DetailLevel::Verbose,
+                        include_model_call_status: true,
+                        include_tool_execution_status: true,
+                        include_debug_notices: true,
+                    },
+                }),
+            },
+        ))
+        .await
+        .expect("send attach");
+    let _begin = events_rx.recv().await.expect("begin hydration");
+    let snapshot = events_rx.recv().await.expect("deliver snapshot");
+    match snapshot {
+        EventIngress::Control(EventControlMessage::DeliverSnapshot(snapshot)) => {
+            let task_ids = snapshot
+                .snapshot
+                .tasks
+                .into_iter()
+                .map(|task| task.task_id)
+                .collect::<Vec<_>>();
+            assert_eq!(task_ids, vec![TaskId("task-1".to_owned())]);
+            assert_eq!(
+                snapshot.snapshot.task_versions[0].task_id,
+                TaskId("task-1".to_owned())
+            );
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
 fn start_args(ingress_capacity: usize, pending_task_command_limit: usize) -> RouterStartArgs {
     start_args_with_factory(
         ingress_capacity,
@@ -904,7 +1096,12 @@ impl RecordingFactoryExecutor {
             if let Some(command) = self.commands.lock().expect("lock commands").pop_front() {
                 return command;
             }
-            self.notify.notified().await;
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                self.notify.notified(),
+            )
+            .await
+            .expect("factory command");
         }
     }
 

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -10,7 +10,8 @@ use selvedge_command_model::{
     ModelCallDispatchRequest, ModelRunId, RawEvent, RefreshClientSnapshot, RuntimeInventoryQuery,
     RuntimeInventoryResponse, StopTaskRuntime, SubmitUserInput, TaskId, TaskProjectionStatus,
     TaskRuntimeCommand, TaskRuntimeCreated, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest, ToolExecutionRunId,
+    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest, ToolExecutionResult,
+    ToolExecutionRunId,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
@@ -20,7 +21,7 @@ use selvedge_db::{
 };
 use selvedge_domain_model::{
     ConversationMessage, ConversationPath, FunctionCallId, HistoryNodeId, MessageContent,
-    MessageRole, ModelProviderProfile, ResponsePreference, ToolName,
+    MessageRole, ModelFinishReason, ModelProviderProfile, ModelReply, ResponsePreference, ToolName,
 };
 use selvedge_router::{
     ApiExecutor, FactoryExecutor, FactorySpawnRequest, RouterStartArgs, SpawnApiEffectError,
@@ -336,6 +337,153 @@ async fn replaced_runtime_discards_stale_core_external_requests() {
         .expect("send stale request");
 
     api.expect_no_request().await;
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn api_result_from_replaced_runtime_is_discarded() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx,
+        factory_executor: factory.clone(),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (first_tx, mut first_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        first_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        first_rx.recv().await.expect("first start command"),
+        TaskRuntimeCommand::Start
+    ));
+    let request = valid_model_request("task-1");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                message: CoreOutputMessage::RequestModelCall(request.clone()),
+            },
+        ))
+        .await
+        .expect("send model request");
+    let _requested = events_rx.recv().await.expect("requested status");
+    let mut second_rx = replace_runtime(
+        &handle.router_tx,
+        &factory,
+        &mut first_rx,
+        TaskRuntimeToken("runtime-1".to_owned()),
+        TaskRuntimeToken("runtime-2".to_owned()),
+    )
+    .await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Api(
+            ApiOutputEnvelope::Success {
+                correlation: request.correlation,
+                reply: valid_model_reply(),
+            },
+        ))
+        .await
+        .expect("send stale api result");
+
+    tokio::time::timeout(std::time::Duration::from_millis(25), second_rx.recv())
+        .await
+        .expect_err("no runtime command");
+    tokio::time::timeout(std::time::Duration::from_millis(25), events_rx.recv())
+        .await
+        .expect_err("no terminal status");
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn tool_result_from_replaced_runtime_is_discarded() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx,
+        factory_executor: factory.clone(),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (first_tx, mut first_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        first_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        first_rx.recv().await.expect("first start command"),
+        TaskRuntimeCommand::Start
+    ));
+    let request = valid_tool_request("task-1");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                message: CoreOutputMessage::RequestToolExecution(request.clone()),
+            },
+        ))
+        .await
+        .expect("send tool request");
+    let _requested = events_rx.recv().await.expect("requested status");
+    let mut second_rx = replace_runtime(
+        &handle.router_tx,
+        &factory,
+        &mut first_rx,
+        TaskRuntimeToken("runtime-1".to_owned()),
+        TaskRuntimeToken("runtime-2".to_owned()),
+    )
+    .await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Tool(
+            ToolExecutionResult {
+                task_id: request.task_id,
+                tool_execution_run_id: request.tool_execution_run_id,
+                function_call_node_id: request.function_call_node_id,
+                function_call_id: request.function_call_id,
+                tool_name: request.tool_name,
+                output_text: "late".to_owned(),
+                is_error: false,
+            },
+        ))
+        .await
+        .expect("send stale tool result");
+
+    tokio::time::timeout(std::time::Duration::from_millis(25), second_rx.recv())
+        .await
+        .expect_err("no runtime command");
+    tokio::time::timeout(std::time::Duration::from_millis(25), events_rx.recv())
+        .await
+        .expect_err("no terminal status");
 
     shutdown(handle).await;
 }
@@ -2233,6 +2381,15 @@ fn valid_model_request(task_id: &str) -> ModelCallDispatchRequest {
     }
 }
 
+fn valid_model_reply() -> ModelReply {
+    ModelReply {
+        content: Some("reply".to_owned()),
+        tool_calls: Vec::new(),
+        usage: None,
+        finish_reason: ModelFinishReason::Stop,
+    }
+}
+
 fn valid_tool_request(task_id: &str) -> ToolExecutionRequest {
     ToolExecutionRequest {
         task_id: TaskId(task_id.to_owned()),
@@ -2242,6 +2399,84 @@ fn valid_tool_request(task_id: &str) -> ToolExecutionRequest {
         tool_name: ToolName("tool".to_owned()),
         arguments: Vec::new(),
     }
+}
+
+async fn replace_runtime(
+    router_tx: &selvedge_command_model::RouterIngressSender,
+    factory: &RecordingFactoryExecutor,
+    current_runtime_rx: &mut tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
+    current_runtime_token: TaskRuntimeToken,
+    replacement_runtime_token: TaskRuntimeToken,
+) -> tokio::sync::mpsc::Receiver<TaskRuntimeCommand> {
+    router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("replace-stop".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        current_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+    router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: current_runtime_token,
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
+    router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("replace-ensure".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    let recreate = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(recreate) = recreate else {
+        panic!("unexpected factory command");
+    };
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: recreate.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: replacement_runtime_token,
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send replacement runtime");
+    assert!(matches!(
+        task_runtime_rx
+            .recv()
+            .await
+            .expect("replacement start command"),
+        TaskRuntimeCommand::Start
+    ));
+    task_runtime_rx
 }
 
 async fn query_inventory(

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -406,6 +406,113 @@ async fn scan_while_runtime_is_removing_runs_after_exit() {
 }
 
 #[tokio::test]
+async fn deferred_scan_survives_until_in_flight_scan_finishes() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("scan-1".to_owned()),
+                command: ClientCommand::EnsureMissingTaskRuntimes(
+                    selvedge_command_model::EnsureMissingTaskRuntimes,
+                ),
+            },
+        ))
+        .await
+        .expect("send first scan");
+    let first_scan = factory.take_one_command().await;
+    let FactoryCommand::EnsureMissingTaskRuntimes(first_scan) = first_scan else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("scan-2".to_owned()),
+                command: ClientCommand::EnsureMissingTaskRuntimes(
+                    selvedge_command_model::EnsureMissingTaskRuntimes,
+                ),
+            },
+        ))
+        .await
+        .expect("send second scan");
+    factory.expect_no_command().await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
+    factory.expect_no_command().await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: first_scan.effect_id,
+                output: FactoryOutput::ScanFinished(FactoryScanOutput {
+                    created: Vec::new(),
+                    skipped: Vec::new(),
+                    failed: Vec::new(),
+                }),
+            },
+        ))
+        .await
+        .expect("finish first scan");
+
+    let second_scan = factory.take_one_command().await;
+    assert!(matches!(
+        second_scan,
+        FactoryCommand::EnsureMissingTaskRuntimes(_)
+    ));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn archive_while_runtime_is_removing_runs_after_exit() {
     let factory = Arc::new(RecordingFactoryExecutor::default());
     let handle =

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -344,6 +344,124 @@ async fn scan_miss_retries_waiting_task_creation() {
 }
 
 #[tokio::test]
+async fn scan_miss_retries_explicit_ensure() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("scan-1".to_owned()),
+                command: ClientCommand::EnsureMissingTaskRuntimes(
+                    selvedge_command_model::EnsureMissingTaskRuntimes,
+                ),
+            },
+        ))
+        .await
+        .expect("send scan");
+    let scan = factory.take_one_command().await;
+    let FactoryCommand::EnsureMissingTaskRuntimes(scan) = scan else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-1".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    factory.expect_no_command().await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: scan.effect_id,
+                output: FactoryOutput::ScanFinished(FactoryScanOutput {
+                    created: Vec::new(),
+                    skipped: Vec::new(),
+                    failed: Vec::new(),
+                }),
+            },
+        ))
+        .await
+        .expect("send scan output");
+
+    let retry = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(retry) = retry else {
+        panic!("unexpected factory command");
+    };
+    assert_eq!(retry.task_id, TaskId("task-1".to_owned()));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn archive_without_runtime_creates_runtime_and_flushes_archive() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("archive-1".to_owned()),
+                command: ClientCommand::ArchiveTask(ArchiveTask {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send archive");
+
+    let command = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(command) = command else {
+        panic!("unexpected factory command");
+    };
+    assert_eq!(command.task_id, TaskId("task-1".to_owned()));
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: command.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send factory output");
+
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("archive command"),
+        TaskRuntimeCommand::Archive
+    ));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn archive_send_failure_requeues_archive_for_recreated_runtime() {
     let factory = Arc::new(RecordingFactoryExecutor::default());
     let handle =

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -10,7 +10,7 @@ use selvedge_command_model::{
     ModelCallDispatchRequest, ModelRunId, RawEvent, RefreshClientSnapshot, RuntimeInventoryQuery,
     RuntimeInventoryResponse, StopTaskRuntime, SubmitUserInput, TaskId, TaskProjectionStatus,
     TaskRuntimeCommand, TaskRuntimeCreated, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest,
+    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest, ToolExecutionRunId,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
@@ -19,8 +19,8 @@ use selvedge_db::{
     open_db,
 };
 use selvedge_domain_model::{
-    ConversationMessage, ConversationPath, MessageContent, MessageRole, ModelProviderProfile,
-    ResponsePreference,
+    ConversationMessage, ConversationPath, FunctionCallId, HistoryNodeId, MessageContent,
+    MessageRole, ModelProviderProfile, ResponsePreference, ToolName,
 };
 use selvedge_router::{
     ApiExecutor, FactoryExecutor, FactorySpawnRequest, RouterStartArgs, SpawnApiEffectError,
@@ -144,6 +144,80 @@ async fn api_spawn_failure_routes_failure_back_to_runtime() {
         }
         _ => panic!("unexpected task runtime command"),
     }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn removing_runtime_discards_late_core_external_requests() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let api = Arc::new(RecordingApiExecutor::default());
+    let tool = Arc::new(RecordingToolExecutor::default());
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx: tokio::sync::mpsc::channel(8).0,
+        factory_executor: factory.clone(),
+        api_executor: api.clone(),
+        tool_executor: tool.clone(),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                message: CoreOutputMessage::RequestModelCall(valid_model_request("task-1")),
+            },
+        ))
+        .await
+        .expect("send model request");
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                message: CoreOutputMessage::RequestToolExecution(valid_tool_request("task-1")),
+            },
+        ))
+        .await
+        .expect("send tool request");
+
+    api.expect_no_request().await;
+    tool.expect_no_request().await;
 
     shutdown(handle).await;
 }
@@ -2011,6 +2085,17 @@ fn valid_model_request(task_id: &str) -> ModelCallDispatchRequest {
     }
 }
 
+fn valid_tool_request(task_id: &str) -> ToolExecutionRequest {
+    ToolExecutionRequest {
+        task_id: TaskId(task_id.to_owned()),
+        tool_execution_run_id: ToolExecutionRunId("tool-run-1".to_owned()),
+        function_call_node_id: HistoryNodeId(1),
+        function_call_id: FunctionCallId("call-1".to_owned()),
+        tool_name: ToolName("tool".to_owned()),
+        arguments: Vec::new(),
+    }
+}
+
 async fn query_inventory(
     router_tx: &selvedge_command_model::RouterIngressSender,
 ) -> RuntimeInventoryResponse {
@@ -2134,6 +2219,32 @@ impl ApiExecutor for FailingApiExecutor {
     }
 }
 
+#[derive(Default)]
+struct RecordingApiExecutor {
+    requests: Mutex<Vec<ModelCallDispatchRequest>>,
+}
+
+impl RecordingApiExecutor {
+    async fn expect_no_request(&self) {
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(
+            self.requests.lock().expect("lock requests").is_empty(),
+            "no api request"
+        );
+    }
+}
+
+impl ApiExecutor for RecordingApiExecutor {
+    fn spawn_model_call(
+        &self,
+        request: ModelCallDispatchRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, SpawnApiEffectError> {
+        self.requests.lock().expect("lock requests").push(request);
+        Ok(tokio::spawn(async {}))
+    }
+}
+
 struct NoopToolExecutor;
 
 impl ToolExecutor for NoopToolExecutor {
@@ -2142,6 +2253,32 @@ impl ToolExecutor for NoopToolExecutor {
         _request: ToolExecutionRequest,
         _router_tx: selvedge_command_model::RouterIngressSender,
     ) -> Result<tokio::task::JoinHandle<()>, SpawnToolEffectError> {
+        Ok(tokio::spawn(async {}))
+    }
+}
+
+#[derive(Default)]
+struct RecordingToolExecutor {
+    requests: Mutex<Vec<ToolExecutionRequest>>,
+}
+
+impl RecordingToolExecutor {
+    async fn expect_no_request(&self) {
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(
+            self.requests.lock().expect("lock requests").is_empty(),
+            "no tool request"
+        );
+    }
+}
+
+impl ToolExecutor for RecordingToolExecutor {
+    fn spawn_tool_execution(
+        &self,
+        request: ToolExecutionRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, SpawnToolEffectError> {
+        self.requests.lock().expect("lock requests").push(request);
         Ok(tokio::spawn(async {}))
     }
 }

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -6,9 +6,10 @@ use selvedge_command_model::{
     CoreOutputEnvelope, CoreOutputMessage, CreatedRuntimeKind, DetailLevel, DomainEvent,
     DomainEventPublishRequest, EventControlMessage, EventIngress, FactoryFailureKind,
     FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
-    HistoryNodeProjectionBody, ModelCallDispatchRequest, RawEvent, RuntimeInventoryQuery,
-    RuntimeInventoryResponse, SubmitUserInput, TaskId, TaskRuntimeCommand, TaskRuntimeCreated,
-    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest,
+    HistoryNodeProjectionBody, ModelCallDispatchRequest, RawEvent, RefreshClientSnapshot,
+    RuntimeInventoryQuery, RuntimeInventoryResponse, StopTaskRuntime, SubmitUserInput, TaskId,
+    TaskRuntimeCommand, TaskRuntimeCreated, TaskRuntimeHandle, TaskRuntimeToken, TaskScope,
+    ToolExecutionRequest,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
@@ -150,6 +151,146 @@ async fn submit_user_input_without_runtime_starts_factory_and_flushes_waiting_co
         TaskRuntimeCommand::UserInput { message_text } => assert_eq!(message_text, "hello"),
         _ => panic!("unexpected task runtime command"),
     }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn queued_stop_after_pending_creation_skips_start() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("ensure-1".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    let command = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(command) = command else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: command.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send factory output");
+
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+    tokio::time::timeout(std::time::Duration::from_millis(25), task_runtime_rx.recv())
+        .await
+        .expect_err("no start command");
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn factory_spawn_failure_preserves_existing_effects() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-1".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send first ensure");
+    let first = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(first) = first else {
+        panic!("unexpected factory command");
+    };
+
+    factory.fail_next_spawn();
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-2".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-2".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send second ensure");
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: first.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send first factory output");
+
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
 
     shutdown(handle).await;
 }
@@ -348,6 +489,33 @@ async fn attach_client_begins_hydration_and_delivers_snapshot() {
         _ => panic!("unexpected event ingress"),
     }
 
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("refresh-1".to_owned()),
+                command: ClientCommand::RefreshClientSnapshot(RefreshClientSnapshot {
+                    client_id: ClientId("client-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send refresh");
+    let snapshot = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("deliver refresh snapshot")
+        .expect("deliver refresh snapshot message");
+    match snapshot {
+        EventIngress::Control(EventControlMessage::DeliverSnapshot(snapshot)) => {
+            assert_eq!(
+                snapshot.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
     shutdown(handle).await;
 }
 
@@ -466,6 +634,7 @@ async fn shutdown(handle: selvedge_router::RouterHandle) {
 #[derive(Default)]
 struct RecordingFactoryExecutor {
     commands: Mutex<VecDeque<FactoryCommand>>,
+    fail_next: Mutex<bool>,
     notify: tokio::sync::Notify,
 }
 
@@ -478,6 +647,10 @@ impl RecordingFactoryExecutor {
             self.notify.notified().await;
         }
     }
+
+    fn fail_next_spawn(&self) {
+        *self.fail_next.lock().expect("lock fail flag") = true;
+    }
 }
 
 impl FactoryExecutor for RecordingFactoryExecutor {
@@ -485,6 +658,13 @@ impl FactoryExecutor for RecordingFactoryExecutor {
         &self,
         request: FactorySpawnRequest,
     ) -> Result<tokio::task::JoinHandle<()>, SpawnFactoryEffectError> {
+        let mut fail_next = self.fail_next.lock().expect("lock fail flag");
+        if *fail_next {
+            *fail_next = false;
+            return Err(SpawnFactoryEffectError::TokioSpawnFailed);
+        }
+        drop(fail_next);
+
         self.commands
             .lock()
             .expect("lock commands")

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -1,0 +1,372 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use selvedge_command_model::{
+    ClientCommand, ClientCommandEnvelope, ClientCommandId, ClientId, ClientSubscription,
+    CreatedRuntimeKind, DetailLevel, EventControlMessage, EventIngress, FactoryOutput,
+    FactoryOutputEnvelope, ModelCallDispatchRequest, RuntimeInventoryQuery,
+    RuntimeInventoryResponse, SubmitUserInput, TaskId, TaskRuntimeCommand, TaskRuntimeCreated,
+    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest,
+};
+use selvedge_db::{
+    CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
+    NewMessageNodeContent, OpenDbOptions, ReasoningEffort, UnixTs, create_history_node,
+    create_root_task, open_db,
+};
+use selvedge_router::{
+    ApiExecutor, FactoryExecutor, FactorySpawnRequest, RouterStartArgs, SpawnApiEffectError,
+    SpawnRouterError, SpawnToolEffectError, ToolExecutor, spawn_router,
+};
+use selvedge_task_runtime_factory::{FactoryCommand, SpawnFactoryEffectError};
+
+#[test]
+fn spawn_router_rejects_zero_ingress_capacity() {
+    let error = spawn_router(start_args(0, 8)).expect_err("invalid ingress capacity");
+
+    assert_eq!(error, SpawnRouterError::InvalidIngressCapacity);
+}
+
+#[tokio::test]
+async fn factory_runtime_created_registers_runtime_and_answers_inventory() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("command-1".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure command");
+    let command = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(command) = command else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: command.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send factory output");
+
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    let inventory = query_inventory(&handle.router_tx).await;
+    assert_eq!(
+        inventory.live_task_runtimes,
+        vec![TaskId("task-1".to_owned())]
+    );
+    assert!(inventory.pending_task_runtime_effects.is_empty());
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn submit_user_input_without_runtime_starts_factory_and_flushes_waiting_command() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("command-1".to_owned()),
+                command: ClientCommand::SubmitUserInput(SubmitUserInput {
+                    task_id: TaskId("task-1".to_owned()),
+                    message_text: "hello".to_owned(),
+                }),
+            },
+        ))
+        .await
+        .expect("send client command");
+
+    let command = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(command) = command else {
+        panic!("unexpected factory command");
+    };
+    assert_eq!(command.task_id, TaskId("task-1".to_owned()));
+
+    let inventory = query_inventory(&handle.router_tx).await;
+    assert_eq!(
+        inventory.pending_task_runtime_effects,
+        vec![TaskId("task-1".to_owned())]
+    );
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: command.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send factory output");
+
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+    match task_runtime_rx.recv().await.expect("waiting command") {
+        TaskRuntimeCommand::UserInput { message_text } => assert_eq!(message_text, "hello"),
+        _ => panic!("unexpected task runtime command"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn attach_client_begins_hydration_and_delivers_snapshot() {
+    let db = open_test_db();
+    create_root(&db, "task-1");
+    assert_eq!(
+        selvedge_db::list_active_tasks(&db)
+            .expect("list active tasks")
+            .len(),
+        1
+    );
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (output_tx, _output_rx) = tokio::sync::mpsc::channel(8);
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("attach-1".to_owned()),
+                command: ClientCommand::AttachClient(selvedge_command_model::AttachClient {
+                    client_id: ClientId("client-1".to_owned()),
+                    output_tx,
+                    subscription: subscription(),
+                }),
+            },
+        ))
+        .await
+        .expect("send attach");
+
+    let begin = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("begin hydration")
+        .expect("begin hydration message");
+    assert!(matches!(
+        begin,
+        EventIngress::Control(EventControlMessage::BeginClientHydration(_))
+    ));
+
+    let snapshot = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("deliver snapshot")
+        .expect("deliver snapshot message");
+    match snapshot {
+        EventIngress::Control(EventControlMessage::DeliverSnapshot(snapshot)) => {
+            assert_eq!(snapshot.client_id, ClientId("client-1".to_owned()));
+            assert_eq!(
+                snapshot.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+            assert_eq!(snapshot.snapshot.tasks.len(), 1);
+            assert_eq!(
+                snapshot.snapshot.tasks[0].task_id,
+                TaskId("task-1".to_owned())
+            );
+            assert_eq!(snapshot.snapshot.task_versions[0].state_version, 0);
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+fn start_args(ingress_capacity: usize, pending_task_command_limit: usize) -> RouterStartArgs {
+    start_args_with_factory(
+        ingress_capacity,
+        pending_task_command_limit,
+        Arc::new(RecordingFactoryExecutor::default()),
+    )
+}
+
+fn start_args_with_factory(
+    ingress_capacity: usize,
+    pending_task_command_limit: usize,
+    factory_executor: Arc<RecordingFactoryExecutor>,
+) -> RouterStartArgs {
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+    RouterStartArgs {
+        db: open_test_db(),
+        events_tx,
+        factory_executor,
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity,
+        pending_task_command_limit,
+    }
+}
+
+fn open_test_db() -> selvedge_db::DbPool {
+    open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db")
+}
+
+fn create_root(db: &selvedge_db::DbPool, task_id: &str) {
+    let cursor_node_id = create_history_node(
+        db,
+        NewHistoryNode {
+            parent_node_id: None,
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: selvedge_db::MessageRole::System,
+                message_text: "system".to_owned(),
+            }),
+            created_at: UnixTs(1),
+        },
+    )
+    .expect("create history node");
+    create_root_task(
+        db,
+        CreateRootTaskInput {
+            task_id: TaskId(task_id.to_owned()),
+            cursor_node_id,
+            model_profile_key: ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create root task");
+}
+
+fn subscription() -> ClientSubscription {
+    ClientSubscription {
+        task_scope: TaskScope::AllTasks,
+        detail_level: DetailLevel::Verbose,
+        include_model_call_status: true,
+        include_tool_execution_status: true,
+        include_debug_notices: true,
+    }
+}
+
+async fn query_inventory(
+    router_tx: &selvedge_command_model::RouterIngressSender,
+) -> RuntimeInventoryResponse {
+    let (reply_to, reply_rx) = tokio::sync::oneshot::channel();
+    router_tx
+        .send(
+            selvedge_command_model::RouterIngressMessage::RuntimeInventoryQuery(
+                RuntimeInventoryQuery { reply_to },
+            ),
+        )
+        .await
+        .expect("send inventory query");
+    reply_rx.await.expect("inventory response")
+}
+
+async fn shutdown(handle: selvedge_router::RouterHandle) {
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Shutdown(
+            selvedge_command_model::RouterShutdown,
+        ))
+        .await
+        .expect("send shutdown");
+    handle.join_handle.await.expect("router joins");
+}
+
+#[derive(Default)]
+struct RecordingFactoryExecutor {
+    commands: Mutex<VecDeque<FactoryCommand>>,
+    notify: tokio::sync::Notify,
+}
+
+impl RecordingFactoryExecutor {
+    async fn take_one_command(&self) -> FactoryCommand {
+        loop {
+            if let Some(command) = self.commands.lock().expect("lock commands").pop_front() {
+                return command;
+            }
+            self.notify.notified().await;
+        }
+    }
+}
+
+impl FactoryExecutor for RecordingFactoryExecutor {
+    fn spawn_factory_effect(
+        &self,
+        request: FactorySpawnRequest,
+    ) -> Result<tokio::task::JoinHandle<()>, SpawnFactoryEffectError> {
+        self.commands
+            .lock()
+            .expect("lock commands")
+            .push_back(request.command);
+        self.notify.notify_waiters();
+        Ok(tokio::spawn(async {}))
+    }
+}
+
+struct NoopApiExecutor;
+
+impl ApiExecutor for NoopApiExecutor {
+    fn spawn_model_call(
+        &self,
+        _request: ModelCallDispatchRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, SpawnApiEffectError> {
+        Ok(tokio::spawn(async {}))
+    }
+}
+
+struct NoopToolExecutor;
+
+impl ToolExecutor for NoopToolExecutor {
+    fn spawn_tool_execution(
+        &self,
+        _request: ToolExecutionRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, SpawnToolEffectError> {
+        Ok(tokio::spawn(async {}))
+    }
+}

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -336,6 +336,76 @@ async fn ensure_while_runtime_is_removing_retries_after_exit() {
 }
 
 #[tokio::test]
+async fn scan_while_runtime_is_removing_runs_after_exit() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("scan-1".to_owned()),
+                command: ClientCommand::EnsureMissingTaskRuntimes(
+                    selvedge_command_model::EnsureMissingTaskRuntimes,
+                ),
+            },
+        ))
+        .await
+        .expect("send scan");
+    factory.expect_no_command().await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
+
+    let scan = factory.take_one_command().await;
+    assert!(matches!(scan, FactoryCommand::EnsureMissingTaskRuntimes(_)));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn scan_in_flight_blocks_duplicate_task_specific_creation() {
     let factory = Arc::new(RecordingFactoryExecutor::default());
     let handle =

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -5,12 +5,12 @@ use selvedge_command_model::{
     ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ArchiveTask, ClientCommand,
     ClientCommandEnvelope, ClientCommandId, ClientId, ClientSubscription, CoreOutputEnvelope,
     CoreOutputMessage, CreatedRuntimeKind, DetailLevel, DomainEvent, DomainEventPublishRequest,
-    EventControlMessage, EventIngress, FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope,
-    FactoryScanOutput, FactoryTaskFailure, HistoryNodeProjectionBody, ModelCallDispatchRequest,
-    ModelRunId, RawEvent, RefreshClientSnapshot, RuntimeInventoryQuery, RuntimeInventoryResponse,
-    StopTaskRuntime, SubmitUserInput, TaskId, TaskProjectionStatus, TaskRuntimeCommand,
-    TaskRuntimeCreated, TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskRuntimeHandle,
-    TaskRuntimeToken, TaskScope, ToolExecutionRequest,
+    EventControlMessage, EventIngress, FactoryFailure, FactoryFailureKind, FactoryOutput,
+    FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure, HistoryNodeProjectionBody,
+    ModelCallDispatchRequest, ModelRunId, RawEvent, RefreshClientSnapshot, RuntimeInventoryQuery,
+    RuntimeInventoryResponse, StopTaskRuntime, SubmitUserInput, TaskId, TaskProjectionStatus,
+    TaskRuntimeCommand, TaskRuntimeCreated, TaskRuntimeExitNotice, TaskRuntimeExitReason,
+    TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
@@ -1016,6 +1016,152 @@ async fn attach_snapshot_respects_task_scope() {
             );
         }
         _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn verbose_attach_snapshot_includes_existing_history() {
+    let db = open_test_db();
+    create_root(&db, "task-1");
+    append_user_message_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "hello".to_owned(),
+        UnixTs(2),
+    )
+    .expect("append user message");
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (output_tx, _output_rx) = tokio::sync::mpsc::channel(8);
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("attach-1".to_owned()),
+                command: ClientCommand::AttachClient(selvedge_command_model::AttachClient {
+                    client_id: ClientId("client-1".to_owned()),
+                    output_tx,
+                    subscription: subscription(),
+                }),
+            },
+        ))
+        .await
+        .expect("send attach");
+    let _begin = events_rx.recv().await.expect("begin hydration");
+    let snapshot = events_rx.recv().await.expect("deliver snapshot");
+    match snapshot {
+        EventIngress::Control(EventControlMessage::DeliverSnapshot(snapshot)) => {
+            assert_eq!(snapshot.snapshot.task_versions[0].state_version, 1);
+            assert_eq!(snapshot.snapshot.history_nodes.len(), 2);
+            assert!(matches!(
+                snapshot.snapshot.history_nodes[1].body,
+                HistoryNodeProjectionBody::Message { .. }
+            ));
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn retryable_creation_failure_preserves_waiting_user_input() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("input-1".to_owned()),
+                command: ClientCommand::SubmitUserInput(SubmitUserInput {
+                    task_id: TaskId("task-1".to_owned()),
+                    message_text: "hello".to_owned(),
+                }),
+            },
+        ))
+        .await
+        .expect("send input");
+    let first = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(first) = first else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: first.effect_id,
+                output: FactoryOutput::Failed(FactoryFailure {
+                    task_id: Some(TaskId("task-1".to_owned())),
+                    kind: FactoryFailureKind::CoreSpawnFailed,
+                    message: "spawn failed".to_owned(),
+                }),
+            },
+        ))
+        .await
+        .expect("send failure");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-1".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    let retry = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(retry) = retry else {
+        panic!("unexpected factory command");
+    };
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: retry.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send runtime");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+    match task_runtime_rx.recv().await.expect("waiting input") {
+        TaskRuntimeCommand::UserInput { message_text } => assert_eq!(message_text, "hello"),
+        _ => panic!("unexpected task runtime command"),
     }
 
     shutdown(handle).await;

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -1044,6 +1044,19 @@ async fn closed_removing_runtime_retries_deferred_archive() {
         ))
         .await
         .expect("send late api");
+    factory.expect_no_command().await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
     let recreate = factory.take_one_command().await;
     let FactoryCommand::EnsureTaskRuntime(recreate) = recreate else {
         panic!("unexpected factory command");

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -3,15 +3,17 @@ use std::sync::{Arc, Mutex};
 
 use selvedge_command_model::{
     ClientCommand, ClientCommandEnvelope, ClientCommandId, ClientId, ClientSubscription,
-    CreatedRuntimeKind, DetailLevel, EventControlMessage, EventIngress, FactoryOutput,
-    FactoryOutputEnvelope, ModelCallDispatchRequest, RuntimeInventoryQuery,
+    CoreOutputEnvelope, CoreOutputMessage, CreatedRuntimeKind, DetailLevel, DomainEvent,
+    DomainEventPublishRequest, EventControlMessage, EventIngress, FactoryFailureKind,
+    FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
+    HistoryNodeProjectionBody, ModelCallDispatchRequest, RawEvent, RuntimeInventoryQuery,
     RuntimeInventoryResponse, SubmitUserInput, TaskId, TaskRuntimeCommand, TaskRuntimeCreated,
     TaskRuntimeHandle, TaskRuntimeToken, TaskScope, ToolExecutionRequest,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
-    NewMessageNodeContent, OpenDbOptions, ReasoningEffort, UnixTs, create_history_node,
-    create_root_task, open_db,
+    NewMessageNodeContent, OpenDbOptions, ReasoningEffort, UnixTs,
+    append_user_message_and_move_cursor, create_history_node, create_root_task, open_db,
 };
 use selvedge_router::{
     ApiExecutor, FactoryExecutor, FactorySpawnRequest, RouterStartArgs, SpawnApiEffectError,
@@ -117,6 +119,9 @@ async fn submit_user_input_without_runtime_starts_factory_and_flushes_waiting_co
         inventory.pending_task_runtime_effects,
         vec![TaskId("task-1".to_owned())]
     );
+    let self_inventory =
+        query_inventory_for_effect(&handle.router_tx, command.effect_id.clone()).await;
+    assert!(self_inventory.pending_task_runtime_effects.is_empty());
 
     let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
     handle
@@ -144,6 +149,131 @@ async fn submit_user_input_without_runtime_starts_factory_and_flushes_waiting_co
     match task_runtime_rx.recv().await.expect("waiting command") {
         TaskRuntimeCommand::UserInput { message_text } => assert_eq!(message_text, "hello"),
         _ => panic!("unexpected task runtime command"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn scan_finished_reports_per_task_failures() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx,
+        factory_executor: factory.clone(),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("scan-1".to_owned()),
+                command: ClientCommand::EnsureMissingTaskRuntimes(
+                    selvedge_command_model::EnsureMissingTaskRuntimes,
+                ),
+            },
+        ))
+        .await
+        .expect("send scan");
+    let command = factory.take_one_command().await;
+    let FactoryCommand::EnsureMissingTaskRuntimes(command) = command else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: command.effect_id,
+                output: FactoryOutput::ScanFinished(FactoryScanOutput {
+                    created: Vec::new(),
+                    skipped: Vec::new(),
+                    failed: vec![FactoryTaskFailure {
+                        task_id: TaskId("task-failed".to_owned()),
+                        kind: FactoryFailureKind::CoreSpawnFailed,
+                        message: "spawn failed".to_owned(),
+                    }],
+                }),
+            },
+        ))
+        .await
+        .expect("send scan output");
+
+    let event = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("scan failure notice")
+        .expect("scan failure event");
+    match event {
+        EventIngress::Raw(RawEvent::Debug(event)) => {
+            assert_eq!(event.task_id, Some(TaskId("task-failed".to_owned())));
+            assert!(event.message_text.contains("CoreSpawnFailed"));
+            assert!(event.message_text.contains("spawn failed"));
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn domain_history_commit_emits_typed_history_event() {
+    let db = open_test_db();
+    create_root(&db, "task-1");
+    let node_id = append_user_message_and_move_cursor(
+        &db,
+        &TaskId("task-1".to_owned()),
+        "hello".to_owned(),
+        UnixTs(2),
+    )
+    .expect("append user message");
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                message: CoreOutputMessage::PublishDomainEvent(DomainEventPublishRequest {
+                    task_id: TaskId("task-1".to_owned()),
+                    event: DomainEvent::UserMessageCommitted { node_id },
+                }),
+            },
+        ))
+        .await
+        .expect("send domain event");
+
+    let event = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("typed event")
+        .expect("typed event message");
+    match event {
+        EventIngress::Raw(RawEvent::HistoryAppended(event)) => {
+            assert_eq!(event.task_id, TaskId("task-1".to_owned()));
+            assert_eq!(event.task_state_version, 1);
+            assert_eq!(event.appended_nodes.len(), 1);
+            assert!(matches!(
+                event.appended_nodes[0].body,
+                HistoryNodeProjectionBody::Message { .. }
+            ));
+        }
+        _ => panic!("unexpected event ingress"),
     }
 
     shutdown(handle).await;
@@ -293,11 +423,28 @@ fn subscription() -> ClientSubscription {
 async fn query_inventory(
     router_tx: &selvedge_command_model::RouterIngressSender,
 ) -> RuntimeInventoryResponse {
+    query_inventory_with_requester(router_tx, None).await
+}
+
+async fn query_inventory_for_effect(
+    router_tx: &selvedge_command_model::RouterIngressSender,
+    effect_id: selvedge_command_model::FactoryEffectId,
+) -> RuntimeInventoryResponse {
+    query_inventory_with_requester(router_tx, Some(effect_id)).await
+}
+
+async fn query_inventory_with_requester(
+    router_tx: &selvedge_command_model::RouterIngressSender,
+    requesting_effect_id: Option<selvedge_command_model::FactoryEffectId>,
+) -> RuntimeInventoryResponse {
     let (reply_to, reply_rx) = tokio::sync::oneshot::channel();
     router_tx
         .send(
             selvedge_command_model::RouterIngressMessage::RuntimeInventoryQuery(
-                RuntimeInventoryQuery { reply_to },
+                RuntimeInventoryQuery {
+                    requesting_effect_id,
+                    reply_to,
+                },
             ),
         )
         .await

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -2,19 +2,25 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use selvedge_command_model::{
-    ClientCommand, ClientCommandEnvelope, ClientCommandId, ClientId, ClientSubscription,
-    CoreOutputEnvelope, CoreOutputMessage, CreatedRuntimeKind, DetailLevel, DomainEvent,
-    DomainEventPublishRequest, EventControlMessage, EventIngress, FactoryFailureKind,
-    FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
-    HistoryNodeProjectionBody, ModelCallDispatchRequest, RawEvent, RefreshClientSnapshot,
-    RuntimeInventoryQuery, RuntimeInventoryResponse, StopTaskRuntime, SubmitUserInput, TaskId,
-    TaskRuntimeCommand, TaskRuntimeCreated, TaskRuntimeHandle, TaskRuntimeToken, TaskScope,
+    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ClientCommand, ClientCommandEnvelope,
+    ClientCommandId, ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage,
+    CreatedRuntimeKind, DetailLevel, DomainEvent, DomainEventPublishRequest, EventControlMessage,
+    EventIngress, FactoryFailureKind, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput,
+    FactoryTaskFailure, HistoryNodeProjectionBody, ModelCallDispatchRequest, ModelRunId, RawEvent,
+    RefreshClientSnapshot, RuntimeInventoryQuery, RuntimeInventoryResponse, StopTaskRuntime,
+    SubmitUserInput, TaskId, TaskProjectionStatus, TaskRuntimeCommand, TaskRuntimeCreated,
+    TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskRuntimeHandle, TaskRuntimeToken, TaskScope,
     ToolExecutionRequest,
 };
 use selvedge_db::{
     CreateRootTaskInput, ModelProfileKey, NewHistoryNode, NewHistoryNodeContent,
     NewMessageNodeContent, OpenDbOptions, ReasoningEffort, UnixTs,
-    append_user_message_and_move_cursor, create_history_node, create_root_task, open_db,
+    append_user_message_and_move_cursor, archive_task, create_history_node, create_root_task,
+    open_db,
+};
+use selvedge_domain_model::{
+    ConversationMessage, ConversationPath, MessageContent, MessageRole, ModelProviderProfile,
+    ResponsePreference,
 };
 use selvedge_router::{
     ApiExecutor, FactoryExecutor, FactorySpawnRequest, RouterStartArgs, SpawnApiEffectError,
@@ -84,6 +90,192 @@ async fn factory_runtime_created_registers_runtime_and_answers_inventory() {
         vec![TaskId("task-1".to_owned())]
     );
     assert!(inventory.pending_task_runtime_effects.is_empty());
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn api_spawn_failure_routes_failure_back_to_runtime() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx: tokio::sync::mpsc::channel(8).0,
+        factory_executor: factory.clone(),
+        api_executor: Arc::new(FailingApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                message: CoreOutputMessage::RequestModelCall(valid_model_request("task-1")),
+            },
+        ))
+        .await
+        .expect("send core output");
+
+    let api_failure =
+        tokio::time::timeout(std::time::Duration::from_millis(50), task_runtime_rx.recv())
+            .await
+            .expect("api failure")
+            .expect("api failure command");
+    match api_failure {
+        TaskRuntimeCommand::ApiModelReply(ApiOutputEnvelope::Failure { correlation, error }) => {
+            assert_eq!(correlation.task_id, TaskId("task-1".to_owned()));
+            assert!(error.message.contains("api executor spawn failed"));
+        }
+        _ => panic!("unexpected task runtime command"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn archived_runtime_exit_publishes_task_changed() {
+    let db = open_test_db();
+    create_root(&db, "task-1");
+    archive_task(&db, &TaskId("task-1".to_owned()), UnixTs(2)).expect("archive task");
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        factory_executor: factory.clone(),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Archived,
+            },
+        ))
+        .await
+        .expect("send exit");
+
+    let event = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("task changed")
+        .expect("task changed event");
+    match event {
+        EventIngress::Raw(RawEvent::TaskChanged(event)) => {
+            assert_eq!(event.task.task_id, TaskId("task-1".to_owned()));
+            assert_eq!(event.task.status, TaskProjectionStatus::Archived);
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn scan_in_flight_blocks_duplicate_task_specific_creation() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("scan-1".to_owned()),
+                command: ClientCommand::EnsureMissingTaskRuntimes(
+                    selvedge_command_model::EnsureMissingTaskRuntimes,
+                ),
+            },
+        ))
+        .await
+        .expect("send scan");
+    let scan = factory.take_one_command().await;
+    let FactoryCommand::EnsureMissingTaskRuntimes(scan) = scan else {
+        panic!("unexpected factory command");
+    };
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("input-1".to_owned()),
+                command: ClientCommand::SubmitUserInput(SubmitUserInput {
+                    task_id: TaskId("task-1".to_owned()),
+                    message_text: "hello".to_owned(),
+                }),
+            },
+        ))
+        .await
+        .expect("send input");
+    factory.expect_no_command().await;
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: scan.effect_id,
+                output: FactoryOutput::ScanFinished(FactoryScanOutput {
+                    created: vec![TaskRuntimeCreated {
+                        task_id: TaskId("task-1".to_owned()),
+                        runtime: TaskRuntimeHandle {
+                            runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                            task_runtime_tx,
+                        },
+                        created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                    }],
+                    skipped: Vec::new(),
+                    failed: Vec::new(),
+                }),
+            },
+        ))
+        .await
+        .expect("send scan output");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("waiting input"),
+        TaskRuntimeCommand::UserInput { .. }
+    ));
 
     shutdown(handle).await;
 }
@@ -588,6 +780,74 @@ fn subscription() -> ClientSubscription {
     }
 }
 
+async fn register_runtime(
+    router_tx: &selvedge_command_model::RouterIngressSender,
+    factory: &RecordingFactoryExecutor,
+    task_runtime_tx: selvedge_command_model::TaskRuntimeSender,
+    task_id: TaskId,
+    runtime_token: TaskRuntimeToken,
+) {
+    router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-runtime".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: task_id.clone(),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    let command = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(command) = command else {
+        panic!("unexpected factory command");
+    };
+    router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: command.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id,
+                    runtime: TaskRuntimeHandle {
+                        runtime_token,
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send factory output");
+}
+
+fn valid_model_request(task_id: &str) -> ModelCallDispatchRequest {
+    ModelCallDispatchRequest {
+        correlation: ApiCallCorrelation {
+            api_effect_id: ApiEffectId("api-1".to_owned()),
+            task_id: TaskId(task_id.to_owned()),
+            model_run_id: ModelRunId("model-1".to_owned()),
+        },
+        provider: ModelProviderProfile {
+            provider_name: "provider".to_owned(),
+            model_name: "model".to_owned(),
+            temperature: None,
+            max_output_tokens: None,
+        },
+        conversation: ConversationPath {
+            messages: vec![ConversationMessage {
+                role: MessageRole::User,
+                content: MessageContent::Text("hello".to_owned()),
+                source_node_id: None,
+            }],
+        },
+        tool_manifest: None,
+        response_preference: ResponsePreference::PlainTextOrToolCalls,
+    }
+}
+
 async fn query_inventory(
     router_tx: &selvedge_command_model::RouterIngressSender,
 ) -> RuntimeInventoryResponse {
@@ -651,6 +911,14 @@ impl RecordingFactoryExecutor {
     fn fail_next_spawn(&self) {
         *self.fail_next.lock().expect("lock fail flag") = true;
     }
+
+    async fn expect_no_command(&self) {
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(
+            self.commands.lock().expect("lock commands").is_empty(),
+            "no factory command"
+        );
+    }
 }
 
 impl FactoryExecutor for RecordingFactoryExecutor {
@@ -683,6 +951,18 @@ impl ApiExecutor for NoopApiExecutor {
         _router_tx: selvedge_command_model::RouterIngressSender,
     ) -> Result<tokio::task::JoinHandle<()>, SpawnApiEffectError> {
         Ok(tokio::spawn(async {}))
+    }
+}
+
+struct FailingApiExecutor;
+
+impl ApiExecutor for FailingApiExecutor {
+    fn spawn_model_call(
+        &self,
+        _request: ModelCallDispatchRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, SpawnApiEffectError> {
+        Err(SpawnApiEffectError::TokioSpawnFailed)
     }
 }
 

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -406,6 +406,100 @@ async fn scan_while_runtime_is_removing_runs_after_exit() {
 }
 
 #[tokio::test]
+async fn archive_while_runtime_is_removing_runs_after_exit() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("archive-1".to_owned()),
+                command: ClientCommand::ArchiveTask(ArchiveTask {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send archive");
+    factory.expect_no_command().await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
+    let recreate = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(recreate) = recreate else {
+        panic!("unexpected factory command");
+    };
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: recreate.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-2".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send factory output");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("archive command"),
+        TaskRuntimeCommand::Archive
+    ));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn scan_in_flight_blocks_duplicate_task_specific_creation() {
     let factory = Arc::new(RecordingFactoryExecutor::default());
     let handle =
@@ -1253,6 +1347,67 @@ async fn attach_snapshot_respects_task_scope() {
             assert_eq!(
                 snapshot.snapshot.task_versions[0].task_id,
                 TaskId("task-1".to_owned())
+            );
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn attached_client_notice_uses_session_command_id() {
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx,
+        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (output_tx, _output_rx) = tokio::sync::mpsc::channel(8);
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("attach-1".to_owned()),
+                command: ClientCommand::AttachClient(selvedge_command_model::AttachClient {
+                    client_id: ClientId("client-1".to_owned()),
+                    output_tx,
+                    subscription: subscription(),
+                }),
+            },
+        ))
+        .await
+        .expect("send attach");
+    let _begin = events_rx.recv().await.expect("begin hydration");
+    let _snapshot = events_rx.recv().await.expect("deliver snapshot");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: Some(ClientId("client-1".to_owned())),
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+
+    let notice = events_rx.recv().await.expect("notice");
+    match notice {
+        EventIngress::Control(EventControlMessage::DeliverNotice(notice)) => {
+            assert_eq!(
+                notice.client_command_id,
+                ClientCommandId("attach-1".to_owned())
             );
         }
         _ => panic!("unexpected event ingress"),

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -862,6 +862,198 @@ async fn archive_without_runtime_creates_runtime_and_flushes_archive() {
 }
 
 #[tokio::test]
+async fn queued_stop_then_archive_recreates_runtime_for_archive_after_stop_exit() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-1".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    let create = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(create) = create else {
+        panic!("unexpected factory command");
+    };
+    for (command_id, command) in [
+        (
+            "stop-1",
+            ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            }),
+        ),
+        (
+            "archive-1",
+            ClientCommand::ArchiveTask(ArchiveTask {
+                task_id: TaskId("task-1".to_owned()),
+            }),
+        ),
+    ] {
+        handle
+            .router_tx
+            .send(selvedge_command_model::RouterIngressMessage::Client(
+                ClientCommandEnvelope {
+                    client_id: None,
+                    command_id: ClientCommandId(command_id.to_owned()),
+                    command,
+                },
+            ))
+            .await
+            .expect("send queued command");
+    }
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: create.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send runtime");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+    tokio::time::timeout(std::time::Duration::from_millis(25), task_runtime_rx.recv())
+        .await
+        .expect_err("archive waits for recreated runtime");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
+    let recreate = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(recreate) = recreate else {
+        panic!("unexpected factory command");
+    };
+
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: recreate.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-2".to_owned()),
+                        task_runtime_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send recreated runtime");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("archive command"),
+        TaskRuntimeCommand::Archive
+    ));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn closed_removing_runtime_retries_deferred_archive() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("archive-1".to_owned()),
+                command: ClientCommand::ArchiveTask(ArchiveTask {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send archive");
+    drop(task_runtime_rx);
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Api(
+            ApiOutputEnvelope::Failure {
+                correlation: valid_model_request("task-1").correlation,
+                error: selvedge_command_model::ModelCallError {
+                    kind: selvedge_command_model::ModelCallErrorKind::Cancelled,
+                    message: "late".to_owned(),
+                },
+            },
+        ))
+        .await
+        .expect("send late api");
+    let recreate = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(recreate) = recreate else {
+        panic!("unexpected factory command");
+    };
+    assert_eq!(recreate.task_id, TaskId("task-1".to_owned()));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn archive_send_failure_requeues_archive_for_recreated_runtime() {
     let factory = Arc::new(RecordingFactoryExecutor::default());
     let handle =

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -989,6 +989,47 @@ async fn domain_history_commit_emits_typed_history_event() {
 }
 
 #[tokio::test]
+async fn runtime_ready_emits_task_changed_event() {
+    let db = open_test_db();
+    create_root(&db, "task-1");
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                message: CoreOutputMessage::RuntimeReady,
+            },
+        ))
+        .await
+        .expect("send runtime ready");
+
+    let event = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("task changed")
+        .expect("task changed event");
+    match event {
+        EventIngress::Raw(RawEvent::TaskChanged(event)) => {
+            assert_eq!(event.task.task_id, TaskId("task-1".to_owned()));
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn attach_client_begins_hydration_and_delivers_snapshot() {
     let db = open_test_db();
     create_root(&db, "task-1");

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -207,6 +207,135 @@ async fn archived_runtime_exit_publishes_task_changed() {
 }
 
 #[tokio::test]
+async fn fatal_runtime_exit_publishes_debug_event() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx,
+        factory_executor: factory.clone(),
+        api_executor: Arc::new(NoopApiExecutor),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::InternalError("broken".to_owned()),
+            },
+        ))
+        .await
+        .expect("send exit");
+
+    let event = tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv())
+        .await
+        .expect("debug event")
+        .expect("debug event message");
+    match event {
+        EventIngress::Raw(RawEvent::Debug(event)) => {
+            assert_eq!(event.task_id, Some(TaskId("task-1".to_owned())));
+            assert!(event.message_text.contains("broken"));
+        }
+        _ => panic!("unexpected event ingress"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn ensure_while_runtime_is_removing_retries_after_exit() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let handle =
+        spawn_router(start_args_with_factory(8, 8, factory.clone())).expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-1".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    factory.expect_no_command().await;
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
+    let retry = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(retry) = retry else {
+        panic!("unexpected factory command");
+    };
+    assert_eq!(retry.task_id, TaskId("task-1".to_owned()));
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
 async fn scan_in_flight_blocks_duplicate_task_specific_creation() {
     let factory = Arc::new(RecordingFactoryExecutor::default());
     let handle =

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -126,6 +126,7 @@ async fn api_spawn_failure_routes_failure_back_to_runtime() {
         .send(selvedge_command_model::RouterIngressMessage::Core(
             CoreOutputEnvelope {
                 task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
                 message: CoreOutputMessage::RequestModelCall(valid_model_request("task-1")),
             },
         ))
@@ -200,6 +201,7 @@ async fn removing_runtime_discards_late_core_external_requests() {
         .send(selvedge_command_model::RouterIngressMessage::Core(
             CoreOutputEnvelope {
                 task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
                 message: CoreOutputMessage::RequestModelCall(valid_model_request("task-1")),
             },
         ))
@@ -210,6 +212,7 @@ async fn removing_runtime_discards_late_core_external_requests() {
         .send(selvedge_command_model::RouterIngressMessage::Core(
             CoreOutputEnvelope {
                 task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
                 message: CoreOutputMessage::RequestToolExecution(valid_tool_request("task-1")),
             },
         ))
@@ -218,6 +221,121 @@ async fn removing_runtime_discards_late_core_external_requests() {
 
     api.expect_no_request().await;
     tool.expect_no_request().await;
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn replaced_runtime_discards_stale_core_external_requests() {
+    let factory = Arc::new(RecordingFactoryExecutor::default());
+    let api = Arc::new(RecordingApiExecutor::default());
+    let handle = spawn_router(RouterStartArgs {
+        db: open_test_db(),
+        events_tx: tokio::sync::mpsc::channel(8).0,
+        factory_executor: factory.clone(),
+        api_executor: api.clone(),
+        tool_executor: Arc::new(NoopToolExecutor),
+        ingress_capacity: 8,
+        pending_task_command_limit: 8,
+    })
+    .expect("spawn router");
+    let (first_tx, mut first_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        first_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        first_rx.recv().await.expect("first start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("stop-1".to_owned()),
+                command: ClientCommand::StopTaskRuntime(StopTaskRuntime {
+                    task_id: TaskId("task-1".to_owned()),
+                }),
+            },
+        ))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        first_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::RuntimeExit(
+            TaskRuntimeExitNotice {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                reason: TaskRuntimeExitReason::Stopped,
+            },
+        ))
+        .await
+        .expect("send exit");
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Client(
+            ClientCommandEnvelope {
+                client_id: None,
+                command_id: ClientCommandId("ensure-2".to_owned()),
+                command: ClientCommand::EnsureTaskRuntime(
+                    selvedge_command_model::EnsureTaskRuntime {
+                        task_id: TaskId("task-1".to_owned()),
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect("send ensure");
+    let recreate = factory.take_one_command().await;
+    let FactoryCommand::EnsureTaskRuntime(recreate) = recreate else {
+        panic!("unexpected factory command");
+    };
+    let (second_tx, mut second_rx) = tokio::sync::mpsc::channel(8);
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Factory(
+            FactoryOutputEnvelope {
+                effect_id: recreate.effect_id,
+                output: FactoryOutput::RuntimeCreated(TaskRuntimeCreated {
+                    task_id: TaskId("task-1".to_owned()),
+                    runtime: TaskRuntimeHandle {
+                        runtime_token: TaskRuntimeToken("runtime-2".to_owned()),
+                        task_runtime_tx: second_tx,
+                    },
+                    created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
+                }),
+            },
+        ))
+        .await
+        .expect("send replacement runtime");
+    assert!(matches!(
+        second_rx.recv().await.expect("second start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .router_tx
+        .send(selvedge_command_model::RouterIngressMessage::Core(
+            CoreOutputEnvelope {
+                task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
+                message: CoreOutputMessage::RequestModelCall(valid_model_request("task-1")),
+            },
+        ))
+        .await
+        .expect("send stale request");
+
+    api.expect_no_request().await;
 
     shutdown(handle).await;
 }
@@ -1492,23 +1610,38 @@ async fn domain_history_commit_emits_typed_history_event() {
         UnixTs(2),
     )
     .expect("append user message");
+    let factory = Arc::new(RecordingFactoryExecutor::default());
     let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        factory_executor: factory.clone(),
         api_executor: Arc::new(NoopApiExecutor),
         tool_executor: Arc::new(NoopToolExecutor),
         ingress_capacity: 8,
         pending_task_command_limit: 8,
     })
     .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
 
     handle
         .router_tx
         .send(selvedge_command_model::RouterIngressMessage::Core(
             CoreOutputEnvelope {
                 task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
                 message: CoreOutputMessage::PublishDomainEvent(DomainEventPublishRequest {
                     task_id: TaskId("task-1".to_owned()),
                     event: DomainEvent::UserMessageCommitted { node_id },
@@ -1542,23 +1675,38 @@ async fn domain_history_commit_emits_typed_history_event() {
 async fn runtime_ready_emits_task_changed_event() {
     let db = open_test_db();
     create_root(&db, "task-1");
+    let factory = Arc::new(RecordingFactoryExecutor::default());
     let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        factory_executor: Arc::new(RecordingFactoryExecutor::default()),
+        factory_executor: factory.clone(),
         api_executor: Arc::new(NoopApiExecutor),
         tool_executor: Arc::new(NoopToolExecutor),
         ingress_capacity: 8,
         pending_task_command_limit: 8,
     })
     .expect("spawn router");
+    let (task_runtime_tx, mut task_runtime_rx) = tokio::sync::mpsc::channel(8);
+    register_runtime(
+        &handle.router_tx,
+        &factory,
+        task_runtime_tx,
+        TaskId("task-1".to_owned()),
+        TaskRuntimeToken("runtime-1".to_owned()),
+    )
+    .await;
+    assert!(matches!(
+        task_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
 
     handle
         .router_tx
         .send(selvedge_command_model::RouterIngressMessage::Core(
             CoreOutputEnvelope {
                 task_id: TaskId("task-1".to_owned()),
+                runtime_token: TaskRuntimeToken("runtime-1".to_owned()),
                 message: CoreOutputMessage::RuntimeReady,
             },
         ))

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -6,8 +6,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use selvedge_command_model::{
     CreatedRuntimeKind, FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput,
     FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason, FactorySkippedTask,
-    FactoryTaskFailure, RouterIngressFactoryMessage, RouterIngressMessage, RouterIngressSender,
-    RuntimeInventoryQuery, RuntimeInventoryResponse, TaskRuntimeCreated,
+    FactoryTaskFailure, RouterIngressMessage, RouterIngressSender, RuntimeInventoryQuery,
+    RuntimeInventoryResponse, TaskRuntimeCreated, TaskRuntimeHandle, TaskRuntimeToken,
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, TaskRuntimeSpawnDeps};
 use selvedge_db::{
@@ -214,7 +214,7 @@ async fn query_runtime_inventory(
 ) -> Result<RuntimeInventoryResponse, String> {
     let (reply_to, reply_rx) = tokio::sync::oneshot::channel();
     router_tx
-        .send(RouterIngressMessage::QueryRuntimeInventory(
+        .send(RouterIngressMessage::RuntimeInventoryQuery(
             RuntimeInventoryQuery { reply_to },
         ))
         .await
@@ -299,13 +299,17 @@ fn spawn_task_runtime_created(
         .spawner
         .spawn_task_runtime(SpawnTaskRuntimeArgs {
             task_id: task_id.clone(),
+            runtime_token: TaskRuntimeToken(format!("{}-runtime-{}", task_id.0, Uuid::new_v4())),
             db: db.clone(),
             router_tx: router_tx.clone(),
             config: core_spawn_deps.config.clone(),
         }) {
         Ok(spawned) => Ok(TaskRuntimeCreated {
             task_id: spawned.task_id,
-            task_runtime_tx: spawned.task_runtime_tx,
+            runtime: TaskRuntimeHandle {
+                runtime_token: spawned.runtime_token,
+                task_runtime_tx: spawned.task_runtime_tx,
+            },
             created_runtime_kind,
         }),
         Err(error) => Err(FactoryFailure {
@@ -322,9 +326,10 @@ async fn send_output(
     output: FactoryOutput,
 ) {
     let _ = router_tx
-        .send(RouterIngressMessage::Factory(
-            RouterIngressFactoryMessage::Output(FactoryOutputEnvelope { effect_id, output }),
-        ))
+        .send(RouterIngressMessage::Factory(FactoryOutputEnvelope {
+            effect_id,
+            output,
+        }))
         .await;
 }
 

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -74,6 +74,7 @@ async fn run_factory_effect(args: FactoryEffectArgs) {
                 &args.db,
                 &args.router_tx,
                 &args.core_spawn_deps,
+                &command.effect_id,
                 command.task_id,
                 CreatedRuntimeKind::ExistingTaskRuntime,
             )
@@ -81,9 +82,13 @@ async fn run_factory_effect(args: FactoryEffectArgs) {
             send_output(args.router_tx, command.effect_id, output).await;
         }
         FactoryCommand::EnsureMissingTaskRuntimes(command) => {
-            let output =
-                ensure_missing_task_runtimes(&args.db, &args.router_tx, &args.core_spawn_deps)
-                    .await;
+            let output = ensure_missing_task_runtimes(
+                &args.db,
+                &args.router_tx,
+                &args.core_spawn_deps,
+                &command.effect_id,
+            )
+            .await;
             send_output(args.router_tx, command.effect_id, output).await;
         }
         FactoryCommand::CreateChildTaskAndRuntime(command) => {
@@ -134,8 +139,9 @@ async fn ensure_missing_task_runtimes(
     db: &DbPool,
     router_tx: &RouterIngressSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
+    effect_id: &FactoryEffectId,
 ) -> FactoryOutput {
-    let inventory = match query_runtime_inventory(router_tx).await {
+    let inventory = match query_runtime_inventory(router_tx, effect_id).await {
         Ok(inventory) => inventory,
         Err(message) => {
             return FactoryOutput::Failed(FactoryFailure {
@@ -211,11 +217,15 @@ async fn ensure_missing_task_runtimes(
 
 async fn query_runtime_inventory(
     router_tx: &RouterIngressSender,
+    effect_id: &FactoryEffectId,
 ) -> Result<RuntimeInventoryResponse, String> {
     let (reply_to, reply_rx) = tokio::sync::oneshot::channel();
     router_tx
         .send(RouterIngressMessage::RuntimeInventoryQuery(
-            RuntimeInventoryQuery { reply_to },
+            RuntimeInventoryQuery {
+                requesting_effect_id: Some(effect_id.clone()),
+                reply_to,
+            },
         ))
         .await
         .map_err(|_| "runtime inventory query could not be sent".to_owned())?;
@@ -228,12 +238,13 @@ async fn ensure_task_runtime(
     db: &DbPool,
     router_tx: &RouterIngressSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
+    effect_id: &FactoryEffectId,
     task_id: TaskId,
     created_runtime_kind: CreatedRuntimeKind,
 ) -> FactoryOutput {
     match load_active_task(db, &task_id) {
         Ok(_) => {
-            let inventory = match query_runtime_inventory(router_tx).await {
+            let inventory = match query_runtime_inventory(router_tx, effect_id).await {
                 Ok(inventory) => inventory,
                 Err(message) => {
                     return FactoryOutput::Failed(FactoryFailure {

--- a/crates/task-runtime-factory/tests/factory_contract.rs
+++ b/crates/task-runtime-factory/tests/factory_contract.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use selvedge_command_model::{
     CreatedRuntimeKind, FactoryEffectId, FactoryFailureKind, FactoryOutput, FactorySkipReason,
-    RouterIngressFactoryMessage, RouterIngressMessage, RuntimeInventoryResponse,
+    RouterIngressMessage, RuntimeInventoryResponse,
 };
 use selvedge_core::{
     SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
@@ -46,8 +46,7 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
     handle.await.expect("factory task joins");
 
     let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
+    let RouterIngressMessage::Factory(envelope) = message else {
         panic!("unexpected router message");
     };
     assert_eq!(envelope.effect_id, FactoryEffectId("factory-1".to_owned()));
@@ -142,7 +141,7 @@ async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
         .await
         .expect("runtime inventory query")
         .expect("runtime inventory message");
-    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
+    let RouterIngressMessage::RuntimeInventoryQuery(query) = query else {
         panic!("unexpected router message");
     };
     query
@@ -155,8 +154,7 @@ async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
 
     handle.await.expect("factory task joins");
     let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
+    let RouterIngressMessage::Factory(envelope) = message else {
         panic!("unexpected router message");
     };
     assert_eq!(
@@ -230,8 +228,7 @@ async fn create_child_task_and_runtime_persists_child_and_copies_parent_settings
     handle.await.expect("factory task joins");
 
     let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
+    let RouterIngressMessage::Factory(envelope) = message else {
         panic!("unexpected router message");
     };
     assert_eq!(
@@ -283,7 +280,7 @@ async fn ensure_missing_task_runtimes_reports_unavailable_inventory() {
     .expect("spawn factory effect");
 
     let query = router_rx.recv().await.expect("runtime inventory query");
-    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
+    let RouterIngressMessage::RuntimeInventoryQuery(query) = query else {
         panic!("unexpected router message");
     };
     drop(query);
@@ -495,8 +492,7 @@ async fn recv_factory_output(
     router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
 ) -> FactoryOutput {
     let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
+    let RouterIngressMessage::Factory(envelope) = message else {
         panic!("unexpected router message");
     };
     envelope.output
@@ -508,7 +504,7 @@ async fn answer_inventory(
     pending_task_runtime_effects: Vec<TaskId>,
 ) {
     let query = router_rx.recv().await.expect("runtime inventory query");
-    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
+    let RouterIngressMessage::RuntimeInventoryQuery(query) = query else {
         panic!("unexpected router message");
     };
     query


### PR DESCRIPTION
## What changed

- Added the `selvedge-router` crate for router-mediated task runtime orchestration.
- Extended `selvedge-command-model` with router ingress, client commands, runtime lifecycle, snapshots, raw events, and runtime inventory contracts.
- Integrated runtime tokens through core, task-runtime-factory, router, API/tool routing, and runtime exit handling.
- Added router-mediated snapshot, event projection, runtime registry, pending command, lifecycle retry, and stale output protection behavior.
- Added DB read helpers needed by router snapshots and event projection.

## Why

The router design moves client, factory, runtime, API, tool, and event ingress through a single actor boundary so runtime lifecycle and client-facing state remain coordinated.

## Correctness notes

- Core output is authenticated by task id plus runtime token.
- External API/tool results are matched against an in-flight registry before status publication.
- Runtime removal and replacement paths discard stale requests/results.
- Attach hydration failure now emits a notice and detaches the client.
- Embedded task ids in core-originated requests/events are validated before dispatch.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `rtk cargo test --workspace --all-targets --all-features`
- `just hooks`
- `codex-review-final main`
