### PR TITLE
Implement selvedge router command model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/,task-runtime-factory/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/,router/,task-runtime-factory/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -105,6 +105,9 @@ This file is for coding agents working in this repository.
 |crates/events/tests:{events_contract.rs}
 |crates/logging:{src/,Cargo.toml,README.md}
 |crates/logging/src:{lib.rs}
+|crates/router:{src/,tests/,Cargo.toml,README.md}
+|crates/router/src:{lib.rs}
+|crates/router/tests:{router_contract.rs}
 |crates/task-runtime-factory:{src/,tests/,Cargo.toml,README.md}
 |crates/task-runtime-factory/src:{lib.rs}
 |crates/task-runtime-factory/tests:{factory_contract.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-router"
+version = "0.0.0"
+dependencies = [
+ "selvedge-api",
+ "selvedge-command-model",
+ "selvedge-core",
+ "selvedge-db",
+ "selvedge-domain-model",
+ "selvedge-events",
+ "selvedge-task-runtime-factory",
+ "tokio",
+]
+
+[[package]]
 name = "selvedge-task-runtime-factory"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/domain-model",
     "crates/events",
     "crates/logging",
+    "crates/router",
     "crates/task-runtime-factory",
     "xtask",
 ]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -182,10 +182,7 @@ async fn send_output(
     router_tx: RouterIngressSender,
     envelope: ApiOutputEnvelope,
 ) -> ApiCallTerminalStatus {
-    match router_tx
-        .send(RouterIngressApiMessage::ApiOutput(envelope))
-        .await
-    {
+    match router_tx.send(RouterIngressApiMessage::ApiOutput(envelope)) {
         Ok(()) => ApiCallTerminalStatus::OutputSent,
         Err(_) => ApiCallTerminalStatus::RouterClosed,
     }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use selvedge_command_model::{
     ApiOutputEnvelope, ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind,
-    RouterIngressApiMessage, RouterIngressSender, validate_dispatch_request,
+    RouterIngressApiMessage, RouterIngressWeakSender, validate_dispatch_request,
 };
 use selvedge_domain_model::{
     ConversationPath, ModelProviderProfile, ModelReply, ResponsePreference, ToolManifest,
@@ -68,7 +68,7 @@ pub enum ProviderCallErrorKind {
 
 pub async fn execute_model_call(
     request: ModelCallDispatchRequest,
-    router_tx: RouterIngressSender,
+    router_tx: RouterIngressWeakSender,
     provider_registry: Arc<dyn ModelProviderRegistry>,
     config: ApiExecutorConfig,
 ) -> ApiCallTerminalStatus {
@@ -78,7 +78,7 @@ pub async fn execute_model_call(
 
 pub fn spawn_model_call_tokio_task(
     request: ModelCallDispatchRequest,
-    router_tx: RouterIngressSender,
+    router_tx: RouterIngressWeakSender,
     provider_registry: Arc<dyn ModelProviderRegistry>,
     config: ApiExecutorConfig,
 ) -> tokio::task::JoinHandle<ApiCallTerminalStatus> {
@@ -179,9 +179,12 @@ async fn run_model_call(
 }
 
 async fn send_output(
-    router_tx: RouterIngressSender,
+    router_tx: RouterIngressWeakSender,
     envelope: ApiOutputEnvelope,
 ) -> ApiCallTerminalStatus {
+    let Some(router_tx) = router_tx.upgrade() else {
+        return ApiCallTerminalStatus::RouterClosed;
+    };
     match router_tx.send(RouterIngressApiMessage::ApiOutput(envelope)) {
         Ok(()) => ApiCallTerminalStatus::OutputSent,
         Err(_) => ApiCallTerminalStatus::RouterClosed,

--- a/crates/api/tests/api_contract.rs
+++ b/crates/api/tests/api_contract.rs
@@ -29,7 +29,7 @@ async fn successful_provider_reply_is_sent_once_with_original_correlation() {
             }),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -71,7 +71,7 @@ async fn invalid_dispatch_request_sends_validation_failure_without_provider_call
             }),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -104,7 +104,7 @@ async fn invalid_correlation_sends_validation_failure_that_satisfies_output_vali
             }),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request,
@@ -138,7 +138,7 @@ async fn invalid_correlation_sends_validation_failure_that_satisfies_output_vali
 async fn missing_provider_sends_provider_request_failure() {
     let request = valid_dispatch_request();
     let registry = Arc::new(StaticRegistry::new(None));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -170,7 +170,7 @@ async fn provider_network_failure_is_classified() {
             message: "network".to_owned(),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -202,7 +202,7 @@ async fn provider_timeout_is_classified() {
             message: "timeout".to_owned(),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -234,7 +234,7 @@ async fn provider_cancelled_failure_is_classified() {
             message: "cancelled".to_owned(),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -259,7 +259,7 @@ async fn invalid_provider_response_is_classified() {
     let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
         ProviderModelResponse { reply: None },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -302,7 +302,7 @@ async fn response_byte_limit_applies_to_tool_call_arguments() {
             }),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -345,7 +345,7 @@ async fn response_byte_limit_includes_structural_payload_bytes() {
             }),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -388,7 +388,7 @@ async fn response_byte_limit_counts_escaped_structured_payload_bytes() {
             }),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
@@ -424,7 +424,7 @@ async fn closed_router_mailbox_discards_completion_result() {
             }),
         },
     )))));
-    let (router_tx, router_rx) = mpsc::channel(1);
+    let (router_tx, router_rx) = mpsc::unbounded_channel();
     drop(router_rx);
 
     let status = execute_model_call(
@@ -454,7 +454,7 @@ async fn spawn_model_call_tokio_task_returns_terminal_status() {
             }),
         },
     )))));
-    let (router_tx, mut router_rx) = mpsc::channel(1);
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let handle = spawn_model_call_tokio_task(
         request,

--- a/crates/api/tests/api_contract.rs
+++ b/crates/api/tests/api_contract.rs
@@ -33,7 +33,7 @@ async fn successful_provider_reply_is_sent_once_with_original_correlation() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -75,7 +75,7 @@ async fn invalid_dispatch_request_sends_validation_failure_without_provider_call
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -108,7 +108,7 @@ async fn invalid_correlation_sends_validation_failure_that_satisfies_output_vali
 
     let status = execute_model_call(
         request,
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -142,7 +142,7 @@ async fn missing_provider_sends_provider_request_failure() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -174,7 +174,7 @@ async fn provider_network_failure_is_classified() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -206,7 +206,7 @@ async fn provider_timeout_is_classified() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -238,7 +238,7 @@ async fn provider_cancelled_failure_is_classified() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -263,7 +263,7 @@ async fn invalid_provider_response_is_classified() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -306,7 +306,7 @@ async fn response_byte_limit_applies_to_tool_call_arguments() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -349,7 +349,7 @@ async fn response_byte_limit_includes_structural_payload_bytes() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -392,7 +392,7 @@ async fn response_byte_limit_counts_escaped_structured_payload_bytes() {
 
     let status = execute_model_call(
         request.clone(),
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -429,7 +429,7 @@ async fn closed_router_mailbox_discards_completion_result() {
 
     let status = execute_model_call(
         request,
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
@@ -458,7 +458,7 @@ async fn spawn_model_call_tokio_task_returns_terminal_status() {
 
     let handle = spawn_model_call_tokio_task(
         request,
-        router_tx,
+        router_tx.downgrade(),
         registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -2,7 +2,7 @@
 
 This crate defines the Selvedge command model API slice used to dispatch model calls, return completed API outputs to the router, and describe router-mediated client event ingress.
 
-Use it to define model-call request correlation, dispatch request, output envelope, call error, router ingress API message types, factory output and runtime inventory messages, event ingress messages, client subscriptions, client snapshots, raw events, and client outbound frames.
+Use it to define model-call request correlation, dispatch request, output envelope, call error, router ingress message types, router commands, factory output messages, event ingress messages, client subscriptions, client snapshots, raw events, and client outbound frames.
 
 This crate is not for network access, database access, filesystem access, provider execution, or task runtime mutation.
 

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -10,4 +10,4 @@ This crate is not for network access, database access, filesystem access, provid
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 
-Factory effects report through `RouterIngressMessage::Factory`. Runtime inventory requests use `RouterIngressMessage::QueryRuntimeInventory` and return live plus pending task runtime task ids through a oneshot response.
+Factory output envelopes are returned by synchronous factory calls. Runtime inventory is supplied to the factory by the router from router-owned live and pending task runtime state.

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -7,8 +7,8 @@ Use it to define model-call request correlation, dispatch request, output envelo
 This crate is not for network access, database access, filesystem access, provider execution, or task runtime mutation.
 
 `RuntimeReady` is only a readiness signal. The task runtime sender is returned by `selvedge-core::spawn_task_runtime` to the creator that owns router registration.
-`TaskRuntimeInstanceId` identifies one spawned runtime instance so the router can ignore stale exits from replaced runtimes.
-`TaskRuntimeCommand::Stop` carries a one-shot acknowledgement sender. A runtime sends the acknowledgement only after it has processed all commands that were ahead of `Stop` in its mailbox and is ready to exit.
+`TaskRuntimeControl` is the shared control block for one runtime. Freeze is a state bit on that control block. `TaskRuntimeControl::stop` is an async function with synchronous barrier semantics: it sets the stop bit and resolves only after the runtime actor writes `TaskRuntimeStopResult`.
+`TaskRuntimeCommand` carries business input only. Stop is outside the business mailbox.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -10,6 +10,7 @@ This crate is not for network access, database access, filesystem access, provid
 `TaskRuntimeControl` is the shared control block for one runtime. Freeze is a state bit on that control block. `TaskRuntimeControl::stop` is an async function with synchronous barrier semantics: it sets the stop bit and resolves only after the runtime actor writes `TaskRuntimeStopResult`.
 `TaskRuntimeCommand` carries business input only. Stop is outside the business mailbox.
 `RouterIngressSender` is unbounded. Runtime, API, and tool outputs must be able to enqueue router ingress without awaiting router mailbox capacity, because router stop waits synchronously for runtime actors to finish.
+`RouterIngressWeakSender` is for internal router producers. Internal producers upgrade it only while an external ingress owner keeps the router mailbox open.
 `CoreOutputEnvelope` carries `task_id` for task-based router routing.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -7,6 +7,7 @@ Use it to define model-call request correlation, dispatch request, output envelo
 This crate is not for network access, database access, filesystem access, provider execution, or task runtime mutation.
 
 `RuntimeReady` is only a readiness signal. The task runtime sender is returned by `selvedge-core::spawn_task_runtime` to the creator that owns router registration.
+`TaskRuntimeInstanceId` identifies one spawned runtime instance so the router can ignore stale exits from replaced runtimes.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -10,6 +10,7 @@ This crate is not for network access, database access, filesystem access, provid
 `TaskRuntimeControl` is the shared control block for one runtime. Freeze is a state bit on that control block. `TaskRuntimeControl::stop` is an async function with synchronous barrier semantics: it sets the stop bit and resolves only after the runtime actor writes `TaskRuntimeStopResult`.
 `TaskRuntimeCommand` carries business input only. Stop is outside the business mailbox.
 `RouterIngressSender` is unbounded. Runtime, API, and tool outputs must be able to enqueue router ingress without awaiting router mailbox capacity, because router stop waits synchronously for runtime actors to finish.
+`CoreOutputEnvelope` carries `task_id` for task-based router routing.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -8,6 +8,7 @@ This crate is not for network access, database access, filesystem access, provid
 
 `RuntimeReady` is only a readiness signal. The task runtime sender is returned by `selvedge-core::spawn_task_runtime` to the creator that owns router registration.
 `TaskRuntimeInstanceId` identifies one spawned runtime instance so the router can ignore stale exits from replaced runtimes.
+`TaskRuntimeCommand::Stop` carries a one-shot acknowledgement sender. A runtime sends the acknowledgement only after it has processed all commands that were ahead of `Stop` in its mailbox and is ready to exit.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -9,6 +9,7 @@ This crate is not for network access, database access, filesystem access, provid
 `RuntimeReady` is only a readiness signal. The task runtime sender is returned by `selvedge-core::spawn_task_runtime` to the creator that owns router registration.
 `TaskRuntimeControl` is the shared control block for one runtime. Freeze is a state bit on that control block. `TaskRuntimeControl::stop` is an async function with synchronous barrier semantics: it sets the stop bit and resolves only after the runtime actor writes `TaskRuntimeStopResult`.
 `TaskRuntimeCommand` carries business input only. Stop is outside the business mailbox.
+`RouterIngressSender` is unbounded. Runtime, API, and tool outputs must be able to enqueue router ingress without awaiting router mailbox capacity, because router stop waits synchronously for runtime actors to finish.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
 

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -134,6 +134,8 @@ pub enum RouterCommand {
 pub enum RouterCommandValidationError {
     MissingClientId,
     MissingClientCommandId,
+    MismatchedClientId,
+    MismatchedClientCommandId,
     EmptyTaskId,
     EmptyMessageText,
     EmptyParentTaskId,
@@ -650,6 +652,12 @@ pub fn validate_router_command(
             validate_client_command_id(command.client_command_id.as_ref())?;
             validate_client_id(Some(client_id))?;
             validate_client_command_id(Some(client_command_id))?;
+            if command.client_id.as_ref() != Some(client_id) {
+                return Err(RouterCommandValidationError::MismatchedClientId);
+            }
+            if command.client_command_id.as_ref() != Some(client_command_id) {
+                return Err(RouterCommandValidationError::MismatchedClientCommandId);
+            }
         }
         RouterCommand::SendUserInput {
             task_id,

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -81,6 +81,7 @@ pub enum RouterIngressMessage {
 
 pub type RouterIngressApiMessage = RouterIngressMessage;
 pub type RouterIngressSender = mpsc::UnboundedSender<RouterIngressMessage>;
+pub type RouterIngressWeakSender = mpsc::WeakUnboundedSender<RouterIngressMessage>;
 pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
 pub type ModelCallRequest = ModelCallDispatchRequest;
 pub type EventIngressSender = mpsc::Sender<EventIngress>;

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -157,6 +157,7 @@ pub enum FactoryOutput {
 #[derive(Debug)]
 pub struct TaskRuntimeCreated {
     pub task_id: TaskId,
+    pub task_runtime_instance_id: TaskRuntimeInstanceId,
     pub task_runtime_tx: TaskRuntimeSender,
     pub created_runtime_kind: CreatedRuntimeKind,
 }
@@ -518,6 +519,9 @@ pub enum DetachReason {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TaskRuntimeInstanceId(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ToolExecutionRunId(pub String);
 
 #[derive(Debug)]
@@ -533,6 +537,7 @@ pub enum TaskRuntimeCommand {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TaskRuntimeExitNotice {
     pub task_id: TaskId,
+    pub task_runtime_instance_id: TaskRuntimeInstanceId,
     pub reason: TaskRuntimeExitReason,
 }
 

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use selvedge_domain_model::{
     ApiDomainValidationError, ConversationPath, FunctionCallId, HistoryNodeId, MessageRole,
@@ -79,6 +79,7 @@ pub enum RouterIngressMessage {
 pub type RouterIngressApiMessage = RouterIngressMessage;
 pub type RouterIngressSender = mpsc::Sender<RouterIngressMessage>;
 pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
+pub type TaskRuntimeStopAckSender = oneshot::Sender<TaskRuntimeStopAck>;
 pub type ModelCallRequest = ModelCallDispatchRequest;
 pub type EventIngressSender = mpsc::Sender<EventIngress>;
 pub type ClientFrameSender = mpsc::Sender<ClientFrame>;
@@ -521,6 +522,12 @@ pub enum DetachReason {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TaskRuntimeInstanceId(pub String);
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskRuntimeStopAck {
+    pub task_id: TaskId,
+    pub task_runtime_instance_id: TaskRuntimeInstanceId,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ToolExecutionRunId(pub String);
 
@@ -531,7 +538,7 @@ pub enum TaskRuntimeCommand {
     ApiModelReply(ApiOutputEnvelope),
     ToolResult(ToolExecutionResult),
     Archive,
-    Stop,
+    Stop { ack_tx: TaskRuntimeStopAckSender },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -80,7 +80,7 @@ pub enum RouterIngressMessage {
 }
 
 pub type RouterIngressApiMessage = RouterIngressMessage;
-pub type RouterIngressSender = mpsc::Sender<RouterIngressMessage>;
+pub type RouterIngressSender = mpsc::UnboundedSender<RouterIngressMessage>;
 pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
 pub type ModelCallRequest = ModelCallDispatchRequest;
 pub type EventIngressSender = mpsc::Sender<EventIngress>;

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -1,8 +1,11 @@
 #![doc = include_str!("../README.md")]
 
 use std::collections::BTreeSet;
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Mutex, Notify, mpsc};
 
 use selvedge_domain_model::{
     ApiDomainValidationError, ConversationPath, FunctionCallId, HistoryNodeId, MessageRole,
@@ -79,7 +82,6 @@ pub enum RouterIngressMessage {
 pub type RouterIngressApiMessage = RouterIngressMessage;
 pub type RouterIngressSender = mpsc::Sender<RouterIngressMessage>;
 pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
-pub type TaskRuntimeStopAckSender = oneshot::Sender<TaskRuntimeStopAck>;
 pub type ModelCallRequest = ModelCallDispatchRequest;
 pub type EventIngressSender = mpsc::Sender<EventIngress>;
 pub type ClientFrameSender = mpsc::Sender<ClientFrame>;
@@ -158,8 +160,8 @@ pub enum FactoryOutput {
 #[derive(Debug)]
 pub struct TaskRuntimeCreated {
     pub task_id: TaskId,
-    pub task_runtime_instance_id: TaskRuntimeInstanceId,
     pub task_runtime_tx: TaskRuntimeSender,
+    pub task_runtime_control: TaskRuntimeControl,
     pub created_runtime_kind: CreatedRuntimeKind,
 }
 
@@ -519,14 +521,105 @@ pub enum DetachReason {
     EventsShutdown,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TaskRuntimeInstanceId(pub String);
+#[derive(Clone)]
+pub struct TaskRuntimeControl {
+    inner: Arc<TaskRuntimeControlInner>,
+}
+
+struct TaskRuntimeControlInner {
+    frozen: AtomicBool,
+    stopping: AtomicBool,
+    stop_result: Mutex<Option<TaskRuntimeStopResult>>,
+    actor_notify: Notify,
+    stop_notify: Notify,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TaskRuntimeStopAck {
-    pub task_id: TaskId,
-    pub task_runtime_instance_id: TaskRuntimeInstanceId,
+pub struct TaskRuntimeStopResult;
+
+impl TaskRuntimeControl {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(TaskRuntimeControlInner {
+                frozen: AtomicBool::new(false),
+                stopping: AtomicBool::new(false),
+                stop_result: Mutex::new(None),
+                actor_notify: Notify::new(),
+                stop_notify: Notify::new(),
+            }),
+        }
+    }
+
+    pub fn freeze(&self) {
+        self.inner.frozen.store(true, Ordering::SeqCst);
+        self.inner.actor_notify.notify_one();
+    }
+
+    pub fn unfreeze(&self) {
+        self.inner.frozen.store(false, Ordering::SeqCst);
+        self.inner.actor_notify.notify_one();
+    }
+
+    pub fn is_frozen(&self) -> bool {
+        self.inner.frozen.load(Ordering::SeqCst)
+    }
+
+    pub fn is_stopping(&self) -> bool {
+        self.inner.stopping.load(Ordering::SeqCst)
+    }
+
+    pub async fn stop(&self) -> TaskRuntimeStopResult {
+        self.inner.stopping.store(true, Ordering::SeqCst);
+        self.inner.actor_notify.notify_one();
+        loop {
+            let notified = self.inner.stop_notify.notified();
+            if let Some(result) = self.inner.stop_result.lock().await.clone() {
+                return result;
+            }
+            notified.await;
+        }
+    }
+
+    pub async fn wait_for_control_change(&self) {
+        self.inner.actor_notify.notified().await;
+    }
+
+    pub async fn finish_stop(&self, result: TaskRuntimeStopResult) {
+        let mut stop_result = self.inner.stop_result.lock().await;
+        if stop_result.is_none() {
+            *stop_result = Some(result);
+            self.inner.stop_notify.notify_waiters();
+        }
+    }
+
+    pub fn same_control(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
 }
+
+impl Default for TaskRuntimeControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for TaskRuntimeControl {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TaskRuntimeControl")
+            .field("frozen", &self.is_frozen())
+            .field("stopping", &self.is_stopping())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for TaskRuntimeControl {
+    fn eq(&self, other: &Self) -> bool {
+        self.same_control(other)
+    }
+}
+
+impl Eq for TaskRuntimeControl {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ToolExecutionRunId(pub String);
@@ -538,13 +631,12 @@ pub enum TaskRuntimeCommand {
     ApiModelReply(ApiOutputEnvelope),
     ToolResult(ToolExecutionResult),
     Archive,
-    Stop { ack_tx: TaskRuntimeStopAckSender },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TaskRuntimeExitNotice {
     pub task_id: TaskId,
-    pub task_runtime_instance_id: TaskRuntimeInstanceId,
+    pub task_runtime_control: TaskRuntimeControl,
     pub reason: TaskRuntimeExitReason,
 }
 

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 use selvedge_domain_model::{
     ApiDomainValidationError, ConversationPath, FunctionCallId, HistoryNodeId, MessageRole,
@@ -67,13 +67,13 @@ pub enum ModelCallErrorKind {
 
 #[derive(Debug)]
 pub enum RouterIngressMessage {
+    Command(RouterCommandEnvelope),
     ApiOutput(ApiOutputEnvelope),
     Core(CoreOutputEnvelope),
     Tool(ToolExecutionResult),
     RuntimeExit(TaskRuntimeExitNotice),
-    Factory(RouterIngressFactoryMessage),
-    QueryRuntimeInventory(RuntimeInventoryQuery),
     PublishToEvents(DomainEventPublishRequest),
+    StopRouter,
 }
 
 pub type RouterIngressApiMessage = RouterIngressMessage;
@@ -87,8 +87,56 @@ pub type ClientFrameSender = mpsc::Sender<ClientFrame>;
 pub struct FactoryEffectId(pub String);
 
 #[derive(Debug)]
-pub enum RouterIngressFactoryMessage {
-    Output(FactoryOutputEnvelope),
+pub struct RouterCommandEnvelope {
+    pub client_id: Option<ClientId>,
+    pub client_command_id: Option<ClientCommandId>,
+    pub command: RouterCommand,
+}
+
+#[derive(Debug)]
+pub enum RouterCommand {
+    AttachClient {
+        client_id: ClientId,
+        client_command_id: ClientCommandId,
+        outbound: ClientFrameSender,
+        subscription: ClientSubscription,
+    },
+    DetachClient {
+        client_id: ClientId,
+        client_command_id: ClientCommandId,
+    },
+    UpdateSubscription {
+        client_id: ClientId,
+        client_command_id: ClientCommandId,
+        subscription: ClientSubscription,
+    },
+    SendUserInput {
+        task_id: TaskId,
+        message_text: String,
+    },
+    ArchiveTask {
+        task_id: TaskId,
+    },
+    StopTaskRuntime {
+        task_id: TaskId,
+    },
+    EnsureTaskRuntime {
+        task_id: TaskId,
+    },
+    EnsureMissingTaskRuntimes,
+    CreateChildTaskAndRuntime {
+        parent_task_id: TaskId,
+        child_cursor_node_id: HistoryNodeId,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RouterCommandValidationError {
+    MissingClientId,
+    MissingClientCommandId,
+    EmptyTaskId,
+    EmptyMessageText,
+    EmptyParentTaskId,
 }
 
 #[derive(Debug)]
@@ -547,17 +595,6 @@ pub enum DomainEvent {
     ErrorNotice { message: String },
 }
 
-#[derive(Debug)]
-pub struct RuntimeInventoryQuery {
-    pub reply_to: oneshot::Sender<RuntimeInventoryResponse>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RuntimeInventoryResponse {
-    pub live_task_runtimes: Vec<TaskId>,
-    pub pending_task_runtime_effects: Vec<TaskId>,
-}
-
 pub fn validate_dispatch_request(request: &ModelCallDispatchRequest) -> Result<(), ModelCallError> {
     validate_correlation(&request.correlation)?;
 
@@ -591,6 +628,52 @@ pub fn validate_api_output_envelope(envelope: &ApiOutputEnvelope) -> Result<(), 
     Ok(())
 }
 
+pub fn validate_router_command(
+    command: &RouterCommandEnvelope,
+) -> Result<(), RouterCommandValidationError> {
+    match &command.command {
+        RouterCommand::AttachClient {
+            client_id,
+            client_command_id,
+            ..
+        }
+        | RouterCommand::DetachClient {
+            client_id,
+            client_command_id,
+        }
+        | RouterCommand::UpdateSubscription {
+            client_id,
+            client_command_id,
+            ..
+        } => {
+            validate_client_id(command.client_id.as_ref())?;
+            validate_client_command_id(command.client_command_id.as_ref())?;
+            validate_client_id(Some(client_id))?;
+            validate_client_command_id(Some(client_command_id))?;
+        }
+        RouterCommand::SendUserInput {
+            task_id,
+            message_text,
+        } => {
+            validate_task_id(task_id)?;
+            if message_text.trim().is_empty() {
+                return Err(RouterCommandValidationError::EmptyMessageText);
+            }
+        }
+        RouterCommand::ArchiveTask { task_id }
+        | RouterCommand::StopTaskRuntime { task_id }
+        | RouterCommand::EnsureTaskRuntime { task_id } => validate_task_id(task_id)?,
+        RouterCommand::EnsureMissingTaskRuntimes => {}
+        RouterCommand::CreateChildTaskAndRuntime { parent_task_id, .. } => {
+            if parent_task_id.0.trim().is_empty() {
+                return Err(RouterCommandValidationError::EmptyParentTaskId);
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_correlation(correlation: &ApiCallCorrelation) -> Result<(), ModelCallError> {
     if correlation.api_effect_id.0.trim().is_empty() {
         return Err(validation_message("api_effect_id must not be empty"));
@@ -602,6 +685,30 @@ fn validate_correlation(correlation: &ApiCallCorrelation) -> Result<(), ModelCal
 
     if correlation.model_run_id.0.trim().is_empty() {
         return Err(validation_message("model_run_id must not be empty"));
+    }
+
+    Ok(())
+}
+
+fn validate_client_id(client_id: Option<&ClientId>) -> Result<(), RouterCommandValidationError> {
+    match client_id {
+        Some(client_id) if !client_id.0.trim().is_empty() => Ok(()),
+        Some(_) | None => Err(RouterCommandValidationError::MissingClientId),
+    }
+}
+
+fn validate_client_command_id(
+    client_command_id: Option<&ClientCommandId>,
+) -> Result<(), RouterCommandValidationError> {
+    match client_command_id {
+        Some(client_command_id) if !client_command_id.0.trim().is_empty() => Ok(()),
+        Some(_) | None => Err(RouterCommandValidationError::MissingClientCommandId),
+    }
+}
+
+fn validate_task_id(task_id: &TaskId) -> Result<(), RouterCommandValidationError> {
+    if task_id.0.trim().is_empty() {
+        return Err(RouterCommandValidationError::EmptyTaskId);
     }
 
     Ok(())

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -8,7 +8,8 @@ use selvedge_command_model::{
     ModelCallError, ModelCallErrorKind, ModelRunId, RouterCommand, RouterCommandEnvelope,
     RouterCommandValidationError, RouterIngressApiMessage, RouterIngressMessage,
     SnapshotTaskVersion, TaskId, TaskProjection, TaskProjectionStatus, TaskRuntimeCreated,
-    TaskScope, validate_api_output_envelope, validate_dispatch_request, validate_router_command,
+    TaskRuntimeInstanceId, TaskScope, validate_api_output_envelope, validate_dispatch_request,
+    validate_router_command,
 };
 use selvedge_domain_model::{
     ConversationMessage, ConversationPath, HistoryNodeId, MessageContent, MessageRole,
@@ -173,6 +174,7 @@ fn factory_output_envelope_exposes_runtime_created_scan_and_failure_contract() {
 
     let runtime_created = TaskRuntimeCreated {
         task_id: TaskId("task-1".to_owned()),
+        task_runtime_instance_id: TaskRuntimeInstanceId("runtime-1".to_owned()),
         task_runtime_tx,
         created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
     };

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -7,8 +7,8 @@ use selvedge_command_model::{
     FactoryTaskFailure, HistoryAppendedEvent, HistoryAppendedRawEvent, ModelCallDispatchRequest,
     ModelCallError, ModelCallErrorKind, ModelRunId, RouterCommand, RouterCommandEnvelope,
     RouterCommandValidationError, RouterIngressApiMessage, RouterIngressMessage,
-    SnapshotTaskVersion, TaskId, TaskProjection, TaskProjectionStatus, TaskRuntimeCreated,
-    TaskRuntimeInstanceId, TaskScope, validate_api_output_envelope, validate_dispatch_request,
+    SnapshotTaskVersion, TaskId, TaskProjection, TaskProjectionStatus, TaskRuntimeControl,
+    TaskRuntimeCreated, TaskScope, validate_api_output_envelope, validate_dispatch_request,
     validate_router_command,
 };
 use selvedge_domain_model::{
@@ -174,8 +174,8 @@ fn factory_output_envelope_exposes_runtime_created_scan_and_failure_contract() {
 
     let runtime_created = TaskRuntimeCreated {
         task_id: TaskId("task-1".to_owned()),
-        task_runtime_instance_id: TaskRuntimeInstanceId("runtime-1".to_owned()),
         task_runtime_tx,
+        task_runtime_control: TaskRuntimeControl::new(),
         created_runtime_kind: CreatedRuntimeKind::ExistingTaskRuntime,
     };
     let created = FactoryOutputEnvelope {

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -288,6 +288,32 @@ fn router_command_validation_enforces_envelope_and_task_payload_contract() {
         Err(RouterCommandValidationError::MissingClientId)
     );
 
+    let mismatched_client_id = RouterCommandEnvelope {
+        client_id: Some(ClientId("client-1".to_owned())),
+        client_command_id: Some(ClientCommandId("detach-1".to_owned())),
+        command: RouterCommand::DetachClient {
+            client_id: ClientId("client-2".to_owned()),
+            client_command_id: ClientCommandId("detach-1".to_owned()),
+        },
+    };
+    assert_eq!(
+        validate_router_command(&mismatched_client_id),
+        Err(RouterCommandValidationError::MismatchedClientId)
+    );
+
+    let mismatched_client_command_id = RouterCommandEnvelope {
+        client_id: Some(ClientId("client-1".to_owned())),
+        client_command_id: Some(ClientCommandId("detach-1".to_owned())),
+        command: RouterCommand::DetachClient {
+            client_id: ClientId("client-1".to_owned()),
+            client_command_id: ClientCommandId("detach-2".to_owned()),
+        },
+    };
+    assert_eq!(
+        validate_router_command(&mismatched_client_command_id),
+        Err(RouterCommandValidationError::MismatchedClientCommandId)
+    );
+
     let empty_task_id = RouterCommandEnvelope {
         client_id: None,
         client_command_id: None,

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -5,10 +5,10 @@ use selvedge_command_model::{
     EventIngress, FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput,
     FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason, FactorySkippedTask,
     FactoryTaskFailure, HistoryAppendedEvent, HistoryAppendedRawEvent, ModelCallDispatchRequest,
-    ModelCallError, ModelCallErrorKind, ModelRunId, RouterIngressApiMessage,
-    RouterIngressFactoryMessage, RouterIngressMessage, RuntimeInventoryQuery,
-    RuntimeInventoryResponse, SnapshotTaskVersion, TaskId, TaskProjection, TaskProjectionStatus,
-    TaskRuntimeCreated, TaskScope, validate_api_output_envelope, validate_dispatch_request,
+    ModelCallError, ModelCallErrorKind, ModelRunId, RouterCommand, RouterCommandEnvelope,
+    RouterCommandValidationError, RouterIngressApiMessage, RouterIngressMessage,
+    SnapshotTaskVersion, TaskId, TaskProjection, TaskProjectionStatus, TaskRuntimeCreated,
+    TaskScope, validate_api_output_envelope, validate_dispatch_request, validate_router_command,
 };
 use selvedge_domain_model::{
     ConversationMessage, ConversationPath, HistoryNodeId, MessageContent, MessageRole,
@@ -241,39 +241,77 @@ fn factory_output_envelope_exposes_runtime_created_scan_and_failure_contract() {
 
 #[test]
 fn router_ingress_exposes_factory_output_and_runtime_inventory_query() {
-    let envelope = FactoryOutputEnvelope {
-        effect_id: FactoryEffectId("factory-1".to_owned()),
-        output: FactoryOutput::Failed(FactoryFailure {
-            task_id: None,
-            kind: FactoryFailureKind::RuntimeInventoryUnavailable,
-            message: "inventory unavailable".to_owned(),
-        }),
+    let command = RouterIngressMessage::Command(RouterCommandEnvelope {
+        client_id: None,
+        client_command_id: None,
+        command: RouterCommand::EnsureMissingTaskRuntimes,
+    });
+    assert!(matches!(command, RouterIngressMessage::Command(_)));
+
+    let stop = RouterIngressMessage::StopRouter;
+    assert!(matches!(stop, RouterIngressMessage::StopRouter));
+}
+
+#[test]
+fn router_command_validation_enforces_envelope_and_task_payload_contract() {
+    let (outbound, _outbound_rx) = tokio::sync::mpsc::channel(4);
+    let subscription = ClientSubscription {
+        task_scope: TaskScope::AllTasks,
+        detail_level: DetailLevel::Verbose,
+        include_model_call_status: true,
+        include_tool_execution_status: true,
+        include_debug_notices: true,
     };
 
-    let factory_message =
-        RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope));
-    match factory_message {
-        RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) => {
-            assert_eq!(envelope.effect_id, FactoryEffectId("factory-1".to_owned()));
-        }
-        _ => panic!("unexpected router ingress message"),
-    }
+    let attach = RouterCommandEnvelope {
+        client_id: Some(ClientId("client-1".to_owned())),
+        client_command_id: Some(ClientCommandId("attach-1".to_owned())),
+        command: RouterCommand::AttachClient {
+            client_id: ClientId("client-1".to_owned()),
+            client_command_id: ClientCommandId("attach-1".to_owned()),
+            outbound,
+            subscription,
+        },
+    };
+    validate_router_command(&attach).expect("valid attach command");
 
-    let (reply_to, _reply_rx) = tokio::sync::oneshot::channel();
-    let query = RouterIngressMessage::QueryRuntimeInventory(RuntimeInventoryQuery { reply_to });
+    let missing_client_id = RouterCommandEnvelope {
+        client_id: None,
+        client_command_id: Some(ClientCommandId("detach-1".to_owned())),
+        command: RouterCommand::DetachClient {
+            client_id: ClientId("client-1".to_owned()),
+            client_command_id: ClientCommandId("detach-1".to_owned()),
+        },
+    };
+    assert_eq!(
+        validate_router_command(&missing_client_id),
+        Err(RouterCommandValidationError::MissingClientId)
+    );
 
-    match query {
-        RouterIngressMessage::QueryRuntimeInventory(query) => {
-            query
-                .reply_to
-                .send(RuntimeInventoryResponse {
-                    live_task_runtimes: vec![TaskId("live".to_owned())],
-                    pending_task_runtime_effects: vec![TaskId("pending".to_owned())],
-                })
-                .expect("send runtime inventory response");
-        }
-        _ => panic!("unexpected router ingress message"),
-    }
+    let empty_task_id = RouterCommandEnvelope {
+        client_id: None,
+        client_command_id: None,
+        command: RouterCommand::EnsureTaskRuntime {
+            task_id: TaskId(" ".to_owned()),
+        },
+    };
+    assert_eq!(
+        validate_router_command(&empty_task_id),
+        Err(RouterCommandValidationError::EmptyTaskId)
+    );
+
+    let empty_message = RouterCommandEnvelope {
+        client_id: None,
+        client_command_id: None,
+        command: RouterCommand::SendUserInput {
+            task_id: TaskId("task-1".to_owned()),
+            message_text: " ".to_owned(),
+        },
+    };
+    assert_eq!(
+        validate_router_command(&empty_message),
+        Err(RouterCommandValidationError::EmptyMessageText)
+    );
 }
 
 fn valid_dispatch_request() -> ModelCallDispatchRequest {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 selvedge-command-model = { path = "../command-model" }
 selvedge-db = { path = "../db" }
 selvedge-domain-model = { path = "../domain-model" }
-tokio = { version = "1.42.0", features = ["rt", "sync"] }
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync"] }
 uuid = { version = "1.11.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -8,6 +8,8 @@ This crate only talks to the router mailbox and the database package. Provider c
 
 On `Start`, the runtime reads the active task snapshot and classifies the concrete cursor tail. User/system/function-output tails request a model call; function-call tails request tool execution; assistant/developer tails await user input with an empty queue. The runtime keeps only in-flight correlation ids and pending tool-call identity in memory; the task cursor lives in SQLite.
 
-The actor checks `TaskRuntimeControl` before receiving each business mailbox command. A stop request makes the actor write `TaskRuntimeStopResult` and return from its loop at that safety point.
+The actor checks `TaskRuntimeControl` before receiving each business mailbox command. A stop request makes the actor return from its loop at that safety point. The runtime writes `TaskRuntimeStopResult` from the actor's unified exit path, so a later stop call also completes after archive, database error, router shutdown, or dropped runtime mailbox.
+
+Runtime output to the router uses the unbounded router ingress sender. Event handlers can enqueue router output synchronously and return to the control check without waiting for router mailbox capacity.
 
 `TaskRuntimeSpawnDeps` wraps the runtime config and a `TaskRuntimeSpawner` implementation. Use `TaskRuntimeSpawnDeps::new` for the default Tokio-backed spawner and `with_spawner` for boundary tests.

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -8,4 +8,6 @@ This crate only talks to the router mailbox and the database package. Provider c
 
 On `Start`, the runtime reads the active task snapshot and classifies the concrete cursor tail. User/system/function-output tails request a model call; function-call tails request tool execution; assistant/developer tails await user input with an empty queue. The runtime keeps only in-flight correlation ids and pending tool-call identity in memory; the task cursor lives in SQLite.
 
+The actor checks `TaskRuntimeControl` before receiving each business mailbox command. A stop request makes the actor write `TaskRuntimeStopResult` and return from its loop at that safety point.
+
 `TaskRuntimeSpawnDeps` wraps the runtime config and a `TaskRuntimeSpawner` implementation. Use `TaskRuntimeSpawnDeps::new` for the default Tokio-backed spawner and `with_spawner` for boundary tests.

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -8,7 +8,7 @@ This crate only talks to the router mailbox and the database package. Provider c
 
 On `Start`, the runtime reads the active task snapshot and classifies the concrete cursor tail. User/system/function-output tails request a model call; function-call tails request tool execution; assistant/developer tails await user input with an empty queue. The runtime keeps only in-flight correlation ids and pending tool-call identity in memory; the task cursor lives in SQLite.
 
-The actor checks `TaskRuntimeControl` before receiving each business mailbox command. A stop request makes the actor return from its loop at that safety point. The runtime writes `TaskRuntimeStopResult` from the actor's unified exit path, so a later stop call also completes after archive, database error, router shutdown, or dropped runtime mailbox.
+The actor checks `TaskRuntimeControl` before receiving each business mailbox command. A stop request makes the actor return from its loop at that safety point. The mailbox receive branch is behind the control branch and the actor rechecks stop after receiving a command, so a stop bit observed at the event boundary prevents the next business command from starting. The runtime writes `TaskRuntimeStopResult` from the actor's unified exit path, so a later stop call also completes after archive, database error, router shutdown, or dropped runtime mailbox.
 
 Runtime output to the router uses the unbounded router ingress sender. Event handlers can enqueue router output synchronously and return to the control check without waiting for router mailbox capacity.
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,8 +7,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use selvedge_command_model::{
     ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DomainEvent,
     DomainEventPublishRequest, ModelCallDispatchRequest, ModelRunId, RouterIngressMessage,
-    RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeInstanceId, TaskRuntimeSender, TaskRuntimeStopAck, ToolExecutionRequest,
+    RouterIngressSender, TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice,
+    TaskRuntimeExitReason, TaskRuntimeSender, TaskRuntimeStopResult, ToolExecutionRequest,
     ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_db::{
@@ -82,8 +82,8 @@ pub struct SpawnTaskRuntimeArgs {
 #[derive(Debug)]
 pub struct SpawnedTaskRuntime {
     pub task_id: TaskId,
-    pub task_runtime_instance_id: TaskRuntimeInstanceId,
     pub task_runtime_tx: TaskRuntimeSender,
+    pub task_runtime_control: TaskRuntimeControl,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -97,17 +97,16 @@ pub fn spawn_task_runtime(
 ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
     let capacity = args.config.mailbox_capacity.max(1);
     let (task_runtime_tx, task_runtime_rx) = tokio::sync::mpsc::channel(capacity);
-    let task_runtime_instance_id =
-        TaskRuntimeInstanceId(format!("{}-runtime-{}", args.task_id.0, Uuid::new_v4()));
+    let task_runtime_control = TaskRuntimeControl::new();
     let spawned = SpawnedTaskRuntime {
         task_id: args.task_id.clone(),
-        task_runtime_instance_id: task_runtime_instance_id.clone(),
         task_runtime_tx: task_runtime_tx.clone(),
+        task_runtime_control: task_runtime_control.clone(),
     };
 
     let actor = TaskRuntimeActor {
         task_id: args.task_id,
-        task_runtime_instance_id,
+        task_runtime_control,
         db: args.db,
         router_tx: args.router_tx,
         rx: task_runtime_rx,
@@ -122,7 +121,7 @@ pub fn spawn_task_runtime(
 
 struct TaskRuntimeActor {
     task_id: TaskId,
-    task_runtime_instance_id: TaskRuntimeInstanceId,
+    task_runtime_control: TaskRuntimeControl,
     db: DbPool,
     router_tx: RouterIngressSender,
     rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
@@ -161,7 +160,27 @@ struct PendingToolCall {
 
 impl TaskRuntimeActor {
     async fn run(mut self) {
-        while let Some(command) = self.rx.recv().await {
+        loop {
+            if self.task_runtime_control.is_stopping() {
+                self.task_runtime_control
+                    .finish_stop(TaskRuntimeStopResult)
+                    .await;
+                break;
+            }
+            let command = if self.task_runtime_control.is_frozen() {
+                self.task_runtime_control.wait_for_control_change().await;
+                continue;
+            } else {
+                tokio::select! {
+                    _ = self.task_runtime_control.wait_for_control_change() => continue,
+                    command = self.rx.recv() => {
+                        let Some(command) = command else {
+                            break;
+                        };
+                        command
+                    }
+                }
+            };
             let should_stop = match command {
                 TaskRuntimeCommand::Start => self.handle_start().await,
                 TaskRuntimeCommand::UserInput { message_text } => {
@@ -172,16 +191,14 @@ impl TaskRuntimeActor {
                 }
                 TaskRuntimeCommand::ToolResult(result) => self.handle_tool_result(result).await,
                 TaskRuntimeCommand::Archive => self.handle_archive().await,
-                TaskRuntimeCommand::Stop { ack_tx } => {
-                    let _ = ack_tx.send(TaskRuntimeStopAck {
-                        task_id: self.task_id.clone(),
-                        task_runtime_instance_id: self.task_runtime_instance_id.clone(),
-                    });
-                    true
-                }
             };
 
             if should_stop {
+                if self.task_runtime_control.is_stopping() {
+                    self.task_runtime_control
+                        .finish_stop(TaskRuntimeStopResult)
+                        .await;
+                }
                 break;
             }
         }
@@ -607,7 +624,7 @@ impl TaskRuntimeActor {
             .router_tx
             .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
                 task_id: self.task_id.clone(),
-                task_runtime_instance_id: self.task_runtime_instance_id.clone(),
+                task_runtime_control: self.task_runtime_control.clone(),
                 reason,
             }))
             .await;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,7 +8,8 @@ use selvedge_command_model::{
     ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DomainEvent,
     DomainEventPublishRequest, ModelCallDispatchRequest, ModelRunId, RouterIngressMessage,
     RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+    TaskRuntimeInstanceId, TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult,
+    ToolExecutionRunId,
 };
 use selvedge_db::{
     DbError, DbPool, FunctionCallId, HistoryNode, HistoryNodeId, MessageRole,
@@ -81,6 +82,7 @@ pub struct SpawnTaskRuntimeArgs {
 #[derive(Debug)]
 pub struct SpawnedTaskRuntime {
     pub task_id: TaskId,
+    pub task_runtime_instance_id: TaskRuntimeInstanceId,
     pub task_runtime_tx: TaskRuntimeSender,
 }
 
@@ -95,13 +97,17 @@ pub fn spawn_task_runtime(
 ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
     let capacity = args.config.mailbox_capacity.max(1);
     let (task_runtime_tx, task_runtime_rx) = tokio::sync::mpsc::channel(capacity);
+    let task_runtime_instance_id =
+        TaskRuntimeInstanceId(format!("{}-runtime-{}", args.task_id.0, Uuid::new_v4()));
     let spawned = SpawnedTaskRuntime {
         task_id: args.task_id.clone(),
+        task_runtime_instance_id: task_runtime_instance_id.clone(),
         task_runtime_tx: task_runtime_tx.clone(),
     };
 
     let actor = TaskRuntimeActor {
         task_id: args.task_id,
+        task_runtime_instance_id,
         db: args.db,
         router_tx: args.router_tx,
         rx: task_runtime_rx,
@@ -116,6 +122,7 @@ pub fn spawn_task_runtime(
 
 struct TaskRuntimeActor {
     task_id: TaskId,
+    task_runtime_instance_id: TaskRuntimeInstanceId,
     db: DbPool,
     router_tx: RouterIngressSender,
     rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
@@ -597,6 +604,7 @@ impl TaskRuntimeActor {
             .router_tx
             .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
                 task_id: self.task_id.clone(),
+                task_runtime_instance_id: self.task_runtime_instance_id.clone(),
                 reason,
             }))
             .await;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -169,6 +169,7 @@ impl TaskRuntimeActor {
                 continue;
             } else {
                 tokio::select! {
+                    biased;
                     _ = self.task_runtime_control.wait_for_control_change() => continue,
                     command = self.rx.recv() => {
                         let Some(command) = command else {
@@ -178,6 +179,9 @@ impl TaskRuntimeActor {
                     }
                 }
             };
+            if self.task_runtime_control.is_stopping() {
+                break;
+            }
             let should_stop = match command {
                 TaskRuntimeCommand::Start => self.handle_start().await,
                 TaskRuntimeCommand::UserInput { message_text } => {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -162,9 +162,6 @@ impl TaskRuntimeActor {
     async fn run(mut self) {
         loop {
             if self.task_runtime_control.is_stopping() {
-                self.task_runtime_control
-                    .finish_stop(TaskRuntimeStopResult)
-                    .await;
                 break;
             }
             let command = if self.task_runtime_control.is_frozen() {
@@ -194,14 +191,12 @@ impl TaskRuntimeActor {
             };
 
             if should_stop {
-                if self.task_runtime_control.is_stopping() {
-                    self.task_runtime_control
-                        .finish_stop(TaskRuntimeStopResult)
-                        .await;
-                }
                 break;
             }
         }
+        self.task_runtime_control
+            .finish_stop(TaskRuntimeStopResult)
+            .await;
     }
 
     async fn handle_start(&mut self) -> bool {
@@ -615,7 +610,6 @@ impl TaskRuntimeActor {
                 task_id: self.task_id.clone(),
                 message,
             }))
-            .await
             .map_err(|_| ())
     }
 
@@ -626,8 +620,7 @@ impl TaskRuntimeActor {
                 task_id: self.task_id.clone(),
                 task_runtime_control: self.task_runtime_control.clone(),
                 reason,
-            }))
-            .await;
+            }));
     }
 
     async fn stop_with_db_error(&self, error: DbError) -> bool {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,8 +8,8 @@ use selvedge_command_model::{
     ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DomainEvent,
     DomainEventPublishRequest, ModelCallDispatchRequest, ModelRunId, RouterIngressMessage,
     RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeInstanceId, TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult,
-    ToolExecutionRunId,
+    TaskRuntimeInstanceId, TaskRuntimeSender, TaskRuntimeStopAck, ToolExecutionRequest,
+    ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_db::{
     DbError, DbPool, FunctionCallId, HistoryNode, HistoryNodeId, MessageRole,
@@ -172,8 +172,11 @@ impl TaskRuntimeActor {
                 }
                 TaskRuntimeCommand::ToolResult(result) => self.handle_tool_result(result).await,
                 TaskRuntimeCommand::Archive => self.handle_archive().await,
-                TaskRuntimeCommand::Stop => {
-                    self.send_exit(TaskRuntimeExitReason::Stopped).await;
+                TaskRuntimeCommand::Stop { ack_tx } => {
+                    let _ = ack_tx.send(TaskRuntimeStopAck {
+                        task_id: self.task_id.clone(),
+                        task_runtime_instance_id: self.task_runtime_instance_id.clone(),
+                    });
                     true
                 }
             };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use selvedge_command_model::{
     ApiEffectId, ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DomainEvent,
     DomainEventPublishRequest, ModelCallDispatchRequest, ModelRunId, RouterIngressMessage,
-    RouterIngressSender, TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice,
+    RouterIngressWeakSender, TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice,
     TaskRuntimeExitReason, TaskRuntimeSender, TaskRuntimeStopResult, ToolExecutionRequest,
     ToolExecutionResult, ToolExecutionRunId,
 };
@@ -75,7 +75,7 @@ impl TaskRuntimeSpawner for DefaultTaskRuntimeSpawner {
 pub struct SpawnTaskRuntimeArgs {
     pub task_id: TaskId,
     pub db: DbPool,
-    pub router_tx: RouterIngressSender,
+    pub router_tx: RouterIngressWeakSender,
     pub config: TaskRuntimeConfig,
 }
 
@@ -123,7 +123,7 @@ struct TaskRuntimeActor {
     task_id: TaskId,
     task_runtime_control: TaskRuntimeControl,
     db: DbPool,
-    router_tx: RouterIngressSender,
+    router_tx: RouterIngressWeakSender,
     rx: tokio::sync::mpsc::Receiver<TaskRuntimeCommand>,
     started: bool,
     model_profiles: HashMap<ModelProfileKey, ModelProviderProfile>,
@@ -605,7 +605,10 @@ impl TaskRuntimeActor {
     }
 
     async fn send_core(&self, message: CoreOutputMessage) -> Result<(), ()> {
-        self.router_tx
+        let Some(router_tx) = self.router_tx.upgrade() else {
+            return Err(());
+        };
+        router_tx
             .send(RouterIngressMessage::Core(CoreOutputEnvelope {
                 task_id: self.task_id.clone(),
                 message,
@@ -614,13 +617,14 @@ impl TaskRuntimeActor {
     }
 
     async fn send_exit(&self, reason: TaskRuntimeExitReason) {
-        let _ = self
-            .router_tx
-            .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
-                task_id: self.task_id.clone(),
-                task_runtime_control: self.task_runtime_control.clone(),
-                reason,
-            }));
+        let Some(router_tx) = self.router_tx.upgrade() else {
+            return;
+        };
+        let _ = router_tx.send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
+            task_id: self.task_id.clone(),
+            task_runtime_control: self.task_runtime_control.clone(),
+            reason,
+        }));
     }
 
     async fn stop_with_db_error(&self, error: DbError) -> bool {

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1753,12 +1753,7 @@ async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> Mode
     })
     .expect("spawn runtime");
     let request = start_and_recv_model_request(&runtime, &mut router_rx).await;
-    let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
-    runtime
-        .task_runtime_tx
-        .send(TaskRuntimeCommand::Stop { ack_tx })
-        .await
-        .expect("stop runtime");
+    let _ = runtime.task_runtime_control.stop().await;
     request.correlation.model_run_id
 }
 

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -1753,9 +1753,10 @@ async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> Mode
     })
     .expect("spawn runtime");
     let request = start_and_recv_model_request(&runtime, &mut router_rx).await;
+    let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
     runtime
         .task_runtime_tx
-        .send(TaskRuntimeCommand::Stop)
+        .send(TaskRuntimeCommand::Stop { ack_tx })
         .await
         .expect("stop runtime");
     request.correlation.model_run_id

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use selvedge_command_model::{
     ApiCallCorrelation, ApiOutputEnvelope, CoreOutputMessage, DomainEvent,
     ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind, ModelRunId, RouterIngressMessage,
-    TaskRuntimeCommand, TaskRuntimeExitReason, ToolExecutionResult,
+    RouterIngressSender, TaskRuntimeCommand, TaskRuntimeExitReason, ToolExecutionResult,
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, TaskRuntimeConfig, spawn_task_runtime};
 use selvedge_db::{
@@ -55,7 +55,7 @@ async fn task_runtime_starts_and_requests_model_call_from_system_cursor() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
@@ -131,7 +131,7 @@ async fn task_runtime_start_requests_model_from_user_cursor_without_draining_que
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -212,7 +212,7 @@ async fn task_runtime_start_promotes_queue_before_awaiting_user_input() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -301,7 +301,7 @@ async fn task_runtime_start_dispatches_tool_from_function_call_cursor() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -386,7 +386,7 @@ async fn task_runtime_start_reconstructs_open_batched_tool_calls_from_history() 
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -407,7 +407,7 @@ async fn task_runtime_start_reconstructs_open_batched_tool_calls_from_history() 
 
 #[tokio::test]
 async fn task_runtime_resolves_model_profile_key_into_provider_and_model() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![]).await;
 
     let request = start_and_recv_model_request(&runtime, &mut router_rx).await;
 
@@ -417,7 +417,7 @@ async fn task_runtime_resolves_model_profile_key_into_provider_and_model() {
 
 #[tokio::test]
 async fn task_runtime_dispatches_all_tool_calls_before_next_model_call() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "search".to_owned(),
         description: "search".to_owned(),
         parameters: Vec::new(),
@@ -475,7 +475,7 @@ async fn task_runtime_dispatches_all_tool_calls_before_next_model_call() {
 
 #[tokio::test]
 async fn task_runtime_stop_returns_after_archive_exit() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(Vec::new()).await;
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(Vec::new()).await;
 
     runtime
         .task_runtime_tx
@@ -499,7 +499,7 @@ async fn task_runtime_stop_returns_after_archive_exit() {
 
 #[tokio::test]
 async fn task_runtime_stop_completes_when_router_ingress_is_not_drained() {
-    let (runtime, _router_rx) = spawn_runtime_with_task(Vec::new()).await;
+    let (runtime, _router_rx, _router_tx) = spawn_runtime_with_task(Vec::new()).await;
 
     runtime
         .task_runtime_tx
@@ -518,7 +518,7 @@ async fn task_runtime_stop_completes_when_router_ingress_is_not_drained() {
 
 #[tokio::test]
 async fn task_runtime_preserves_batched_tool_call_order_in_next_model_request() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "search".to_owned(),
         description: "search".to_owned(),
         parameters: Vec::new(),
@@ -642,7 +642,7 @@ async fn task_runtime_ignores_tool_result_with_mismatched_call_identity() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -724,7 +724,7 @@ async fn task_runtime_ignores_tool_result_with_mismatched_call_identity() {
 
 #[tokio::test]
 async fn task_runtime_rejects_duplicate_tool_call_ids_in_one_model_reply() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![
         ToolSpec {
             name: "search".to_owned(),
             description: "search".to_owned(),
@@ -771,7 +771,7 @@ async fn task_runtime_rejects_duplicate_tool_call_ids_in_one_model_reply() {
 
 #[tokio::test]
 async fn task_runtime_uses_tool_parameter_type_for_integer_arguments() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "repeat".to_owned(),
         description: "repeat".to_owned(),
         parameters: vec![ToolParameter {
@@ -856,7 +856,7 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -890,7 +890,7 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
 
 #[tokio::test]
 async fn task_runtime_validates_all_tool_calls_before_dispatching_any() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "enabled".to_owned(),
         description: "enabled".to_owned(),
         parameters: Vec::new(),
@@ -930,7 +930,7 @@ async fn task_runtime_validates_all_tool_calls_before_dispatching_any() {
 
 #[tokio::test]
 async fn task_runtime_rejects_tool_calls_missing_required_arguments() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "repeat".to_owned(),
         description: "repeat".to_owned(),
         parameters: vec![ToolParameter {
@@ -968,7 +968,7 @@ async fn task_runtime_rejects_tool_calls_missing_required_arguments() {
 
 #[tokio::test]
 async fn task_runtime_ignores_unrelated_validation_failure_while_waiting() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![]).await;
     let correlation = start_and_request_model(&runtime, &mut router_rx).await;
     runtime
         .task_runtime_tx
@@ -1028,7 +1028,7 @@ async fn task_runtime_ignores_unrelated_validation_failure_while_waiting() {
 
 #[tokio::test]
 async fn task_runtime_reports_current_model_call_failure() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![]).await;
     let correlation = start_and_request_model(&runtime, &mut router_rx).await;
 
     runtime
@@ -1062,7 +1062,7 @@ async fn task_runtime_reports_current_model_call_failure() {
 
 #[tokio::test]
 async fn task_runtime_promotes_queued_input_after_model_failure() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![]).await;
     let correlation = start_and_request_model(&runtime, &mut router_rx).await;
     runtime
         .task_runtime_tx
@@ -1138,7 +1138,7 @@ async fn task_runtime_rejects_empty_idle_user_input_before_append() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -1165,7 +1165,7 @@ async fn task_runtime_rejects_empty_idle_user_input_before_append() {
 
 #[tokio::test]
 async fn task_runtime_ignores_replayed_start_after_model_request() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![]).await;
     let _correlation = start_and_request_model(&runtime, &mut router_rx).await;
 
     runtime
@@ -1183,7 +1183,7 @@ async fn task_runtime_ignores_replayed_start_after_model_request() {
 
 #[tokio::test]
 async fn task_runtime_preserves_model_wait_state_for_stray_tool_result() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![]).await;
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![]).await;
     let _correlation = start_and_request_model(&runtime, &mut router_rx).await;
 
     runtime
@@ -1252,7 +1252,7 @@ async fn task_runtime_uses_fresh_model_run_ids_after_respawn() {
 
 #[tokio::test]
 async fn task_runtime_rejects_unconvertible_required_arguments() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "repeat".to_owned(),
         description: "repeat".to_owned(),
         parameters: vec![ToolParameter {
@@ -1332,7 +1332,7 @@ async fn task_runtime_preserves_queued_input_when_append_fails() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -1353,7 +1353,7 @@ async fn task_runtime_preserves_queued_input_when_append_fails() {
 
 #[tokio::test]
 async fn task_runtime_rejects_fractional_integer_arguments_before_persistence() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "repeat".to_owned(),
         description: "repeat".to_owned(),
         parameters: vec![ToolParameter {
@@ -1394,7 +1394,7 @@ async fn task_runtime_rejects_fractional_integer_arguments_before_persistence() 
 
 #[tokio::test]
 async fn task_runtime_rejects_out_of_range_integer_arguments() {
-    let (runtime, mut router_rx) = spawn_runtime_with_task(vec![ToolSpec {
+    let (runtime, mut router_rx, _router_tx) = spawn_runtime_with_task(vec![ToolSpec {
         name: "repeat".to_owned(),
         description: "repeat".to_owned(),
         parameters: vec![ToolParameter {
@@ -1502,7 +1502,7 @@ async fn task_runtime_recovers_open_tool_call_before_model_dispatch() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -1603,7 +1603,7 @@ async fn task_runtime_allows_messages_between_tool_call_and_matching_output() {
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
@@ -1637,6 +1637,7 @@ async fn spawn_runtime_with_task(
 ) -> (
     selvedge_core::SpawnedTaskRuntime,
     tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
+    RouterIngressSender,
 ) {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
@@ -1677,14 +1678,14 @@ async fn spawn_runtime_with_task(
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),
         },
     })
     .expect("spawn runtime");
-    (runtime, router_rx)
+    (runtime, router_rx, router_tx)
 }
 
 async fn start_and_request_model(
@@ -1790,7 +1791,7 @@ async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> Mode
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         config: TaskRuntimeConfig {
             mailbox_capacity: 16,
             model_profiles: model_profiles(),

--- a/crates/core/tests/runtime_contract.rs
+++ b/crates/core/tests/runtime_contract.rs
@@ -51,7 +51,7 @@ async fn task_runtime_starts_and_requests_model_call_from_system_cursor() {
     )
     .expect("create task");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -127,7 +127,7 @@ async fn task_runtime_start_requests_model_from_user_cursor_without_draining_que
     )
     .expect("queue input");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
@@ -208,7 +208,7 @@ async fn task_runtime_start_promotes_queue_before_awaiting_user_input() {
     )
     .expect("queue input");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
@@ -297,7 +297,7 @@ async fn task_runtime_start_dispatches_tool_from_function_call_cursor() {
     )
     .expect("append function call");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -382,7 +382,7 @@ async fn task_runtime_start_reconstructs_open_batched_tool_calls_from_history() 
     )
     .expect("append batched calls");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -471,6 +471,49 @@ async fn task_runtime_dispatches_all_tool_calls_before_next_model_call() {
 
     let second_tool_request = recv_tool_request(&mut router_rx).await;
     assert_eq!(second_tool_request.function_call_id.0, "call-2");
+}
+
+#[tokio::test]
+async fn task_runtime_stop_returns_after_archive_exit() {
+    let (runtime, mut router_rx) = spawn_runtime_with_task(Vec::new()).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Archive)
+        .await
+        .expect("send archive");
+    let message = router_rx.recv().await.expect("runtime exit");
+    assert!(matches!(
+        message,
+        RouterIngressMessage::RuntimeExit(notice)
+            if matches!(notice.reason, TaskRuntimeExitReason::Archived)
+    ));
+
+    tokio::time::timeout(
+        Duration::from_millis(50),
+        runtime.task_runtime_control.stop(),
+    )
+    .await
+    .expect("stop completed");
+}
+
+#[tokio::test]
+async fn task_runtime_stop_completes_when_router_ingress_is_not_drained() {
+    let (runtime, _router_rx) = spawn_runtime_with_task(Vec::new()).await;
+
+    runtime
+        .task_runtime_tx
+        .send(TaskRuntimeCommand::Start)
+        .await
+        .expect("send start");
+    tokio::task::yield_now().await;
+
+    tokio::time::timeout(
+        Duration::from_millis(50),
+        runtime.task_runtime_control.stop(),
+    )
+    .await
+    .expect("stop completed");
 }
 
 #[tokio::test]
@@ -595,7 +638,7 @@ async fn task_runtime_ignores_tool_result_with_mismatched_call_identity() {
         },
     )
     .expect("create task");
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
@@ -809,7 +852,7 @@ async fn task_runtime_rejects_tool_calls_outside_enabled_manifest() {
         },
     )
     .expect("create task");
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -1091,7 +1134,7 @@ async fn task_runtime_rejects_empty_idle_user_input_before_append() {
         },
     )
     .expect("create task");
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -1285,7 +1328,7 @@ async fn task_runtime_preserves_queued_input_when_append_fails() {
     )
     .expect("queue input");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db: db.clone(),
@@ -1455,7 +1498,7 @@ async fn task_runtime_recovers_open_tool_call_before_model_dispatch() {
         UnixTs(3),
     )
     .expect("append assistant cursor after open call");
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -1556,7 +1599,7 @@ async fn task_runtime_allows_messages_between_tool_call_and_matching_output() {
         UnixTs(4),
     )
     .expect("append function output");
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -1593,7 +1636,7 @@ async fn spawn_runtime_with_task(
     tools: Vec<ToolSpec>,
 ) -> (
     selvedge_core::SpawnedTaskRuntime,
-    tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
 ) {
     let db = open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
@@ -1630,7 +1673,7 @@ async fn spawn_runtime_with_task(
     )
     .expect("create task");
 
-    let (router_tx, router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,
@@ -1646,7 +1689,7 @@ async fn spawn_runtime_with_task(
 
 async fn start_and_request_model(
     runtime: &selvedge_core::SpawnedTaskRuntime,
-    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    router_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
 ) -> ApiCallCorrelation {
     start_and_recv_model_request(runtime, router_rx)
         .await
@@ -1655,7 +1698,7 @@ async fn start_and_request_model(
 
 async fn start_and_recv_model_request(
     runtime: &selvedge_core::SpawnedTaskRuntime,
-    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    router_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
 ) -> ModelCallDispatchRequest {
     runtime
         .task_runtime_tx
@@ -1679,7 +1722,7 @@ async fn start_and_recv_model_request(
 }
 
 async fn recv_tool_request(
-    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    router_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
 ) -> selvedge_command_model::ToolExecutionRequest {
     let message = router_rx.recv().await.expect("tool request");
     match message {
@@ -1692,7 +1735,7 @@ async fn recv_tool_request(
 }
 
 async fn recv_model_request(
-    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    router_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
 ) -> ModelCallDispatchRequest {
     let message = router_rx.recv().await.expect("model request");
     match message {
@@ -1727,7 +1770,9 @@ fn tool_transcript_events(request: &ModelCallDispatchRequest) -> Vec<String> {
         .collect()
 }
 
-async fn assert_internal_exit(router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>) {
+async fn assert_internal_exit(
+    router_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
+) {
     let message = router_rx.recv().await.expect("runtime exit");
     match message {
         RouterIngressMessage::RuntimeExit(notice) => {
@@ -1741,7 +1786,7 @@ async fn assert_internal_exit(router_rx: &mut tokio::sync::mpsc::Receiver<Router
 }
 
 async fn spawn_runtime_and_start_one_model_call(db: selvedge_db::DbPool) -> ModelRunId {
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(16);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime = spawn_task_runtime(SpawnTaskRuntimeArgs {
         task_id: TaskId("task-1".to_owned()),
         db,

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "selvedge-router"
+edition = "2024"
+publish = false
+
+[dependencies]
+selvedge-api = { path = "../api" }
+selvedge-command-model = { path = "../command-model" }
+selvedge-core = { path = "../core" }
+selvedge-db = { path = "../db" }
+selvedge-domain-model = { path = "../domain-model" }
+selvedge-events = { path = "../events" }
+selvedge-task-runtime-factory = { path = "../task-runtime-factory" }
+tokio = { version = "1.42.0", features = ["rt", "sync"] }
+
+[dev-dependencies]
+selvedge-domain-model = { path = "../domain-model" }
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -8,6 +8,8 @@ This crate does not execute provider calls, tool calls, task-local state transit
 
 Router ingress is unbounded. The router is the lifecycle coordinator for task runtimes, and runtime-to-router output must enqueue without waiting for router mailbox capacity while the router is synchronously stopping a runtime.
 
+Core output routing is task-id based. A runtime that enqueued core output before a synchronous stop still has that output routed normally; stop controls runtime registry ownership and future task command delivery.
+
 ## Runtime Ownership Decision
 
 The router's runtime uniqueness invariant is route ownership: for one `TaskId`, at most one `TaskRuntimeSender` in `task_runtime_registry` may receive router task commands at a time. Creation is also single-owned through `pending_effects_by_task`.

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -9,6 +9,7 @@ This crate does not execute provider calls, tool calls, task-local state transit
 Router ingress is unbounded. The router is the lifecycle coordinator for task runtimes, and runtime-to-router output must enqueue without waiting for router mailbox capacity while the router is synchronously stopping a runtime. The router handle owns the strong ingress sender; runtime, API, tool, and factory producers receive weak ingress senders so dropping external ingress owners closes the router mailbox.
 
 Core output routing is task-id based. A runtime that enqueued core output before a synchronous stop still has that output routed normally; stop controls runtime registry ownership and future task command delivery.
+Core output with an embedded task id must match the envelope task id before the router starts model calls, tool executions, or event publication.
 
 ## Runtime Ownership Decision
 

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -6,7 +6,7 @@ Use it to spawn the process-local mailbox that routes client commands, task runt
 
 This crate does not execute provider calls, tool calls, task-local state transitions, database writes, or client delivery directly. It delegates those effects to the API, configured tool executor, task-runtime factory, core runtime, database, and events crates.
 
-Router ingress is unbounded. The router is the lifecycle coordinator for task runtimes, and runtime-to-router output must enqueue without waiting for router mailbox capacity while the router is synchronously stopping a runtime.
+Router ingress is unbounded. The router is the lifecycle coordinator for task runtimes, and runtime-to-router output must enqueue without waiting for router mailbox capacity while the router is synchronously stopping a runtime. The router handle owns the strong ingress sender; runtime, API, tool, and factory producers receive weak ingress senders so dropping external ingress owners closes the router mailbox.
 
 Core output routing is task-id based. A runtime that enqueued core output before a synchronous stop still has that output routed normally; stop controls runtime registry ownership and future task command delivery.
 

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -5,3 +5,5 @@ This crate owns the Selvedge router actor.
 Use it to spawn the process-local mailbox that routes client commands, task runtime output, API output, tool output, factory-created task runtimes, and events ingress. The router owns the live task runtime registry, pending runtime effects, and deferred task-local commands.
 
 This crate does not execute provider calls, tool calls, task-local state transitions, database writes, or client delivery directly. It delegates those effects to the API, configured tool executor, task-runtime factory, core runtime, database, and events crates.
+
+TODO: Define client data synchronization outside this crate. The router forwards client session controls and runtime diagnostics; it does not produce client-visible task, history, parent-edge, snapshot, or subscription-filtered data views.

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -1,0 +1,7 @@
+# router
+
+This crate owns the Selvedge router actor.
+
+Use it to spawn the process-local mailbox that routes client commands, task runtime output, API output, tool output, factory-created task runtimes, and events ingress. The router owns the live task runtime registry, pending runtime effects, and deferred task-local commands.
+
+This crate does not execute provider calls, tool calls, task-local state transitions, database writes, or client delivery directly. It delegates those effects to the API, configured tool executor, task-runtime factory, core runtime, database, and events crates.

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -6,6 +6,8 @@ Use it to spawn the process-local mailbox that routes client commands, task runt
 
 This crate does not execute provider calls, tool calls, task-local state transitions, database writes, or client delivery directly. It delegates those effects to the API, configured tool executor, task-runtime factory, core runtime, database, and events crates.
 
+Router ingress is unbounded. The router is the lifecycle coordinator for task runtimes, and runtime-to-router output must enqueue without waiting for router mailbox capacity while the router is synchronously stopping a runtime.
+
 ## Runtime Ownership Decision
 
 The router's runtime uniqueness invariant is route ownership: for one `TaskId`, at most one `TaskRuntimeSender` in `task_runtime_registry` may receive router task commands at a time. Creation is also single-owned through `pending_effects_by_task`.

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -6,4 +6,12 @@ Use it to spawn the process-local mailbox that routes client commands, task runt
 
 This crate does not execute provider calls, tool calls, task-local state transitions, database writes, or client delivery directly. It delegates those effects to the API, configured tool executor, task-runtime factory, core runtime, database, and events crates.
 
+## Runtime Ownership Decision
+
+The router's runtime uniqueness invariant is route ownership: for one `TaskId`, at most one `TaskRuntimeSender` in `task_runtime_registry` may receive router task commands at a time. Creation is also single-owned through `pending_effects_by_task`.
+
+Stop is a synchronous barrier in the router actor. `StopTaskRuntime` calls `TaskRuntimeControl::stop().await` for the current runtime entry and does not drain the router mailbox while waiting. The stop request and completion result live in the runtime's shared control block, so stop does not use the runtime business mailbox or the router mailbox.
+
+Runtime ownership flows as missing, pending create, live, stopping, then released. During stopping, the router actor is inside the stop call. After `TaskRuntimeStopResult` returns, the router removes the registry entry only if it is still the same control block.
+
 TODO: Define client data synchronization outside this crate. The router forwards client session controls and runtime diagnostics; it does not produce client-visible task, history, parent-edge, snapshot, or subscription-filtered data views.

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -1,0 +1,613 @@
+#![doc = include_str!("../README.md")]
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use selvedge_api::{ApiExecutorConfig, ModelProviderRegistry, spawn_model_call_tokio_task};
+use selvedge_command_model::{
+    ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DebugRawEvent, DetachReason,
+    DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
+    FactoryEffectId, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
+    RawEvent, RouterCommand, RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender,
+    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeSender, ToolExecutionRequest,
+    ToolExecutionResult, validate_router_command,
+};
+use selvedge_core::TaskRuntimeSpawnDeps;
+use selvedge_db::DbPool;
+use selvedge_domain_model::TaskId;
+use selvedge_task_runtime_factory::{
+    CreateChildTaskAndRuntimeCommand, EnsureMissingTaskRuntimesCommand, EnsureTaskRuntimeCommand,
+    FactoryCommand, FactoryEffectArgs, FactoryRuntimeInventory, run_factory_effect,
+};
+use tokio::task::JoinHandle;
+
+pub struct RouterStartArgs {
+    pub db: DbPool,
+    pub events_tx: EventIngressSender,
+    pub api_provider_registry: Arc<dyn ModelProviderRegistry>,
+    pub api_config: ApiExecutorConfig,
+    pub tool_executor: Arc<dyn ToolExecutionSpawner>,
+    pub core_spawn_deps: TaskRuntimeSpawnDeps,
+    pub router_mailbox_capacity: usize,
+}
+
+pub trait ToolExecutionSpawner: Send + Sync {
+    fn spawn_tool_execution(
+        &self,
+        request: ToolExecutionRequest,
+        router_tx: RouterIngressSender,
+    ) -> Result<JoinHandle<()>, ToolExecutionSpawnError>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ToolExecutionSpawnError {
+    TokioSpawnFailed,
+    ToolExecutorUnavailable,
+}
+
+pub struct RouterHandle {
+    pub ingress_tx: RouterIngressSender,
+    pub join_handle: JoinHandle<RouterExitStatus>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RouterExitStatus {
+    Stopped,
+    EventsMailboxClosed,
+    RouterMailboxClosed,
+    FatalError(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpawnRouterError {
+    InvalidMailboxCapacity,
+    TokioSpawnFailed,
+}
+
+pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterError> {
+    if args.router_mailbox_capacity == 0 {
+        return Err(SpawnRouterError::InvalidMailboxCapacity);
+    }
+
+    let (ingress_tx, ingress_rx) = tokio::sync::mpsc::channel(args.router_mailbox_capacity);
+    let actor = RouterActor {
+        db: args.db,
+        events_tx: args.events_tx,
+        api_provider_registry: args.api_provider_registry,
+        api_config: args.api_config,
+        tool_executor: args.tool_executor,
+        core_spawn_deps: args.core_spawn_deps,
+        router_tx: ingress_tx.clone(),
+        ingress_rx,
+        task_runtime_registry: HashMap::new(),
+        pending_effects: HashMap::new(),
+        pending_effects_by_task: HashMap::new(),
+        deferred_commands: HashMap::new(),
+        next_effect_seq: 1,
+    };
+    let join_handle = tokio::spawn(actor.run());
+
+    Ok(RouterHandle {
+        ingress_tx,
+        join_handle,
+    })
+}
+
+struct RouterActor {
+    db: DbPool,
+    events_tx: EventIngressSender,
+    api_provider_registry: Arc<dyn ModelProviderRegistry>,
+    api_config: ApiExecutorConfig,
+    tool_executor: Arc<dyn ToolExecutionSpawner>,
+    core_spawn_deps: TaskRuntimeSpawnDeps,
+    router_tx: RouterIngressSender,
+    ingress_rx: tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    task_runtime_registry: HashMap<TaskId, TaskRuntimeSender>,
+    pending_effects: HashMap<FactoryEffectId, PendingRuntimeEffect>,
+    pending_effects_by_task: HashMap<TaskId, FactoryEffectId>,
+    deferred_commands: HashMap<TaskId, VecDeque<TaskRuntimeCommand>>,
+    next_effect_seq: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PendingRuntimeEffect {
+    task_id: Option<TaskId>,
+}
+
+impl RouterActor {
+    async fn run(mut self) -> RouterExitStatus {
+        while let Some(ingress) = self.ingress_rx.recv().await {
+            let result = match ingress {
+                RouterIngressMessage::Command(command) => self.handle_command(command).await,
+                RouterIngressMessage::Core(envelope) => self.handle_core(envelope).await,
+                RouterIngressMessage::ApiOutput(envelope) => self.handle_api_output(envelope).await,
+                RouterIngressMessage::Tool(result) => self.handle_tool_output(result).await,
+                RouterIngressMessage::RuntimeExit(notice) => self.handle_runtime_exit(notice).await,
+                RouterIngressMessage::PublishToEvents(request) => {
+                    self.publish_domain_event(request).await
+                }
+                RouterIngressMessage::StopRouter => {
+                    self.stop_runtimes().await;
+                    return RouterExitStatus::Stopped;
+                }
+            };
+
+            if let Err(status) = result {
+                self.stop_runtimes().await;
+                return status;
+            }
+        }
+
+        self.stop_runtimes().await;
+        RouterExitStatus::RouterMailboxClosed
+    }
+
+    async fn handle_command(
+        &mut self,
+        envelope: RouterCommandEnvelope,
+    ) -> Result<(), RouterExitStatus> {
+        if validate_router_command(&envelope).is_err() {
+            return self
+                .publish_debug(None, "router command validation failed")
+                .await;
+        }
+
+        match envelope.command {
+            RouterCommand::AttachClient {
+                client_id,
+                client_command_id,
+                outbound,
+                subscription,
+            } => {
+                self.send_event(EventIngress::Control(
+                    EventControlMessage::BeginClientHydration(
+                        selvedge_command_model::BeginClientHydration {
+                            client_id,
+                            client_command_id,
+                            outbound,
+                            subscription,
+                        },
+                    ),
+                ))
+                .await
+            }
+            RouterCommand::DetachClient {
+                client_id,
+                client_command_id,
+            } => {
+                self.send_event(EventIngress::Control(EventControlMessage::DetachClient(
+                    selvedge_command_model::DetachClient {
+                        client_id,
+                        client_command_id,
+                        reason: DetachReason::ClientRequested,
+                    },
+                )))
+                .await
+            }
+            RouterCommand::UpdateSubscription {
+                client_id,
+                client_command_id,
+                subscription,
+            } => {
+                self.send_event(EventIngress::Control(
+                    EventControlMessage::UpdateSubscription(
+                        selvedge_command_model::UpdateSubscription {
+                            client_id,
+                            client_command_id,
+                            subscription,
+                        },
+                    ),
+                ))
+                .await
+            }
+            RouterCommand::SendUserInput {
+                task_id,
+                message_text,
+            } => {
+                self.route_task_local_command(
+                    task_id,
+                    TaskRuntimeCommand::UserInput { message_text },
+                    true,
+                )
+                .await
+            }
+            RouterCommand::ArchiveTask { task_id } => {
+                self.route_task_local_command(task_id, TaskRuntimeCommand::Archive, true)
+                    .await
+            }
+            RouterCommand::StopTaskRuntime { task_id } => self.stop_task_runtime(task_id).await,
+            RouterCommand::EnsureTaskRuntime { task_id } => self.ensure_task_runtime(task_id).await,
+            RouterCommand::EnsureMissingTaskRuntimes => self.ensure_missing_task_runtimes().await,
+            RouterCommand::CreateChildTaskAndRuntime {
+                parent_task_id,
+                child_cursor_node_id,
+            } => {
+                self.create_child_task_and_runtime(parent_task_id, child_cursor_node_id)
+                    .await
+            }
+        }
+    }
+
+    async fn handle_core(&mut self, envelope: CoreOutputEnvelope) -> Result<(), RouterExitStatus> {
+        match envelope.message {
+            CoreOutputMessage::RequestModelCall(request) => {
+                let _join_handle = spawn_model_call_tokio_task(
+                    request,
+                    self.router_tx.clone(),
+                    self.api_provider_registry.clone(),
+                    self.api_config.clone(),
+                );
+                Ok(())
+            }
+            CoreOutputMessage::RequestToolExecution(request) => {
+                match self
+                    .tool_executor
+                    .spawn_tool_execution(request, self.router_tx.clone())
+                {
+                    Ok(_join_handle) => Ok(()),
+                    Err(_) => {
+                        self.publish_debug(
+                            Some(envelope.task_id),
+                            "tool execution task spawn failed",
+                        )
+                        .await
+                    }
+                }
+            }
+            CoreOutputMessage::PublishDomainEvent(request) => {
+                self.publish_domain_event(request).await
+            }
+            CoreOutputMessage::RuntimeReady => {
+                self.publish_domain_event(DomainEventPublishRequest {
+                    task_id: envelope.task_id,
+                    event: DomainEvent::TaskRuntimeReady,
+                })
+                .await
+            }
+        }
+    }
+
+    async fn handle_api_output(
+        &mut self,
+        envelope: ApiOutputEnvelope,
+    ) -> Result<(), RouterExitStatus> {
+        let task_id = match &envelope {
+            ApiOutputEnvelope::Success { correlation, .. }
+            | ApiOutputEnvelope::Failure { correlation, .. } => correlation.task_id.clone(),
+        };
+
+        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
+            self.send_to_task_runtime(
+                task_id,
+                sender,
+                TaskRuntimeCommand::ApiModelReply(envelope),
+                false,
+            )
+            .await
+        } else {
+            self.publish_debug(Some(task_id), "stale api output discarded")
+                .await
+        }
+    }
+
+    async fn handle_tool_output(
+        &mut self,
+        result: ToolExecutionResult,
+    ) -> Result<(), RouterExitStatus> {
+        let task_id = result.task_id.clone();
+        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
+            self.send_to_task_runtime(
+                task_id,
+                sender,
+                TaskRuntimeCommand::ToolResult(result),
+                false,
+            )
+            .await
+        } else {
+            self.publish_debug(Some(task_id), "stale tool output discarded")
+                .await
+        }
+    }
+
+    async fn handle_runtime_exit(
+        &mut self,
+        notice: TaskRuntimeExitNotice,
+    ) -> Result<(), RouterExitStatus> {
+        let removed = self.task_runtime_registry.remove(&notice.task_id).is_some();
+        let message = if removed {
+            format!("task runtime exited: {:?}", notice.reason)
+        } else {
+            format!("stale task runtime exit discarded: {:?}", notice.reason)
+        };
+        self.publish_debug(Some(notice.task_id), message).await
+    }
+
+    async fn route_task_local_command(
+        &mut self,
+        task_id: TaskId,
+        command: TaskRuntimeCommand,
+        create_when_missing: bool,
+    ) -> Result<(), RouterExitStatus> {
+        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
+            return self
+                .send_to_task_runtime(task_id, sender, command, create_when_missing)
+                .await;
+        }
+
+        if self.pending_effects_by_task.contains_key(&task_id) {
+            self.deferred_commands
+                .entry(task_id)
+                .or_default()
+                .push_back(command);
+            return Ok(());
+        }
+
+        if create_when_missing {
+            self.deferred_commands
+                .entry(task_id.clone())
+                .or_default()
+                .push_back(command);
+            return self.start_ensure_task_runtime_effect(task_id).await;
+        }
+
+        self.publish_debug(Some(task_id), "task runtime is not live")
+            .await
+    }
+
+    async fn send_to_task_runtime(
+        &mut self,
+        task_id: TaskId,
+        sender: TaskRuntimeSender,
+        command: TaskRuntimeCommand,
+        create_when_closed: bool,
+    ) -> Result<(), RouterExitStatus> {
+        let Err(error) = sender.send(command).await else {
+            return Ok(());
+        };
+
+        self.task_runtime_registry.remove(&task_id);
+        if create_when_closed {
+            self.deferred_commands
+                .entry(task_id.clone())
+                .or_default()
+                .push_back(error.0);
+            return self.start_ensure_task_runtime_effect(task_id).await;
+        }
+
+        self.publish_debug(Some(task_id), "task runtime mailbox closed")
+            .await
+    }
+
+    async fn ensure_task_runtime(&mut self, task_id: TaskId) -> Result<(), RouterExitStatus> {
+        if self.task_runtime_registry.contains_key(&task_id) {
+            return self
+                .publish_debug(Some(task_id), "task runtime is already live")
+                .await;
+        }
+        if self.pending_effects_by_task.contains_key(&task_id) {
+            return self
+                .publish_debug(Some(task_id), "task runtime creation is already pending")
+                .await;
+        }
+
+        self.start_ensure_task_runtime_effect(task_id).await
+    }
+
+    async fn start_ensure_task_runtime_effect(
+        &mut self,
+        task_id: TaskId,
+    ) -> Result<(), RouterExitStatus> {
+        let effect_id = self.next_effect_id();
+        self.pending_effects.insert(
+            effect_id.clone(),
+            PendingRuntimeEffect {
+                task_id: Some(task_id.clone()),
+            },
+        );
+        self.pending_effects_by_task
+            .insert(task_id.clone(), effect_id.clone());
+        let command =
+            FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand { effect_id, task_id });
+        self.run_factory_effect(command).await
+    }
+
+    async fn ensure_missing_task_runtimes(&mut self) -> Result<(), RouterExitStatus> {
+        let effect_id = self.next_effect_id();
+        self.pending_effects
+            .insert(effect_id.clone(), PendingRuntimeEffect { task_id: None });
+        let command = FactoryCommand::EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimesCommand {
+            effect_id,
+        });
+        self.run_factory_effect(command).await
+    }
+
+    async fn create_child_task_and_runtime(
+        &mut self,
+        parent_task_id: TaskId,
+        child_cursor_node_id: selvedge_domain_model::HistoryNodeId,
+    ) -> Result<(), RouterExitStatus> {
+        let effect_id = self.next_effect_id();
+        self.pending_effects
+            .insert(effect_id.clone(), PendingRuntimeEffect { task_id: None });
+        let command = FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
+            effect_id,
+            parent_task_id,
+            child_cursor_node_id,
+        });
+        self.run_factory_effect(command).await
+    }
+
+    async fn run_factory_effect(
+        &mut self,
+        command: FactoryCommand,
+    ) -> Result<(), RouterExitStatus> {
+        let current_task_effect = match &command {
+            FactoryCommand::EnsureTaskRuntime(command) => Some(&command.task_id),
+            FactoryCommand::EnsureMissingTaskRuntimes(_)
+            | FactoryCommand::CreateChildTaskAndRuntime(_) => None,
+        };
+        let inventory = FactoryRuntimeInventory {
+            live_task_runtimes: self.task_runtime_registry.keys().cloned().collect(),
+            pending_task_runtime_effects: self
+                .pending_effects_by_task
+                .keys()
+                .filter(|task_id| Some(*task_id) != current_task_effect)
+                .cloned()
+                .collect(),
+        };
+        let envelope = run_factory_effect(FactoryEffectArgs {
+            command,
+            db: self.db.clone(),
+            router_tx: self.router_tx.clone(),
+            core_spawn_deps: self.core_spawn_deps.clone(),
+            runtime_inventory: inventory,
+        });
+        self.apply_factory_output(envelope).await
+    }
+
+    async fn apply_factory_output(
+        &mut self,
+        envelope: FactoryOutputEnvelope,
+    ) -> Result<(), RouterExitStatus> {
+        let Some(pending) = self.pending_effects.remove(&envelope.effect_id) else {
+            return self
+                .publish_debug(None, "stale factory output discarded")
+                .await;
+        };
+        if let Some(task_id) = &pending.task_id {
+            self.pending_effects_by_task.remove(task_id);
+        }
+
+        match envelope.output {
+            FactoryOutput::RuntimeCreated(created) => {
+                self.register_runtime(created.task_id, created.task_runtime_tx)
+                    .await
+            }
+            FactoryOutput::ScanFinished(scan) => self.apply_scan_output(scan).await,
+            FactoryOutput::Failed(failure) => {
+                if let Some(task_id) = failure.task_id.clone() {
+                    self.deferred_commands.remove(&task_id);
+                }
+                self.publish_debug(failure.task_id, failure.message).await
+            }
+        }
+    }
+
+    async fn apply_scan_output(&mut self, scan: FactoryScanOutput) -> Result<(), RouterExitStatus> {
+        for created in scan.created {
+            self.register_runtime(created.task_id, created.task_runtime_tx)
+                .await?;
+        }
+        for failure in scan.failed {
+            self.publish_factory_task_failure(failure).await?;
+        }
+        Ok(())
+    }
+
+    async fn register_runtime(
+        &mut self,
+        task_id: TaskId,
+        sender: TaskRuntimeSender,
+    ) -> Result<(), RouterExitStatus> {
+        self.task_runtime_registry
+            .insert(task_id.clone(), sender.clone());
+        if sender.send(TaskRuntimeCommand::Start).await.is_err() {
+            self.task_runtime_registry.remove(&task_id);
+            return self
+                .publish_debug(Some(task_id), "task runtime start failed")
+                .await;
+        }
+
+        let mut deferred = self.deferred_commands.remove(&task_id).unwrap_or_default();
+        while let Some(command) = deferred.pop_front() {
+            if sender.send(command).await.is_err() {
+                self.task_runtime_registry.remove(&task_id);
+                return self
+                    .publish_debug(Some(task_id), "deferred task command delivery failed")
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn stop_task_runtime(&mut self, task_id: TaskId) -> Result<(), RouterExitStatus> {
+        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
+            return self
+                .send_to_task_runtime(task_id, sender, TaskRuntimeCommand::Stop, false)
+                .await;
+        }
+        if self.pending_effects_by_task.remove(&task_id).is_some() {
+            self.deferred_commands.remove(&task_id);
+            return self
+                .publish_debug(Some(task_id), "pending task runtime creation cancelled")
+                .await;
+        }
+        self.publish_debug(Some(task_id), "task runtime is not live")
+            .await
+    }
+
+    async fn stop_runtimes(&mut self) {
+        let senders = self
+            .task_runtime_registry
+            .drain()
+            .map(|(_, sender)| sender)
+            .collect::<Vec<_>>();
+        for sender in senders {
+            let _ = sender.send(TaskRuntimeCommand::Stop).await;
+        }
+    }
+
+    async fn publish_domain_event(
+        &mut self,
+        request: DomainEventPublishRequest,
+    ) -> Result<(), RouterExitStatus> {
+        let raw = match request.event {
+            DomainEvent::TaskRuntimeReady => RawEvent::Debug(DebugRawEvent {
+                task_id: Some(request.task_id),
+                message_text: "task runtime ready".to_owned(),
+            }),
+            DomainEvent::ErrorNotice { message } => RawEvent::Debug(DebugRawEvent {
+                task_id: Some(request.task_id),
+                message_text: message,
+            }),
+            other => RawEvent::Debug(DebugRawEvent {
+                task_id: Some(request.task_id),
+                message_text: format!("domain event: {other:?}"),
+            }),
+        };
+        self.send_event(EventIngress::Raw(raw)).await
+    }
+
+    async fn publish_debug(
+        &mut self,
+        task_id: Option<TaskId>,
+        message: impl Into<String>,
+    ) -> Result<(), RouterExitStatus> {
+        self.send_event(EventIngress::Raw(RawEvent::Debug(DebugRawEvent {
+            task_id,
+            message_text: message.into(),
+        })))
+        .await
+    }
+
+    async fn publish_factory_task_failure(
+        &mut self,
+        failure: FactoryTaskFailure,
+    ) -> Result<(), RouterExitStatus> {
+        self.publish_debug(Some(failure.task_id), failure.message)
+            .await
+    }
+
+    async fn send_event(&mut self, event: EventIngress) -> Result<(), RouterExitStatus> {
+        self.events_tx
+            .send(event)
+            .await
+            .map_err(|_| RouterExitStatus::EventsMailboxClosed)
+    }
+
+    fn next_effect_id(&mut self) -> FactoryEffectId {
+        let effect_id = FactoryEffectId(format!("router-effect-{}", self.next_effect_seq));
+        self.next_effect_seq += 1;
+        effect_id
+    }
+}

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -246,17 +246,15 @@ impl RouterActor {
                 Ok(())
             }
             CoreOutputMessage::RequestToolExecution(request) => {
+                let fallback_request = request.clone();
                 match self
                     .tool_executor
                     .spawn_tool_execution(request, self.router_tx.clone())
                 {
                     Ok(_join_handle) => Ok(()),
                     Err(_) => {
-                        self.publish_debug(
-                            Some(envelope.task_id),
-                            "tool execution task spawn failed",
-                        )
-                        .await
+                        self.handle_tool_output(tool_spawn_failed_result(fallback_request))
+                            .await
                     }
                 }
             }
@@ -667,5 +665,17 @@ impl RouterActor {
         let effect_id = FactoryEffectId(format!("router-effect-{}", self.next_effect_seq));
         self.next_effect_seq += 1;
         effect_id
+    }
+}
+
+fn tool_spawn_failed_result(request: ToolExecutionRequest) -> ToolExecutionResult {
+    ToolExecutionResult {
+        task_id: request.task_id,
+        tool_execution_run_id: request.tool_execution_run_id,
+        function_call_node_id: request.function_call_node_id,
+        function_call_id: request.function_call_id,
+        tool_name: request.tool_name,
+        output_text: "tool execution spawn failed".to_owned(),
+        is_error: true,
     }
 }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -10,7 +10,7 @@ use selvedge_command_model::{
     FactoryEffectId, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
     RawEvent, RouterCommand, RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender,
     TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeInstanceId, TaskRuntimeSender,
-    ToolExecutionRequest, ToolExecutionResult, validate_router_command,
+    TaskRuntimeStopAck, ToolExecutionRequest, ToolExecutionResult, validate_router_command,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::DbPool;
@@ -582,12 +582,13 @@ impl RouterActor {
     }
 
     async fn stop_task_runtime(&mut self, task_id: TaskId) -> Result<(), RouterExitStatus> {
-        if let Some(entry) = self.task_runtime_registry.remove(&task_id) {
-            if entry.sender.send(TaskRuntimeCommand::Stop).await.is_err() {
+        if let Some(entry) = self.task_runtime_registry.get(&task_id).cloned() {
+            if self.stop_runtime_entry(&task_id, entry).await.is_err() {
                 return self
                     .publish_debug(Some(task_id), "task runtime mailbox closed")
                     .await;
             }
+            self.task_runtime_registry.remove(&task_id);
             return Ok(());
         }
         if self.pending_effects_by_task.remove(&task_id).is_some() {
@@ -601,13 +602,29 @@ impl RouterActor {
     }
 
     async fn stop_runtimes(&mut self) {
-        let senders = self
-            .task_runtime_registry
-            .drain()
-            .map(|(_, entry)| entry.sender)
-            .collect::<Vec<_>>();
-        for sender in senders {
-            let _ = sender.send(TaskRuntimeCommand::Stop).await;
+        let entries = self.task_runtime_registry.drain().collect::<Vec<_>>();
+        for (task_id, entry) in entries {
+            let _ = self.stop_runtime_entry(&task_id, entry).await;
+        }
+    }
+
+    async fn stop_runtime_entry(
+        &self,
+        task_id: &TaskId,
+        entry: RuntimeRegistryEntry,
+    ) -> Result<TaskRuntimeStopAck, ()> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        entry
+            .sender
+            .send(TaskRuntimeCommand::Stop { ack_tx })
+            .await
+            .map_err(|_| ())?;
+        let ack = ack_rx.await.map_err(|_| ())?;
+        if ack.task_id == *task_id && ack.task_runtime_instance_id == entry.task_runtime_instance_id
+        {
+            Ok(ack)
+        } else {
+            Err(())
         }
     }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -570,10 +570,12 @@ impl RouterActor {
                 task_id: Some(request.task_id),
                 message_text: message,
             }),
-            other => RawEvent::Debug(DebugRawEvent {
-                task_id: Some(request.task_id),
-                message_text: format!("domain event: {other:?}"),
-            }),
+            DomainEvent::UserMessageCommitted { .. }
+            | DomainEvent::AssistantMessageCommitted { .. }
+            | DomainEvent::ReasoningCommitted { .. }
+            | DomainEvent::FunctionCallCommitted { .. }
+            | DomainEvent::FunctionOutputCommitted { .. }
+            | DomainEvent::TaskArchived => return Ok(()),
         };
         self.send_event(EventIngress::Raw(raw)).await
     }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -19,6 +19,7 @@ use selvedge_task_runtime_factory::{
     CreateChildTaskAndRuntimeCommand, EnsureMissingTaskRuntimesCommand, EnsureTaskRuntimeCommand,
     FactoryCommand, FactoryEffectArgs, FactoryRuntimeInventory, run_factory_effect,
 };
+use tokio::sync::mpsc::WeakUnboundedSender;
 use tokio::task::JoinHandle;
 
 pub struct RouterStartArgs {
@@ -71,7 +72,7 @@ pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterEr
         api_config: args.api_config,
         tool_executor: args.tool_executor,
         core_spawn_deps: args.core_spawn_deps,
-        router_tx: ingress_tx.clone(),
+        router_tx: ingress_tx.downgrade(),
         ingress_rx,
         task_runtime_registry: HashMap::new(),
         pending_effects: HashMap::new(),
@@ -94,7 +95,7 @@ struct RouterActor {
     api_config: ApiExecutorConfig,
     tool_executor: Arc<dyn ToolExecutionSpawner>,
     core_spawn_deps: TaskRuntimeSpawnDeps,
-    router_tx: RouterIngressSender,
+    router_tx: WeakUnboundedSender<RouterIngressMessage>,
     ingress_rx: tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
     task_runtime_registry: HashMap<TaskId, RuntimeRegistryEntry>,
     pending_effects: HashMap<FactoryEffectId, PendingRuntimeEffect>,
@@ -115,6 +116,12 @@ struct RuntimeRegistryEntry {
 }
 
 impl RouterActor {
+    fn router_tx(&self) -> Result<RouterIngressSender, RouterExitStatus> {
+        self.router_tx
+            .upgrade()
+            .ok_or(RouterExitStatus::RouterMailboxClosed)
+    }
+
     async fn run(mut self) -> RouterExitStatus {
         while let Some(ingress) = self.ingress_rx.recv().await {
             let result = match ingress {
@@ -235,7 +242,7 @@ impl RouterActor {
             CoreOutputMessage::RequestModelCall(request) => {
                 let _join_handle = spawn_model_call_tokio_task(
                     request,
-                    self.router_tx.clone(),
+                    self.router_tx()?,
                     self.api_provider_registry.clone(),
                     self.api_config.clone(),
                 );
@@ -245,7 +252,7 @@ impl RouterActor {
                 let fallback_request = request.clone();
                 match self
                     .tool_executor
-                    .spawn_tool_execution(request, self.router_tx.clone())
+                    .spawn_tool_execution(request, self.router_tx()?)
                 {
                     Ok(_join_handle) => Ok(()),
                     Err(_) => {
@@ -476,7 +483,7 @@ impl RouterActor {
         let envelope = run_factory_effect(FactoryEffectArgs {
             command,
             db: self.db.clone(),
-            router_tx: self.router_tx.clone(),
+            router_tx: self.router_tx()?,
             core_spawn_deps: self.core_spawn_deps.clone(),
             runtime_inventory: inventory,
         });

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -9,8 +9,8 @@ use selvedge_command_model::{
     DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
     FactoryEffectId, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
     RawEvent, RouterCommand, RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender,
-    TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice, TaskRuntimeSender,
-    ToolExecutionRequest, ToolExecutionResult, validate_router_command,
+    RouterIngressWeakSender, TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice,
+    TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, validate_router_command,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::DbPool;
@@ -19,7 +19,6 @@ use selvedge_task_runtime_factory::{
     CreateChildTaskAndRuntimeCommand, EnsureMissingTaskRuntimesCommand, EnsureTaskRuntimeCommand,
     FactoryCommand, FactoryEffectArgs, FactoryRuntimeInventory, run_factory_effect,
 };
-use tokio::sync::mpsc::WeakUnboundedSender;
 use tokio::task::JoinHandle;
 
 pub struct RouterStartArgs {
@@ -35,7 +34,7 @@ pub trait ToolExecutionSpawner: Send + Sync {
     fn spawn_tool_execution(
         &self,
         request: ToolExecutionRequest,
-        router_tx: RouterIngressSender,
+        router_tx: RouterIngressWeakSender,
     ) -> Result<JoinHandle<()>, ToolExecutionSpawnError>;
 }
 
@@ -95,7 +94,7 @@ struct RouterActor {
     api_config: ApiExecutorConfig,
     tool_executor: Arc<dyn ToolExecutionSpawner>,
     core_spawn_deps: TaskRuntimeSpawnDeps,
-    router_tx: WeakUnboundedSender<RouterIngressMessage>,
+    router_tx: RouterIngressWeakSender,
     ingress_rx: tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
     task_runtime_registry: HashMap<TaskId, RuntimeRegistryEntry>,
     pending_effects: HashMap<FactoryEffectId, PendingRuntimeEffect>,
@@ -116,12 +115,6 @@ struct RuntimeRegistryEntry {
 }
 
 impl RouterActor {
-    fn router_tx(&self) -> Result<RouterIngressSender, RouterExitStatus> {
-        self.router_tx
-            .upgrade()
-            .ok_or(RouterExitStatus::RouterMailboxClosed)
-    }
-
     async fn run(mut self) -> RouterExitStatus {
         while let Some(ingress) = self.ingress_rx.recv().await {
             let result = match ingress {
@@ -242,7 +235,7 @@ impl RouterActor {
             CoreOutputMessage::RequestModelCall(request) => {
                 let _join_handle = spawn_model_call_tokio_task(
                     request,
-                    self.router_tx()?,
+                    self.router_tx.clone(),
                     self.api_provider_registry.clone(),
                     self.api_config.clone(),
                 );
@@ -252,7 +245,7 @@ impl RouterActor {
                 let fallback_request = request.clone();
                 match self
                     .tool_executor
-                    .spawn_tool_execution(request, self.router_tx()?)
+                    .spawn_tool_execution(request, self.router_tx.clone())
                 {
                     Ok(_join_handle) => Ok(()),
                     Err(_) => {
@@ -483,7 +476,7 @@ impl RouterActor {
         let envelope = run_factory_effect(FactoryEffectArgs {
             command,
             db: self.db.clone(),
-            router_tx: self.router_tx()?,
+            router_tx: self.router_tx.clone(),
             core_spawn_deps: self.core_spawn_deps.clone(),
             runtime_inventory: inventory,
         });

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -229,6 +229,8 @@ impl RouterActor {
     }
 
     async fn handle_core(&mut self, envelope: CoreOutputEnvelope) -> Result<(), RouterExitStatus> {
+        // Core output is task-routed. Runtime identity gates registry ownership and exit cleanup;
+        // queued core outputs already in ingress continue through normal task routing.
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
                 let _join_handle = spawn_model_call_tokio_task(

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -9,8 +9,8 @@ use selvedge_command_model::{
     DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
     FactoryEffectId, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
     RawEvent, RouterCommand, RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender,
-    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeSender, ToolExecutionRequest,
-    ToolExecutionResult, validate_router_command,
+    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeInstanceId, TaskRuntimeSender,
+    ToolExecutionRequest, ToolExecutionResult, validate_router_command,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::DbPool;
@@ -102,7 +102,7 @@ struct RouterActor {
     core_spawn_deps: TaskRuntimeSpawnDeps,
     router_tx: RouterIngressSender,
     ingress_rx: tokio::sync::mpsc::Receiver<RouterIngressMessage>,
-    task_runtime_registry: HashMap<TaskId, TaskRuntimeSender>,
+    task_runtime_registry: HashMap<TaskId, RuntimeRegistryEntry>,
     pending_effects: HashMap<FactoryEffectId, PendingRuntimeEffect>,
     pending_effects_by_task: HashMap<TaskId, FactoryEffectId>,
     deferred_commands: HashMap<TaskId, VecDeque<TaskRuntimeCommand>>,
@@ -112,6 +112,12 @@ struct RouterActor {
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PendingRuntimeEffect {
     task_id: Option<TaskId>,
+}
+
+#[derive(Clone, Debug)]
+struct RuntimeRegistryEntry {
+    task_runtime_instance_id: TaskRuntimeInstanceId,
+    sender: TaskRuntimeSender,
 }
 
 impl RouterActor {
@@ -276,7 +282,11 @@ impl RouterActor {
             | ApiOutputEnvelope::Failure { correlation, .. } => correlation.task_id.clone(),
         };
 
-        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
+        if let Some(sender) = self
+            .task_runtime_registry
+            .get(&task_id)
+            .map(|entry| entry.sender.clone())
+        {
             self.send_to_task_runtime(
                 task_id,
                 sender,
@@ -295,7 +305,11 @@ impl RouterActor {
         result: ToolExecutionResult,
     ) -> Result<(), RouterExitStatus> {
         let task_id = result.task_id.clone();
-        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
+        if let Some(sender) = self
+            .task_runtime_registry
+            .get(&task_id)
+            .map(|entry| entry.sender.clone())
+        {
             self.send_to_task_runtime(
                 task_id,
                 sender,
@@ -316,7 +330,7 @@ impl RouterActor {
         let removed = self
             .task_runtime_registry
             .get(&notice.task_id)
-            .is_some_and(|sender| sender.is_closed());
+            .is_some_and(|entry| entry.task_runtime_instance_id == notice.task_runtime_instance_id);
         if removed {
             self.task_runtime_registry.remove(&notice.task_id);
         }
@@ -334,7 +348,11 @@ impl RouterActor {
         command: TaskRuntimeCommand,
         create_when_missing: bool,
     ) -> Result<(), RouterExitStatus> {
-        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
+        if let Some(sender) = self
+            .task_runtime_registry
+            .get(&task_id)
+            .map(|entry| entry.sender.clone())
+        {
             return self
                 .send_to_task_runtime(task_id, sender, command, create_when_missing)
                 .await;
@@ -486,8 +504,12 @@ impl RouterActor {
 
         match envelope.output {
             FactoryOutput::RuntimeCreated(created) => {
-                self.register_runtime(created.task_id, created.task_runtime_tx)
-                    .await
+                self.register_runtime(
+                    created.task_id,
+                    created.task_runtime_instance_id,
+                    created.task_runtime_tx,
+                )
+                .await
             }
             FactoryOutput::ScanFinished(scan) => self.apply_scan_output(scan).await,
             FactoryOutput::Failed(failure) => {
@@ -501,8 +523,12 @@ impl RouterActor {
 
     async fn apply_scan_output(&mut self, scan: FactoryScanOutput) -> Result<(), RouterExitStatus> {
         for created in scan.created {
-            self.register_runtime(created.task_id, created.task_runtime_tx)
-                .await?;
+            self.register_runtime(
+                created.task_id,
+                created.task_runtime_instance_id,
+                created.task_runtime_tx,
+            )
+            .await?;
         }
         for failure in scan.failed {
             self.publish_factory_task_failure(failure).await?;
@@ -513,10 +539,16 @@ impl RouterActor {
     async fn register_runtime(
         &mut self,
         task_id: TaskId,
+        task_runtime_instance_id: TaskRuntimeInstanceId,
         sender: TaskRuntimeSender,
     ) -> Result<(), RouterExitStatus> {
-        self.task_runtime_registry
-            .insert(task_id.clone(), sender.clone());
+        self.task_runtime_registry.insert(
+            task_id.clone(),
+            RuntimeRegistryEntry {
+                task_runtime_instance_id,
+                sender: sender.clone(),
+            },
+        );
         let mut deferred = self.deferred_commands.remove(&task_id).unwrap_or_default();
         if deferred
             .iter()
@@ -552,8 +584,8 @@ impl RouterActor {
     }
 
     async fn stop_task_runtime(&mut self, task_id: TaskId) -> Result<(), RouterExitStatus> {
-        if let Some(sender) = self.task_runtime_registry.remove(&task_id) {
-            if sender.send(TaskRuntimeCommand::Stop).await.is_err() {
+        if let Some(entry) = self.task_runtime_registry.remove(&task_id) {
+            if entry.sender.send(TaskRuntimeCommand::Stop).await.is_err() {
                 return self
                     .publish_debug(Some(task_id), "task runtime mailbox closed")
                     .await;
@@ -574,7 +606,7 @@ impl RouterActor {
         let senders = self
             .task_runtime_registry
             .drain()
-            .map(|(_, sender)| sender)
+            .map(|(_, entry)| entry.sender)
             .collect::<Vec<_>>();
         for sender in senders {
             let _ = sender.send(TaskRuntimeCommand::Stop).await;

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -313,7 +313,13 @@ impl RouterActor {
         &mut self,
         notice: TaskRuntimeExitNotice,
     ) -> Result<(), RouterExitStatus> {
-        let removed = self.task_runtime_registry.remove(&notice.task_id).is_some();
+        let removed = self
+            .task_runtime_registry
+            .get(&notice.task_id)
+            .is_some_and(|sender| sender.is_closed());
+        if removed {
+            self.task_runtime_registry.remove(&notice.task_id);
+        }
         let message = if removed {
             format!("task runtime exited: {:?}", notice.reason)
         } else {
@@ -511,6 +517,22 @@ impl RouterActor {
     ) -> Result<(), RouterExitStatus> {
         self.task_runtime_registry
             .insert(task_id.clone(), sender.clone());
+        let mut deferred = self.deferred_commands.remove(&task_id).unwrap_or_default();
+        if deferred
+            .iter()
+            .any(|command| matches!(command, TaskRuntimeCommand::Archive))
+        {
+            while let Some(command) = deferred.pop_front() {
+                if sender.send(command).await.is_err() {
+                    self.task_runtime_registry.remove(&task_id);
+                    return self
+                        .publish_debug(Some(task_id), "deferred task command delivery failed")
+                        .await;
+                }
+            }
+            return Ok(());
+        }
+
         if sender.send(TaskRuntimeCommand::Start).await.is_err() {
             self.task_runtime_registry.remove(&task_id);
             return self
@@ -518,7 +540,6 @@ impl RouterActor {
                 .await;
         }
 
-        let mut deferred = self.deferred_commands.remove(&task_id).unwrap_or_default();
         while let Some(command) = deferred.pop_front() {
             if sender.send(command).await.is_err() {
                 self.task_runtime_registry.remove(&task_id);

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -9,8 +9,8 @@ use selvedge_command_model::{
     DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
     FactoryEffectId, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
     RawEvent, RouterCommand, RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender,
-    TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeInstanceId, TaskRuntimeSender,
-    TaskRuntimeStopAck, ToolExecutionRequest, ToolExecutionResult, validate_router_command,
+    TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice, TaskRuntimeSender,
+    ToolExecutionRequest, ToolExecutionResult, validate_router_command,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::DbPool;
@@ -116,8 +116,8 @@ struct PendingRuntimeEffect {
 
 #[derive(Clone, Debug)]
 struct RuntimeRegistryEntry {
-    task_runtime_instance_id: TaskRuntimeInstanceId,
     sender: TaskRuntimeSender,
+    control: TaskRuntimeControl,
 }
 
 impl RouterActor {
@@ -328,7 +328,7 @@ impl RouterActor {
         let removed = self
             .task_runtime_registry
             .get(&notice.task_id)
-            .is_some_and(|entry| entry.task_runtime_instance_id == notice.task_runtime_instance_id);
+            .is_some_and(|entry| entry.control.same_control(&notice.task_runtime_control));
         if removed {
             self.task_runtime_registry.remove(&notice.task_id);
         }
@@ -504,8 +504,8 @@ impl RouterActor {
             FactoryOutput::RuntimeCreated(created) => {
                 self.register_runtime(
                     created.task_id,
-                    created.task_runtime_instance_id,
                     created.task_runtime_tx,
+                    created.task_runtime_control,
                 )
                 .await
             }
@@ -523,8 +523,8 @@ impl RouterActor {
         for created in scan.created {
             self.register_runtime(
                 created.task_id,
-                created.task_runtime_instance_id,
                 created.task_runtime_tx,
+                created.task_runtime_control,
             )
             .await?;
         }
@@ -537,14 +537,14 @@ impl RouterActor {
     async fn register_runtime(
         &mut self,
         task_id: TaskId,
-        task_runtime_instance_id: TaskRuntimeInstanceId,
         sender: TaskRuntimeSender,
+        control: TaskRuntimeControl,
     ) -> Result<(), RouterExitStatus> {
         self.task_runtime_registry.insert(
             task_id.clone(),
             RuntimeRegistryEntry {
-                task_runtime_instance_id,
                 sender: sender.clone(),
+                control,
             },
         );
         let mut deferred = self.deferred_commands.remove(&task_id).unwrap_or_default();
@@ -583,12 +583,12 @@ impl RouterActor {
 
     async fn stop_task_runtime(&mut self, task_id: TaskId) -> Result<(), RouterExitStatus> {
         if let Some(entry) = self.task_runtime_registry.get(&task_id).cloned() {
-            if self.stop_runtime_entry(&task_id, entry).await.is_err() {
+            if self.stop_runtime_entry(entry.clone()).await.is_err() {
                 return self
                     .publish_debug(Some(task_id), "task runtime mailbox closed")
                     .await;
             }
-            self.task_runtime_registry.remove(&task_id);
+            self.remove_runtime_if_current(&task_id, &entry);
             return Ok(());
         }
         if self.pending_effects_by_task.remove(&task_id).is_some() {
@@ -602,29 +602,29 @@ impl RouterActor {
     }
 
     async fn stop_runtimes(&mut self) {
-        let entries = self.task_runtime_registry.drain().collect::<Vec<_>>();
+        let entries = self
+            .task_runtime_registry
+            .iter()
+            .map(|(task_id, entry)| (task_id.clone(), entry.clone()))
+            .collect::<Vec<_>>();
         for (task_id, entry) in entries {
-            let _ = self.stop_runtime_entry(&task_id, entry).await;
+            let _ = self.stop_runtime_entry(entry.clone()).await;
+            self.remove_runtime_if_current(&task_id, &entry);
         }
     }
 
-    async fn stop_runtime_entry(
-        &self,
-        task_id: &TaskId,
-        entry: RuntimeRegistryEntry,
-    ) -> Result<TaskRuntimeStopAck, ()> {
-        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-        entry
-            .sender
-            .send(TaskRuntimeCommand::Stop { ack_tx })
-            .await
-            .map_err(|_| ())?;
-        let ack = ack_rx.await.map_err(|_| ())?;
-        if ack.task_id == *task_id && ack.task_runtime_instance_id == entry.task_runtime_instance_id
-        {
-            Ok(ack)
-        } else {
-            Err(())
+    async fn stop_runtime_entry(&self, entry: RuntimeRegistryEntry) -> Result<(), ()> {
+        let _ = entry.control.stop().await;
+        Ok(())
+    }
+
+    fn remove_runtime_if_current(&mut self, task_id: &TaskId, entry: &RuntimeRegistryEntry) {
+        let is_current = self
+            .task_runtime_registry
+            .get(task_id)
+            .is_some_and(|current| current.control.same_control(&entry.control));
+        if is_current {
+            self.task_runtime_registry.remove(task_id);
         }
     }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -531,10 +531,13 @@ impl RouterActor {
     }
 
     async fn stop_task_runtime(&mut self, task_id: TaskId) -> Result<(), RouterExitStatus> {
-        if let Some(sender) = self.task_runtime_registry.get(&task_id).cloned() {
-            return self
-                .send_to_task_runtime(task_id, sender, TaskRuntimeCommand::Stop, false)
-                .await;
+        if let Some(sender) = self.task_runtime_registry.remove(&task_id) {
+            if sender.send(TaskRuntimeCommand::Stop).await.is_err() {
+                return self
+                    .publish_debug(Some(task_id), "task runtime mailbox closed")
+                    .await;
+            }
+            return Ok(());
         }
         if self.pending_effects_by_task.remove(&task_id).is_some() {
             self.deferred_commands.remove(&task_id);

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -231,8 +231,12 @@ impl RouterActor {
     async fn handle_core(&mut self, envelope: CoreOutputEnvelope) -> Result<(), RouterExitStatus> {
         // Core output is task-routed. Runtime identity gates registry ownership and exit cleanup;
         // queued core outputs already in ingress continue through normal task routing.
+        let task_id = envelope.task_id;
         match envelope.message {
             CoreOutputMessage::RequestModelCall(request) => {
+                if request.correlation.task_id != task_id {
+                    return Ok(());
+                }
                 let _join_handle = spawn_model_call_tokio_task(
                     request,
                     self.router_tx.clone(),
@@ -242,6 +246,9 @@ impl RouterActor {
                 Ok(())
             }
             CoreOutputMessage::RequestToolExecution(request) => {
+                if request.task_id != task_id {
+                    return Ok(());
+                }
                 let fallback_request = request.clone();
                 match self
                     .tool_executor
@@ -255,11 +262,14 @@ impl RouterActor {
                 }
             }
             CoreOutputMessage::PublishDomainEvent(request) => {
+                if request.task_id != task_id {
+                    return Ok(());
+                }
                 self.publish_domain_event(request).await
             }
             CoreOutputMessage::RuntimeReady => {
                 self.publish_domain_event(DomainEventPublishRequest {
-                    task_id: envelope.task_id,
+                    task_id,
                     event: DomainEvent::TaskRuntimeReady,
                 })
                 .await

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -28,7 +28,6 @@ pub struct RouterStartArgs {
     pub api_config: ApiExecutorConfig,
     pub tool_executor: Arc<dyn ToolExecutionSpawner>,
     pub core_spawn_deps: TaskRuntimeSpawnDeps,
-    pub router_mailbox_capacity: usize,
 }
 
 pub trait ToolExecutionSpawner: Send + Sync {
@@ -60,16 +59,11 @@ pub enum RouterExitStatus {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SpawnRouterError {
-    InvalidMailboxCapacity,
     TokioSpawnFailed,
 }
 
 pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterError> {
-    if args.router_mailbox_capacity == 0 {
-        return Err(SpawnRouterError::InvalidMailboxCapacity);
-    }
-
-    let (ingress_tx, ingress_rx) = tokio::sync::mpsc::channel(args.router_mailbox_capacity);
+    let (ingress_tx, ingress_rx) = tokio::sync::mpsc::unbounded_channel();
     let actor = RouterActor {
         db: args.db,
         events_tx: args.events_tx,
@@ -101,7 +95,7 @@ struct RouterActor {
     tool_executor: Arc<dyn ToolExecutionSpawner>,
     core_spawn_deps: TaskRuntimeSpawnDeps,
     router_tx: RouterIngressSender,
-    ingress_rx: tokio::sync::mpsc::Receiver<RouterIngressMessage>,
+    ingress_rx: tokio::sync::mpsc::UnboundedReceiver<RouterIngressMessage>,
     task_runtime_registry: HashMap<TaskId, RuntimeRegistryEntry>,
     pending_effects: HashMap<FactoryEffectId, PendingRuntimeEffect>,
     pending_effects_by_task: HashMap<TaskId, FactoryEffectId>,

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -23,8 +23,7 @@ use selvedge_db::{
 };
 use selvedge_domain_model::{FunctionCallId, HistoryNodeId, ModelProviderProfile, ToolName};
 use selvedge_router::{
-    RouterExitStatus, RouterStartArgs, SpawnRouterError, ToolExecutionSpawnError,
-    ToolExecutionSpawner, spawn_router,
+    RouterExitStatus, RouterStartArgs, ToolExecutionSpawnError, ToolExecutionSpawner, spawn_router,
 };
 
 #[tokio::test]
@@ -45,7 +44,6 @@ async fn attach_client_command_is_forwarded_to_events() {
             mailbox_capacity: 8,
             model_profiles: HashMap::new(),
         }),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -69,7 +67,6 @@ async fn attach_client_command_is_forwarded_to_events() {
                 subscription: subscription.clone(),
             },
         }))
-        .await
         .expect("send command");
 
     let event = events_rx.recv().await.expect("events ingress");
@@ -89,7 +86,6 @@ async fn attach_client_command_is_forwarded_to_events() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     assert_eq!(
         handle.join_handle.await.expect("join router"),
@@ -120,7 +116,6 @@ async fn task_local_command_creates_runtime_and_flushes_deferred_user_input() {
             },
             spawner.clone(),
         ),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -134,7 +129,6 @@ async fn task_local_command_creates_runtime_and_flushes_deferred_user_input() {
                 message_text: "hello".to_owned(),
             },
         }))
-        .await
         .expect("send command");
 
     let mut runtime_rx = spawner.wait_receiver("task-1").await;
@@ -149,7 +143,6 @@ async fn task_local_command_creates_runtime_and_flushes_deferred_user_input() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     spawner.finish_stop("task-1").await;
     assert_eq!(
@@ -181,7 +174,6 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
             },
             spawner.clone(),
         ),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -194,7 +186,6 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send ensure");
     let mut runtime_rx = spawner.wait_receiver("task-1").await;
     assert!(matches!(
@@ -212,7 +203,6 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::ApiOutput(api_output))
-        .await
         .expect("send api output");
     let api_command = runtime_rx.recv().await.expect("api command");
     assert!(matches!(api_command, TaskRuntimeCommand::ApiModelReply(_)));
@@ -220,7 +210,6 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::Tool(tool_result("task-1")))
-        .await
         .expect("send tool output");
     let tool_command = runtime_rx.recv().await.expect("tool command");
     assert!(matches!(tool_command, TaskRuntimeCommand::ToolResult(_)));
@@ -228,7 +217,6 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     spawner.finish_stop("task-1").await;
     assert_eq!(
@@ -260,7 +248,6 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
             },
             spawner.clone(),
         ),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -273,7 +260,6 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send ensure");
     let mut stopped_runtime_rx = spawner.wait_receiver("task-1").await;
     let stopped_runtime_control = spawner.wait_control("task-1").await;
@@ -291,7 +277,6 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send stop");
     finish_stop(stopped_runtime_control.clone()).await;
 
@@ -305,7 +290,6 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
                 message_text: "after stop".to_owned(),
             },
         }))
-        .await
         .expect("send user input");
     let mut replacement_runtime_rx = spawner.wait_receiver("task-1").await;
     assert!(matches!(
@@ -332,7 +316,6 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     spawner.finish_stop("task-1").await;
     assert_eq!(
@@ -364,7 +347,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
             },
             spawner.clone(),
         ),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -377,7 +359,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send ensure");
     let mut stopped_runtime_rx = spawner.wait_receiver("task-1").await;
     let stopped_runtime_control = spawner.wait_control("task-1").await;
@@ -395,7 +376,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send stop");
     finish_stop(stopped_runtime_control.clone()).await;
 
@@ -409,7 +389,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
                 message_text: "after stop".to_owned(),
             },
         }))
-        .await
         .expect("send user input");
     let mut replacement_runtime_rx = spawner.wait_receiver("task-1").await;
     assert!(matches!(
@@ -434,7 +413,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
             task_runtime_control: stopped_runtime_control,
             reason: TaskRuntimeExitReason::Stopped,
         }))
-        .await
         .expect("send stale exit");
 
     handle
@@ -448,7 +426,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
                 },
             },
         ))
-        .await
         .expect("send api output");
     assert!(matches!(
         replacement_runtime_rx.recv().await.expect("api reply"),
@@ -458,7 +435,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     spawner.finish_stop("task-1").await;
     assert_eq!(
@@ -490,7 +466,6 @@ async fn current_runtime_exit_removes_registry_entry() {
             },
             spawner.clone(),
         ),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -503,7 +478,6 @@ async fn current_runtime_exit_removes_registry_entry() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send ensure");
     let mut first_runtime_rx = spawner.wait_receiver("task-1").await;
     let first_runtime_control = spawner.wait_control("task-1").await;
@@ -519,7 +493,6 @@ async fn current_runtime_exit_removes_registry_entry() {
             task_runtime_control: first_runtime_control,
             reason: TaskRuntimeExitReason::Stopped,
         }))
-        .await
         .expect("send current exit");
     let exit_debug = events_rx.recv().await.expect("exit debug");
     assert_debug_contains(
@@ -537,7 +510,6 @@ async fn current_runtime_exit_removes_registry_entry() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send replacement ensure");
     let mut replacement_runtime_rx = spawner.wait_receiver("task-1").await;
     assert!(matches!(
@@ -551,7 +523,6 @@ async fn current_runtime_exit_removes_registry_entry() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     spawner.finish_stop("task-1").await;
     assert_eq!(
@@ -583,7 +554,6 @@ async fn inactive_archive_is_delivered_before_runtime_start() {
             },
             spawner.clone(),
         ),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -596,7 +566,6 @@ async fn inactive_archive_is_delivered_before_runtime_start() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send archive");
     let mut runtime_rx = spawner.wait_receiver("task-1").await;
     assert!(matches!(
@@ -612,7 +581,6 @@ async fn inactive_archive_is_delivered_before_runtime_start() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     spawner.finish_stop("task-1").await;
     assert_eq!(
@@ -639,7 +607,6 @@ async fn stale_outputs_and_runtime_ready_are_published_to_events() {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -654,7 +621,6 @@ async fn stale_outputs_and_runtime_ready_are_published_to_events() {
                 },
             },
         ))
-        .await
         .expect("send api output");
     let stale_api = events_rx.recv().await.expect("stale api debug");
     assert_debug_contains(stale_api, Some(TaskId("missing".to_owned())), "stale api");
@@ -662,7 +628,6 @@ async fn stale_outputs_and_runtime_ready_are_published_to_events() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::Tool(tool_result("missing")))
-        .await
         .expect("send tool output");
     let stale_tool = events_rx.recv().await.expect("stale tool debug");
     assert_debug_contains(stale_tool, Some(TaskId("missing".to_owned())), "stale tool");
@@ -673,7 +638,6 @@ async fn stale_outputs_and_runtime_ready_are_published_to_events() {
             task_id: TaskId("task-ready".to_owned()),
             message: CoreOutputMessage::RuntimeReady,
         }))
-        .await
         .expect("send runtime ready");
     let ready = events_rx.recv().await.expect("ready debug");
     assert_debug_contains(
@@ -685,7 +649,6 @@ async fn stale_outputs_and_runtime_ready_are_published_to_events() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     assert_eq!(
         handle.join_handle.await.expect("join router"),
@@ -711,7 +674,6 @@ async fn data_domain_events_are_not_published_to_events() {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -725,7 +687,6 @@ async fn data_domain_events_are_not_published_to_events() {
                 },
             },
         ))
-        .await
         .expect("send data event");
     assert!(
         tokio::time::timeout(Duration::from_millis(50), events_rx.recv())
@@ -736,7 +697,6 @@ async fn data_domain_events_are_not_published_to_events() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     assert_eq!(
         handle.join_handle.await.expect("join router"),
@@ -763,7 +723,6 @@ async fn core_tool_execution_request_uses_configured_tool_spawner() {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -773,7 +732,6 @@ async fn core_tool_execution_request_uses_configured_tool_spawner() {
             task_id: TaskId("task-1".to_owned()),
             message: CoreOutputMessage::RequestToolExecution(tool_request("task-1")),
         }))
-        .await
         .expect("send core tool request");
 
     let request = tool_spawner.wait_request().await;
@@ -783,7 +741,6 @@ async fn core_tool_execution_request_uses_configured_tool_spawner() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     assert_eq!(
         handle.join_handle.await.expect("join router"),
@@ -814,7 +771,6 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
             },
             spawner.clone(),
         ),
-        router_mailbox_capacity: 8,
     })
     .expect("spawn router");
 
@@ -827,7 +783,6 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
                 task_id: TaskId("task-1".to_owned()),
             },
         }))
-        .await
         .expect("send ensure");
     let mut runtime_rx = spawner.wait_receiver("task-1").await;
     assert!(matches!(
@@ -841,7 +796,6 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
             task_id: TaskId("task-1".to_owned()),
             message: CoreOutputMessage::RequestToolExecution(tool_request("task-1")),
         }))
-        .await
         .expect("send core tool request");
 
     let TaskRuntimeCommand::ToolResult(result) =
@@ -855,7 +809,6 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
     handle
         .ingress_tx
         .send(RouterIngressMessage::StopRouter)
-        .await
         .expect("stop router");
     spawner.finish_stop("task-1").await;
     assert_eq!(
@@ -864,11 +817,11 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
     );
 }
 
-#[test]
-fn spawn_router_rejects_zero_mailbox_capacity() {
+#[tokio::test]
+async fn spawn_router_uses_unbounded_ingress() {
     let db = open_memory_db();
     let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
-    let result = spawn_router(RouterStartArgs {
+    let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
         api_provider_registry: Arc::new(EmptyProviderRegistry),
@@ -881,12 +834,16 @@ fn spawn_router_rejects_zero_mailbox_capacity() {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
-        router_mailbox_capacity: 0,
-    });
-    let Err(error) = result else {
-        panic!("expected invalid mailbox capacity");
-    };
-    assert_eq!(error, SpawnRouterError::InvalidMailboxCapacity);
+    })
+    .expect("spawn router");
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
 }
 
 fn open_memory_db() -> DbPool {

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -5,10 +5,11 @@ use std::time::Duration;
 use selvedge_api::{ApiExecutorConfig, ModelProviderAdapter, ModelProviderRegistry};
 use selvedge_command_model::{
     ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommandId,
-    ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel,
-    EventControlMessage, EventIngress, ModelCallError, ModelCallErrorKind, ModelRunId, RawEvent,
-    RouterCommand, RouterCommandEnvelope, RouterIngressMessage, TaskRuntimeCommand, TaskScope,
-    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+    ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel, DomainEvent,
+    DomainEventPublishRequest, EventControlMessage, EventIngress, ModelCallError,
+    ModelCallErrorKind, ModelRunId, RawEvent, RouterCommand, RouterCommandEnvelope,
+    RouterIngressMessage, TaskRuntimeCommand, TaskScope, ToolExecutionRequest, ToolExecutionResult,
+    ToolExecutionRunId,
 };
 use selvedge_core::{
     SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
@@ -296,6 +297,57 @@ async fn stale_outputs_and_runtime_ready_are_published_to_events() {
         ready,
         Some(TaskId("task-ready".to_owned())),
         "task runtime ready",
+    );
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn data_domain_events_are_not_published_to_events() {
+    let db = open_memory_db();
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::PublishToEvents(
+            DomainEventPublishRequest {
+                task_id: TaskId("task-1".to_owned()),
+                event: DomainEvent::UserMessageCommitted {
+                    node_id: HistoryNodeId(1),
+                },
+            },
+        ))
+        .await
+        .expect("send data event");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), events_rx.recv())
+            .await
+            .is_err()
     );
 
     handle

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -749,6 +749,49 @@ async fn core_tool_execution_request_uses_configured_tool_spawner() {
 }
 
 #[tokio::test]
+async fn mismatched_core_tool_task_id_is_ignored() {
+    let db = open_memory_db();
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+    let tool_spawner = Arc::new(CapturingToolSpawner::default());
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: tool_spawner.clone(),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Core(CoreOutputEnvelope {
+            task_id: TaskId("task-1".to_owned()),
+            message: CoreOutputMessage::RequestToolExecution(tool_request("task-2")),
+        }))
+        .expect("send core tool request");
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(tool_spawner.request_count(), 0);
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
 async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
     let db = open_memory_db();
     create_root(&db, "task-1");
@@ -1056,6 +1099,10 @@ struct CapturingToolSpawner {
 }
 
 impl CapturingToolSpawner {
+    fn request_count(&self) -> usize {
+        self.requests.lock().expect("lock requests").len()
+    }
+
     async fn wait_request(&self) -> ToolExecutionRequest {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
         loop {

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -8,8 +8,8 @@ use selvedge_command_model::{
     ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel, DomainEvent,
     DomainEventPublishRequest, EventControlMessage, EventIngress, ModelCallError,
     ModelCallErrorKind, ModelRunId, RawEvent, RouterCommand, RouterCommandEnvelope,
-    RouterIngressMessage, TaskRuntimeCommand, TaskScope, ToolExecutionRequest, ToolExecutionResult,
-    ToolExecutionRunId,
+    RouterIngressMessage, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
+    TaskScope, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_core::{
     SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
@@ -330,6 +330,192 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
         tokio::time::timeout(Duration::from_millis(50), stopped_runtime_rx.recv()).await
     {
         panic!("unexpected stopped runtime command: {command:?}");
+    }
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn stale_runtime_exit_preserves_replacement_runtime() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let spawner = Arc::new(CapturingRuntimeSpawner::default());
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            spawner.clone(),
+        ),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send ensure");
+    let mut stopped_runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        stopped_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::StopTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        stopped_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::SendUserInput {
+                task_id: TaskId("task-1".to_owned()),
+                message_text: "after stop".to_owned(),
+            },
+        }))
+        .await
+        .expect("send user input");
+    let mut replacement_runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        replacement_runtime_rx
+            .recv()
+            .await
+            .expect("replacement start"),
+        TaskRuntimeCommand::Start
+    ));
+    assert!(matches!(
+        replacement_runtime_rx
+            .recv()
+            .await
+            .expect("replacement input"),
+        TaskRuntimeCommand::UserInput { .. }
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
+            task_id: TaskId("task-1".to_owned()),
+            reason: TaskRuntimeExitReason::Stopped,
+        }))
+        .await
+        .expect("send stale exit");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::ApiOutput(
+            ApiOutputEnvelope::Failure {
+                correlation: correlation("task-1"),
+                error: ModelCallError {
+                    kind: ModelCallErrorKind::ProviderNetwork,
+                    message: "network failed".to_owned(),
+                },
+            },
+        ))
+        .await
+        .expect("send api output");
+    assert!(matches!(
+        replacement_runtime_rx.recv().await.expect("api reply"),
+        TaskRuntimeCommand::ApiModelReply(_)
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn inactive_archive_is_delivered_before_runtime_start() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let spawner = Arc::new(CapturingRuntimeSpawner::default());
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            spawner.clone(),
+        ),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::ArchiveTask {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send archive");
+    let mut runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        runtime_rx.recv().await.expect("archive command"),
+        TaskRuntimeCommand::Archive
+    ));
+    if let Ok(Some(command)) =
+        tokio::time::timeout(Duration::from_millis(50), runtime_rx.recv()).await
+    {
+        panic!("unexpected archive runtime command: {command:?}");
     }
 
     handle

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -151,6 +151,11 @@ async fn task_local_command_creates_runtime_and_flushes_deferred_user_input() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
+    ack_stop(
+        runtime_rx.recv().await.expect("stop command"),
+        "task-1",
+        "task-1-runtime-0",
+    );
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -229,10 +234,11 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    assert!(matches!(
+    ack_stop(
         runtime_rx.recv().await.expect("stop command"),
-        TaskRuntimeCommand::Stop
-    ));
+        "task-1",
+        "task-1-runtime-0",
+    );
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -294,10 +300,11 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
         }))
         .await
         .expect("send stop");
-    assert!(matches!(
+    ack_stop(
         stopped_runtime_rx.recv().await.expect("stop command"),
-        TaskRuntimeCommand::Stop
-    ));
+        "task-1",
+        "task-1-runtime-0",
+    );
 
     handle
         .ingress_tx
@@ -338,6 +345,11 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
+    ack_stop(
+        replacement_runtime_rx.recv().await.expect("stop command"),
+        "task-1",
+        "task-1-runtime-1",
+    );
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -399,10 +411,11 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
         }))
         .await
         .expect("send stop");
-    assert!(matches!(
+    ack_stop(
         stopped_runtime_rx.recv().await.expect("stop command"),
-        TaskRuntimeCommand::Stop
-    ));
+        "task-1",
+        "task-1-runtime-0",
+    );
 
     handle
         .ingress_tx
@@ -465,6 +478,11 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
+    ack_stop(
+        replacement_runtime_rx.recv().await.expect("stop command"),
+        "task-1",
+        "task-1-runtime-1",
+    );
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -556,6 +574,11 @@ async fn current_runtime_exit_removes_registry_entry() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
+    ack_stop(
+        replacement_runtime_rx.recv().await.expect("stop command"),
+        "task-1",
+        "task-1-runtime-1",
+    );
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -616,6 +639,11 @@ async fn inactive_archive_is_delivered_before_runtime_start() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
+    ack_stop(
+        runtime_rx.recv().await.expect("stop command"),
+        "task-1",
+        "task-1-runtime-0",
+    );
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -858,6 +886,11 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
+    ack_stop(
+        runtime_rx.recv().await.expect("stop command"),
+        "task-1",
+        "task-1-runtime-0",
+    );
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -972,6 +1005,22 @@ fn assert_debug_contains(event: EventIngress, task_id: Option<TaskId>, message: 
     };
     assert_eq!(debug.task_id, task_id);
     assert!(debug.message_text.contains(message));
+}
+
+fn ack_stop(command: TaskRuntimeCommand, task_id: &str, task_runtime_instance_id: &str) {
+    let TaskRuntimeCommand::Stop { ack_tx } = command else {
+        panic!("unexpected task runtime command");
+    };
+    assert!(
+        ack_tx
+            .send(selvedge_command_model::TaskRuntimeStopAck {
+                task_id: TaskId(task_id.to_owned()),
+                task_runtime_instance_id: TaskRuntimeInstanceId(
+                    task_runtime_instance_id.to_owned()
+                ),
+            })
+            .is_ok()
+    );
 }
 
 struct EmptyProviderRegistry;

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -1,0 +1,569 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use selvedge_api::{ApiExecutorConfig, ModelProviderAdapter, ModelProviderRegistry};
+use selvedge_command_model::{
+    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommandId,
+    ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel,
+    EventControlMessage, EventIngress, ModelCallError, ModelCallErrorKind, ModelRunId, RawEvent,
+    RouterCommand, RouterCommandEnvelope, RouterIngressMessage, TaskRuntimeCommand, TaskScope,
+    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+};
+use selvedge_core::{
+    SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
+    TaskRuntimeSpawnDeps, TaskRuntimeSpawner,
+};
+use selvedge_db::{
+    CreateRootTaskInput, DbPool, MessageRole, ModelProfileKey, NewHistoryNode,
+    NewHistoryNodeContent, NewMessageNodeContent, OpenDbOptions, ReasoningEffort, TaskId, UnixTs,
+    create_history_node, create_root_task, open_db,
+};
+use selvedge_domain_model::{FunctionCallId, HistoryNodeId, ModelProviderProfile, ToolName};
+use selvedge_router::{
+    RouterExitStatus, RouterStartArgs, SpawnRouterError, ToolExecutionSpawnError,
+    ToolExecutionSpawner, spawn_router,
+};
+
+#[tokio::test]
+async fn attach_client_command_is_forwarded_to_events() {
+    let db = open_memory_db();
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: HashMap::new(),
+        }),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    let (outbound, _outbound_rx) = tokio::sync::mpsc::channel(4);
+    let subscription = ClientSubscription {
+        task_scope: TaskScope::AllTasks,
+        detail_level: DetailLevel::Verbose,
+        include_model_call_status: true,
+        include_tool_execution_status: true,
+        include_debug_notices: true,
+    };
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: Some(ClientId("client-1".to_owned())),
+            client_command_id: Some(ClientCommandId("attach-1".to_owned())),
+            command: RouterCommand::AttachClient {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                outbound,
+                subscription: subscription.clone(),
+            },
+        }))
+        .await
+        .expect("send command");
+
+    let event = events_rx.recv().await.expect("events ingress");
+    let EventIngress::Control(EventControlMessage::BeginClientHydration(BeginClientHydration {
+        client_id,
+        client_command_id,
+        subscription: received_subscription,
+        ..
+    })) = event
+    else {
+        panic!("unexpected events ingress");
+    };
+    assert_eq!(client_id, ClientId("client-1".to_owned()));
+    assert_eq!(client_command_id, ClientCommandId("attach-1".to_owned()));
+    assert_eq!(received_subscription, subscription);
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn task_local_command_creates_runtime_and_flushes_deferred_user_input() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let spawner = Arc::new(CapturingRuntimeSpawner::default());
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            spawner.clone(),
+        ),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::SendUserInput {
+                task_id: TaskId("task-1".to_owned()),
+                message_text: "hello".to_owned(),
+            },
+        }))
+        .await
+        .expect("send command");
+
+    let mut runtime_rx = spawner.wait_receiver("task-1").await;
+    let start = runtime_rx.recv().await.expect("start command");
+    assert!(matches!(start, TaskRuntimeCommand::Start));
+    let input = runtime_rx.recv().await.expect("user input command");
+    let TaskRuntimeCommand::UserInput { message_text } = input else {
+        panic!("unexpected task runtime command");
+    };
+    assert_eq!(message_text, "hello");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let spawner = Arc::new(CapturingRuntimeSpawner::default());
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            spawner.clone(),
+        ),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send ensure");
+    let mut runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    let api_output = ApiOutputEnvelope::Failure {
+        correlation: correlation("task-1"),
+        error: ModelCallError {
+            kind: ModelCallErrorKind::ProviderNetwork,
+            message: "network failed".to_owned(),
+        },
+    };
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::ApiOutput(api_output))
+        .await
+        .expect("send api output");
+    let api_command = runtime_rx.recv().await.expect("api command");
+    assert!(matches!(api_command, TaskRuntimeCommand::ApiModelReply(_)));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Tool(tool_result("task-1")))
+        .await
+        .expect("send tool output");
+    let tool_command = runtime_rx.recv().await.expect("tool command");
+    assert!(matches!(tool_command, TaskRuntimeCommand::ToolResult(_)));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert!(matches!(
+        runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn stale_outputs_and_runtime_ready_are_published_to_events() {
+    let db = open_memory_db();
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::ApiOutput(
+            ApiOutputEnvelope::Failure {
+                correlation: correlation("missing"),
+                error: ModelCallError {
+                    kind: ModelCallErrorKind::ProviderNetwork,
+                    message: "network failed".to_owned(),
+                },
+            },
+        ))
+        .await
+        .expect("send api output");
+    let stale_api = events_rx.recv().await.expect("stale api debug");
+    assert_debug_contains(stale_api, Some(TaskId("missing".to_owned())), "stale api");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Tool(tool_result("missing")))
+        .await
+        .expect("send tool output");
+    let stale_tool = events_rx.recv().await.expect("stale tool debug");
+    assert_debug_contains(stale_tool, Some(TaskId("missing".to_owned())), "stale tool");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Core(CoreOutputEnvelope {
+            task_id: TaskId("task-ready".to_owned()),
+            message: CoreOutputMessage::RuntimeReady,
+        }))
+        .await
+        .expect("send runtime ready");
+    let ready = events_rx.recv().await.expect("ready debug");
+    assert_debug_contains(
+        ready,
+        Some(TaskId("task-ready".to_owned())),
+        "task runtime ready",
+    );
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn core_tool_execution_request_uses_configured_tool_spawner() {
+    let db = open_memory_db();
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+    let tool_spawner = Arc::new(CapturingToolSpawner::default());
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: tool_spawner.clone(),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Core(CoreOutputEnvelope {
+            task_id: TaskId("task-1".to_owned()),
+            message: CoreOutputMessage::RequestToolExecution(tool_request("task-1")),
+        }))
+        .await
+        .expect("send core tool request");
+
+    let request = tool_spawner.wait_request().await;
+    assert_eq!(request.task_id, TaskId("task-1".to_owned()));
+    assert_eq!(request.tool_name, ToolName("tool".to_owned()));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[test]
+fn spawn_router_rejects_zero_mailbox_capacity() {
+    let db = open_memory_db();
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+    let result = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+        router_mailbox_capacity: 0,
+    });
+    let Err(error) = result else {
+        panic!("expected invalid mailbox capacity");
+    };
+    assert_eq!(error, SpawnRouterError::InvalidMailboxCapacity);
+}
+
+fn open_memory_db() -> DbPool {
+    open_db(OpenDbOptions {
+        sqlite_path: ":memory:".to_owned(),
+    })
+    .expect("open db")
+}
+
+fn create_root(db: &DbPool, task_id: &str) {
+    let cursor_node_id = create_history_node(
+        db,
+        NewHistoryNode {
+            parent_node_id: None,
+            content: NewHistoryNodeContent::Message(NewMessageNodeContent {
+                message_role: MessageRole::User,
+                message_text: "hello".to_owned(),
+            }),
+            created_at: UnixTs(1),
+        },
+    )
+    .expect("create message node");
+    create_root_task(
+        db,
+        CreateRootTaskInput {
+            task_id: TaskId(task_id.to_owned()),
+            cursor_node_id,
+            model_profile_key: ModelProfileKey("default".to_owned()),
+            reasoning_effort: ReasoningEffort::Medium,
+            enabled_tools: Vec::new(),
+            now: UnixTs(1),
+        },
+    )
+    .expect("create root task");
+}
+
+fn model_profiles() -> HashMap<ModelProfileKey, ModelProviderProfile> {
+    HashMap::from([(
+        ModelProfileKey("default".to_owned()),
+        ModelProviderProfile {
+            provider_name: "provider".to_owned(),
+            model_name: "model".to_owned(),
+            temperature: None,
+            max_output_tokens: None,
+        },
+    )])
+}
+
+fn correlation(task_id: &str) -> ApiCallCorrelation {
+    ApiCallCorrelation {
+        api_effect_id: ApiEffectId("api-1".to_owned()),
+        task_id: TaskId(task_id.to_owned()),
+        model_run_id: ModelRunId("model-1".to_owned()),
+    }
+}
+
+fn tool_result(task_id: &str) -> ToolExecutionResult {
+    ToolExecutionResult {
+        task_id: TaskId(task_id.to_owned()),
+        tool_execution_run_id: ToolExecutionRunId("tool-1".to_owned()),
+        function_call_node_id: HistoryNodeId(1),
+        function_call_id: FunctionCallId("call-1".to_owned()),
+        tool_name: ToolName("tool".to_owned()),
+        output_text: "done".to_owned(),
+        is_error: false,
+    }
+}
+
+fn tool_request(task_id: &str) -> ToolExecutionRequest {
+    ToolExecutionRequest {
+        task_id: TaskId(task_id.to_owned()),
+        tool_execution_run_id: ToolExecutionRunId("tool-1".to_owned()),
+        function_call_node_id: HistoryNodeId(1),
+        function_call_id: FunctionCallId("call-1".to_owned()),
+        tool_name: ToolName("tool".to_owned()),
+        arguments: Vec::new(),
+    }
+}
+
+fn assert_debug_contains(event: EventIngress, task_id: Option<TaskId>, message: &str) {
+    let EventIngress::Raw(RawEvent::Debug(debug)) = event else {
+        panic!("unexpected event ingress");
+    };
+    assert_eq!(debug.task_id, task_id);
+    assert!(debug.message_text.contains(message));
+}
+
+struct EmptyProviderRegistry;
+
+impl ModelProviderRegistry for EmptyProviderRegistry {
+    fn resolve(&self, _provider_name: &str) -> Option<Arc<dyn ModelProviderAdapter>> {
+        None
+    }
+}
+
+struct NoopToolSpawner;
+
+impl ToolExecutionSpawner for NoopToolSpawner {
+    fn spawn_tool_execution(
+        &self,
+        _request: ToolExecutionRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, ToolExecutionSpawnError> {
+        Ok(tokio::spawn(async {}))
+    }
+}
+
+#[derive(Default)]
+struct CapturingToolSpawner {
+    requests: Mutex<Vec<ToolExecutionRequest>>,
+}
+
+impl CapturingToolSpawner {
+    async fn wait_request(&self) -> ToolExecutionRequest {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            {
+                let mut requests = self.requests.lock().expect("lock requests");
+                if let Some(request) = requests.pop() {
+                    return request;
+                }
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "tool execution request"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+}
+
+impl ToolExecutionSpawner for CapturingToolSpawner {
+    fn spawn_tool_execution(
+        &self,
+        request: ToolExecutionRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, ToolExecutionSpawnError> {
+        let mut requests = self
+            .requests
+            .lock()
+            .map_err(|_| ToolExecutionSpawnError::ToolExecutorUnavailable)?;
+        requests.push(request);
+        Ok(tokio::spawn(async {}))
+    }
+}
+
+#[derive(Default)]
+struct CapturingRuntimeSpawner {
+    receivers: Mutex<HashMap<TaskId, tokio::sync::mpsc::Receiver<TaskRuntimeCommand>>>,
+}
+
+impl CapturingRuntimeSpawner {
+    async fn wait_receiver(
+        &self,
+        task_id: &str,
+    ) -> tokio::sync::mpsc::Receiver<TaskRuntimeCommand> {
+        let task_id = TaskId(task_id.to_owned());
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            {
+                let mut receivers = self.receivers.lock().expect("lock receivers");
+                if let Some(receiver) = receivers.remove(&task_id) {
+                    return receiver;
+                }
+            }
+            assert!(tokio::time::Instant::now() < deadline, "runtime receiver");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+}
+
+impl TaskRuntimeSpawner for CapturingRuntimeSpawner {
+    fn spawn_task_runtime(
+        &self,
+        args: SpawnTaskRuntimeArgs,
+    ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
+        let (task_runtime_tx, task_runtime_rx) = tokio::sync::mpsc::channel(8);
+        let mut receivers = self
+            .receivers
+            .lock()
+            .map_err(|_| SpawnTaskRuntimeError::TokioSpawnFailed)?;
+        receivers.insert(args.task_id.clone(), task_runtime_rx);
+        Ok(SpawnedTaskRuntime {
+            task_id: args.task_id,
+            task_runtime_tx,
+        })
+    }
+}

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -9,7 +9,8 @@ use selvedge_command_model::{
     DomainEventPublishRequest, EventControlMessage, EventIngress, ModelCallError,
     ModelCallErrorKind, ModelRunId, RawEvent, RouterCommand, RouterCommandEnvelope,
     RouterIngressMessage, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskScope, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+    TaskRuntimeInstanceId, TaskScope, ToolExecutionRequest, ToolExecutionResult,
+    ToolExecutionRunId,
 };
 use selvedge_core::{
     SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
@@ -435,6 +436,7 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
         .ingress_tx
         .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
             task_id: TaskId("task-1".to_owned()),
+            task_runtime_instance_id: TaskRuntimeInstanceId("task-1-runtime-0".to_owned()),
             reason: TaskRuntimeExitReason::Stopped,
         }))
         .await
@@ -456,6 +458,97 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
     assert!(matches!(
         replacement_runtime_rx.recv().await.expect("api reply"),
         TaskRuntimeCommand::ApiModelReply(_)
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn current_runtime_exit_removes_registry_entry() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let spawner = Arc::new(CapturingRuntimeSpawner::default());
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            spawner.clone(),
+        ),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send ensure");
+    let mut first_runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        first_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
+            task_id: TaskId("task-1".to_owned()),
+            task_runtime_instance_id: TaskRuntimeInstanceId("task-1-runtime-0".to_owned()),
+            reason: TaskRuntimeExitReason::Stopped,
+        }))
+        .await
+        .expect("send current exit");
+    let exit_debug = events_rx.recv().await.expect("exit debug");
+    assert_debug_contains(
+        exit_debug,
+        Some(TaskId("task-1".to_owned())),
+        "task runtime exited",
+    );
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send replacement ensure");
+    let mut replacement_runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        replacement_runtime_rx
+            .recv()
+            .await
+            .expect("replacement start"),
+        TaskRuntimeCommand::Start
     ));
 
     handle
@@ -871,6 +964,7 @@ impl ToolExecutionSpawner for CapturingToolSpawner {
 #[derive(Default)]
 struct CapturingRuntimeSpawner {
     receivers: Mutex<HashMap<TaskId, tokio::sync::mpsc::Receiver<TaskRuntimeCommand>>>,
+    next_instance_seq: Mutex<u64>,
 }
 
 impl CapturingRuntimeSpawner {
@@ -899,6 +993,13 @@ impl TaskRuntimeSpawner for CapturingRuntimeSpawner {
         args: SpawnTaskRuntimeArgs,
     ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
         let (task_runtime_tx, task_runtime_rx) = tokio::sync::mpsc::channel(8);
+        let mut next_instance_seq = self
+            .next_instance_seq
+            .lock()
+            .map_err(|_| SpawnTaskRuntimeError::TokioSpawnFailed)?;
+        let task_runtime_instance_id =
+            TaskRuntimeInstanceId(format!("{}-runtime-{}", args.task_id.0, *next_instance_seq));
+        *next_instance_seq += 1;
         let mut receivers = self
             .receivers
             .lock()
@@ -906,6 +1007,7 @@ impl TaskRuntimeSpawner for CapturingRuntimeSpawner {
         receivers.insert(args.task_id.clone(), task_runtime_rx);
         Ok(SpawnedTaskRuntime {
             task_id: args.task_id,
+            task_runtime_instance_id,
             task_runtime_tx,
         })
     }

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -8,8 +8,8 @@ use selvedge_command_model::{
     ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel, DomainEvent,
     DomainEventPublishRequest, EventControlMessage, EventIngress, ModelCallError,
     ModelCallErrorKind, ModelRunId, RawEvent, RouterCommand, RouterCommandEnvelope,
-    RouterIngressMessage, TaskRuntimeCommand, TaskRuntimeExitNotice, TaskRuntimeExitReason,
-    TaskRuntimeInstanceId, TaskScope, ToolExecutionRequest, ToolExecutionResult,
+    RouterIngressMessage, TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice,
+    TaskRuntimeExitReason, TaskScope, ToolExecutionRequest, ToolExecutionResult,
     ToolExecutionRunId,
 };
 use selvedge_core::{
@@ -151,11 +151,7 @@ async fn task_local_command_creates_runtime_and_flushes_deferred_user_input() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    ack_stop(
-        runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-0",
-    );
+    spawner.finish_stop("task-1").await;
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -234,11 +230,7 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    ack_stop(
-        runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-0",
-    );
+    spawner.finish_stop("task-1").await;
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -284,6 +276,7 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
         .await
         .expect("send ensure");
     let mut stopped_runtime_rx = spawner.wait_receiver("task-1").await;
+    let stopped_runtime_control = spawner.wait_control("task-1").await;
     assert!(matches!(
         stopped_runtime_rx.recv().await.expect("start command"),
         TaskRuntimeCommand::Start
@@ -300,11 +293,7 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
         }))
         .await
         .expect("send stop");
-    ack_stop(
-        stopped_runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-0",
-    );
+    finish_stop(stopped_runtime_control.clone()).await;
 
     handle
         .ingress_tx
@@ -345,11 +334,7 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    ack_stop(
-        replacement_runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-1",
-    );
+    spawner.finish_stop("task-1").await;
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -395,6 +380,7 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
         .await
         .expect("send ensure");
     let mut stopped_runtime_rx = spawner.wait_receiver("task-1").await;
+    let stopped_runtime_control = spawner.wait_control("task-1").await;
     assert!(matches!(
         stopped_runtime_rx.recv().await.expect("start command"),
         TaskRuntimeCommand::Start
@@ -411,11 +397,7 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
         }))
         .await
         .expect("send stop");
-    ack_stop(
-        stopped_runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-0",
-    );
+    finish_stop(stopped_runtime_control.clone()).await;
 
     handle
         .ingress_tx
@@ -449,7 +431,7 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
         .ingress_tx
         .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
             task_id: TaskId("task-1".to_owned()),
-            task_runtime_instance_id: TaskRuntimeInstanceId("task-1-runtime-0".to_owned()),
+            task_runtime_control: stopped_runtime_control,
             reason: TaskRuntimeExitReason::Stopped,
         }))
         .await
@@ -478,11 +460,7 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    ack_stop(
-        replacement_runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-1",
-    );
+    spawner.finish_stop("task-1").await;
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -528,6 +506,7 @@ async fn current_runtime_exit_removes_registry_entry() {
         .await
         .expect("send ensure");
     let mut first_runtime_rx = spawner.wait_receiver("task-1").await;
+    let first_runtime_control = spawner.wait_control("task-1").await;
     assert!(matches!(
         first_runtime_rx.recv().await.expect("start command"),
         TaskRuntimeCommand::Start
@@ -537,7 +516,7 @@ async fn current_runtime_exit_removes_registry_entry() {
         .ingress_tx
         .send(RouterIngressMessage::RuntimeExit(TaskRuntimeExitNotice {
             task_id: TaskId("task-1".to_owned()),
-            task_runtime_instance_id: TaskRuntimeInstanceId("task-1-runtime-0".to_owned()),
+            task_runtime_control: first_runtime_control,
             reason: TaskRuntimeExitReason::Stopped,
         }))
         .await
@@ -574,11 +553,7 @@ async fn current_runtime_exit_removes_registry_entry() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    ack_stop(
-        replacement_runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-1",
-    );
+    spawner.finish_stop("task-1").await;
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -639,11 +614,7 @@ async fn inactive_archive_is_delivered_before_runtime_start() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    ack_stop(
-        runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-0",
-    );
+    spawner.finish_stop("task-1").await;
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -886,11 +857,7 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
         .send(RouterIngressMessage::StopRouter)
         .await
         .expect("stop router");
-    ack_stop(
-        runtime_rx.recv().await.expect("stop command"),
-        "task-1",
-        "task-1-runtime-0",
-    );
+    spawner.finish_stop("task-1").await;
     assert_eq!(
         handle.join_handle.await.expect("join router"),
         RouterExitStatus::Stopped
@@ -1007,20 +974,15 @@ fn assert_debug_contains(event: EventIngress, task_id: Option<TaskId>, message: 
     assert!(debug.message_text.contains(message));
 }
 
-fn ack_stop(command: TaskRuntimeCommand, task_id: &str, task_runtime_instance_id: &str) {
-    let TaskRuntimeCommand::Stop { ack_tx } = command else {
-        panic!("unexpected task runtime command");
-    };
-    assert!(
-        ack_tx
-            .send(selvedge_command_model::TaskRuntimeStopAck {
-                task_id: TaskId(task_id.to_owned()),
-                task_runtime_instance_id: TaskRuntimeInstanceId(
-                    task_runtime_instance_id.to_owned()
-                ),
-            })
-            .is_ok()
-    );
+async fn finish_stop(control: TaskRuntimeControl) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    while !control.is_stopping() {
+        assert!(tokio::time::Instant::now() < deadline, "runtime stopping");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    control
+        .finish_stop(selvedge_command_model::TaskRuntimeStopResult)
+        .await;
 }
 
 struct EmptyProviderRegistry;
@@ -1097,7 +1059,7 @@ impl ToolExecutionSpawner for CapturingToolSpawner {
 #[derive(Default)]
 struct CapturingRuntimeSpawner {
     receivers: Mutex<HashMap<TaskId, tokio::sync::mpsc::Receiver<TaskRuntimeCommand>>>,
-    next_instance_seq: Mutex<u64>,
+    controls: Mutex<HashMap<TaskId, TaskRuntimeControl>>,
 }
 
 impl CapturingRuntimeSpawner {
@@ -1118,6 +1080,26 @@ impl CapturingRuntimeSpawner {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
+
+    async fn wait_control(&self, task_id: &str) -> TaskRuntimeControl {
+        let task_id = TaskId(task_id.to_owned());
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            {
+                let mut controls = self.controls.lock().expect("lock controls");
+                if let Some(control) = controls.remove(&task_id) {
+                    return control;
+                }
+            }
+            assert!(tokio::time::Instant::now() < deadline, "runtime control");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn finish_stop(&self, task_id: &str) {
+        let control = self.wait_control(task_id).await;
+        finish_stop(control).await;
+    }
 }
 
 impl TaskRuntimeSpawner for CapturingRuntimeSpawner {
@@ -1126,22 +1108,21 @@ impl TaskRuntimeSpawner for CapturingRuntimeSpawner {
         args: SpawnTaskRuntimeArgs,
     ) -> Result<SpawnedTaskRuntime, SpawnTaskRuntimeError> {
         let (task_runtime_tx, task_runtime_rx) = tokio::sync::mpsc::channel(8);
-        let mut next_instance_seq = self
-            .next_instance_seq
-            .lock()
-            .map_err(|_| SpawnTaskRuntimeError::TokioSpawnFailed)?;
-        let task_runtime_instance_id =
-            TaskRuntimeInstanceId(format!("{}-runtime-{}", args.task_id.0, *next_instance_seq));
-        *next_instance_seq += 1;
+        let task_runtime_control = TaskRuntimeControl::new();
         let mut receivers = self
             .receivers
             .lock()
             .map_err(|_| SpawnTaskRuntimeError::TokioSpawnFailed)?;
         receivers.insert(args.task_id.clone(), task_runtime_rx);
+        let mut controls = self
+            .controls
+            .lock()
+            .map_err(|_| SpawnTaskRuntimeError::TokioSpawnFailed)?;
+        controls.insert(args.task_id.clone(), task_runtime_control.clone());
         Ok(SpawnedTaskRuntime {
             task_id: args.task_id,
-            task_runtime_instance_id,
             task_runtime_tx,
+            task_runtime_control,
         })
     }
 }

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -875,6 +875,53 @@ async fn router_exits_when_ingress_sender_is_dropped() {
     assert_eq!(status, RouterExitStatus::RouterMailboxClosed);
 }
 
+#[tokio::test]
+async fn router_exits_when_ingress_sender_is_dropped_with_live_runtime() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .expect("send ensure");
+    let ready = events_rx.recv().await.expect("runtime ready");
+    assert_debug_contains(
+        ready,
+        Some(TaskId("task-1".to_owned())),
+        "task runtime ready",
+    );
+
+    drop(handle.ingress_tx);
+
+    let status = tokio::time::timeout(Duration::from_millis(50), handle.join_handle)
+        .await
+        .expect("router exit")
+        .expect("join router");
+    assert_eq!(status, RouterExitStatus::RouterMailboxClosed);
+}
+
 fn open_memory_db() -> DbPool {
     open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),
@@ -985,7 +1032,7 @@ impl ToolExecutionSpawner for NoopToolSpawner {
     fn spawn_tool_execution(
         &self,
         _request: ToolExecutionRequest,
-        _router_tx: selvedge_command_model::RouterIngressSender,
+        _router_tx: selvedge_command_model::RouterIngressWeakSender,
     ) -> Result<tokio::task::JoinHandle<()>, ToolExecutionSpawnError> {
         Ok(tokio::spawn(async {}))
     }
@@ -997,7 +1044,7 @@ impl ToolExecutionSpawner for FailingToolSpawner {
     fn spawn_tool_execution(
         &self,
         _request: ToolExecutionRequest,
-        _router_tx: selvedge_command_model::RouterIngressSender,
+        _router_tx: selvedge_command_model::RouterIngressWeakSender,
     ) -> Result<tokio::task::JoinHandle<()>, ToolExecutionSpawnError> {
         Err(ToolExecutionSpawnError::TokioSpawnFailed)
     }
@@ -1031,7 +1078,7 @@ impl ToolExecutionSpawner for CapturingToolSpawner {
     fn spawn_tool_execution(
         &self,
         request: ToolExecutionRequest,
-        _router_tx: selvedge_command_model::RouterIngressSender,
+        _router_tx: selvedge_command_model::RouterIngressWeakSender,
     ) -> Result<tokio::task::JoinHandle<()>, ToolExecutionSpawnError> {
         let mut requests = self
             .requests

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -239,6 +239,111 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
 }
 
 #[tokio::test]
+async fn stop_runtime_removes_sender_before_later_task_commands() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let spawner = Arc::new(CapturingRuntimeSpawner::default());
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            spawner.clone(),
+        ),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send ensure");
+    let mut stopped_runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        stopped_runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::StopTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send stop");
+    assert!(matches!(
+        stopped_runtime_rx.recv().await.expect("stop command"),
+        TaskRuntimeCommand::Stop
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::SendUserInput {
+                task_id: TaskId("task-1".to_owned()),
+                message_text: "after stop".to_owned(),
+            },
+        }))
+        .await
+        .expect("send user input");
+    let mut replacement_runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        replacement_runtime_rx
+            .recv()
+            .await
+            .expect("replacement start"),
+        TaskRuntimeCommand::Start
+    ));
+    let TaskRuntimeCommand::UserInput { message_text } = replacement_runtime_rx
+        .recv()
+        .await
+        .expect("replacement input")
+    else {
+        panic!("unexpected task runtime command");
+    };
+    assert_eq!(message_text, "after stop");
+    if let Ok(Some(command)) =
+        tokio::time::timeout(Duration::from_millis(50), stopped_runtime_rx.recv()).await
+    {
+        panic!("unexpected stopped runtime command: {command:?}");
+    }
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
 async fn stale_outputs_and_runtime_ready_are_published_to_events() {
     let db = open_memory_db();
     let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -792,6 +792,78 @@ async fn core_tool_execution_request_uses_configured_tool_spawner() {
     );
 }
 
+#[tokio::test]
+async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
+    let db = open_memory_db();
+    create_root(&db, "task-1");
+    let spawner = Arc::new(CapturingRuntimeSpawner::default());
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(FailingToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
+            TaskRuntimeConfig {
+                mailbox_capacity: 8,
+                model_profiles: model_profiles(),
+            },
+            spawner.clone(),
+        ),
+        router_mailbox_capacity: 8,
+    })
+    .expect("spawn router");
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureTaskRuntime {
+                task_id: TaskId("task-1".to_owned()),
+            },
+        }))
+        .await
+        .expect("send ensure");
+    let mut runtime_rx = spawner.wait_receiver("task-1").await;
+    assert!(matches!(
+        runtime_rx.recv().await.expect("start command"),
+        TaskRuntimeCommand::Start
+    ));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Core(CoreOutputEnvelope {
+            task_id: TaskId("task-1".to_owned()),
+            message: CoreOutputMessage::RequestToolExecution(tool_request("task-1")),
+        }))
+        .await
+        .expect("send core tool request");
+
+    let TaskRuntimeCommand::ToolResult(result) =
+        runtime_rx.recv().await.expect("tool result command")
+    else {
+        panic!("unexpected task runtime command");
+    };
+    assert!(result.is_error);
+    assert!(result.output_text.contains("tool execution spawn failed"));
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .await
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
 #[test]
 fn spawn_router_rejects_zero_mailbox_capacity() {
     let db = open_memory_db();
@@ -919,6 +991,18 @@ impl ToolExecutionSpawner for NoopToolSpawner {
         _router_tx: selvedge_command_model::RouterIngressSender,
     ) -> Result<tokio::task::JoinHandle<()>, ToolExecutionSpawnError> {
         Ok(tokio::spawn(async {}))
+    }
+}
+
+struct FailingToolSpawner;
+
+impl ToolExecutionSpawner for FailingToolSpawner {
+    fn spawn_tool_execution(
+        &self,
+        _request: ToolExecutionRequest,
+        _router_tx: selvedge_command_model::RouterIngressSender,
+    ) -> Result<tokio::task::JoinHandle<()>, ToolExecutionSpawnError> {
+        Err(ToolExecutionSpawnError::TokioSpawnFailed)
     }
 }
 

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -846,6 +846,35 @@ async fn spawn_router_uses_unbounded_ingress() {
     );
 }
 
+#[tokio::test]
+async fn router_exits_when_ingress_sender_is_dropped() {
+    let db = open_memory_db();
+    let (events_tx, _events_rx) = tokio::sync::mpsc::channel(8);
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_provider_registry: Arc::new(EmptyProviderRegistry),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: model_profiles(),
+        }),
+    })
+    .expect("spawn router");
+
+    drop(handle.ingress_tx);
+
+    let status = tokio::time::timeout(Duration::from_millis(50), handle.join_handle)
+        .await
+        .expect("router exit")
+        .expect("join router");
+    assert_eq!(status, RouterExitStatus::RouterMailboxClosed);
+}
+
 fn open_memory_db() -> DbPool {
     open_db(OpenDbOptions {
         sqlite_path: ":memory:".to_owned(),

--- a/crates/task-runtime-factory/README.md
+++ b/crates/task-runtime-factory/README.md
@@ -2,6 +2,8 @@
 
 This crate runs one-shot factory effects for router-mediated task runtimes.
 
-Use it to create a runtime for an existing active task, scan active tasks and create missing runtimes, or create a child task then create its runtime. Each effect reports exactly one factory output envelope to the router ingress channel.
+Use it to create a runtime for an existing active task, scan active tasks and create missing runtimes, or create a child task then create its runtime. The router calls `run_factory_effect` directly and receives exactly one factory output envelope as the return value.
+
+`FactoryRuntimeInventory` is supplied by the router from its current in-memory registry and pending-effect state. The factory uses it only to skip already live or pending task runtimes.
 
 This crate is not for runtime registry ownership, task-local commands, provider calls, tool execution, direct event delivery, root task creation, or filesystem access.

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -270,6 +270,7 @@ fn spawn_task_runtime_created(
         }) {
         Ok(spawned) => Ok(TaskRuntimeCreated {
             task_id: spawned.task_id,
+            task_runtime_instance_id: spawned.task_runtime_instance_id,
             task_runtime_tx: spawned.task_runtime_tx,
             created_runtime_kind,
         }),

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -6,8 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use selvedge_command_model::{
     CreatedRuntimeKind, FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput,
     FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason, FactorySkippedTask,
-    FactoryTaskFailure, RouterIngressFactoryMessage, RouterIngressMessage, RouterIngressSender,
-    RuntimeInventoryQuery, RuntimeInventoryResponse, TaskRuntimeCreated,
+    FactoryTaskFailure, RouterIngressSender, TaskRuntimeCreated,
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, TaskRuntimeSpawnDeps};
 use selvedge_db::{
@@ -15,7 +14,6 @@ use selvedge_db::{
     load_active_task,
 };
 use selvedge_domain_model::HistoryNodeId;
-use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -49,42 +47,36 @@ pub struct FactoryEffectArgs {
     pub db: DbPool,
     pub router_tx: RouterIngressSender,
     pub core_spawn_deps: TaskRuntimeSpawnDeps,
+    pub runtime_inventory: FactoryRuntimeInventory,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SpawnFactoryEffectError {
-    MissingDbHandle,
-    MissingRouterSender,
-    MissingCoreSpawnDeps,
-    TokioSpawnFailed,
+pub struct FactoryRuntimeInventory {
+    pub live_task_runtimes: Vec<TaskId>,
+    pub pending_task_runtime_effects: Vec<TaskId>,
 }
 
-pub fn spawn_factory_effect(
-    args: FactoryEffectArgs,
-) -> Result<JoinHandle<()>, SpawnFactoryEffectError> {
-    Ok(tokio::spawn(async move {
-        run_factory_effect(args).await;
-    }))
-}
-
-async fn run_factory_effect(args: FactoryEffectArgs) {
-    match args.command {
+pub fn run_factory_effect(args: FactoryEffectArgs) -> FactoryOutputEnvelope {
+    let (effect_id, output) = match args.command {
         FactoryCommand::EnsureTaskRuntime(command) => {
             let output = ensure_task_runtime(
                 &args.db,
                 &args.router_tx,
                 &args.core_spawn_deps,
+                &args.runtime_inventory,
                 command.task_id,
                 CreatedRuntimeKind::ExistingTaskRuntime,
-            )
-            .await;
-            send_output(args.router_tx, command.effect_id, output).await;
+            );
+            (command.effect_id, output)
         }
         FactoryCommand::EnsureMissingTaskRuntimes(command) => {
-            let output =
-                ensure_missing_task_runtimes(&args.db, &args.router_tx, &args.core_spawn_deps)
-                    .await;
-            send_output(args.router_tx, command.effect_id, output).await;
+            let output = ensure_missing_task_runtimes(
+                &args.db,
+                &args.router_tx,
+                &args.core_spawn_deps,
+                &args.runtime_inventory,
+            );
+            (command.effect_id, output)
         }
         FactoryCommand::CreateChildTaskAndRuntime(command) => {
             let output = create_child_task_and_runtime(
@@ -94,9 +86,10 @@ async fn run_factory_effect(args: FactoryEffectArgs) {
                 command.parent_task_id,
                 command.child_cursor_node_id,
             );
-            send_output(args.router_tx, command.effect_id, output).await;
+            (command.effect_id, output)
         }
-    }
+    };
+    FactoryOutputEnvelope { effect_id, output }
 }
 
 fn create_child_task_and_runtime(
@@ -130,28 +123,21 @@ fn create_child_task_and_runtime(
     )
 }
 
-async fn ensure_missing_task_runtimes(
+fn ensure_missing_task_runtimes(
     db: &DbPool,
     router_tx: &RouterIngressSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
+    runtime_inventory: &FactoryRuntimeInventory,
 ) -> FactoryOutput {
-    let inventory = match query_runtime_inventory(router_tx).await {
-        Ok(inventory) => inventory,
-        Err(message) => {
-            return FactoryOutput::Failed(FactoryFailure {
-                task_id: None,
-                kind: FactoryFailureKind::RuntimeInventoryUnavailable,
-                message,
-            });
-        }
-    };
-    let live_task_runtimes = inventory
+    let live_task_runtimes = runtime_inventory
         .live_task_runtimes
-        .into_iter()
+        .iter()
+        .cloned()
         .collect::<HashSet<_>>();
-    let pending_task_runtime_effects = inventory
+    let pending_task_runtime_effects = runtime_inventory
         .pending_task_runtime_effects
-        .into_iter()
+        .iter()
+        .cloned()
         .collect::<HashSet<_>>();
     let active_tasks = match list_active_tasks(db) {
         Ok(active_tasks) => active_tasks,
@@ -209,48 +195,27 @@ async fn ensure_missing_task_runtimes(
     })
 }
 
-async fn query_runtime_inventory(
-    router_tx: &RouterIngressSender,
-) -> Result<RuntimeInventoryResponse, String> {
-    let (reply_to, reply_rx) = tokio::sync::oneshot::channel();
-    router_tx
-        .send(RouterIngressMessage::QueryRuntimeInventory(
-            RuntimeInventoryQuery { reply_to },
-        ))
-        .await
-        .map_err(|_| "runtime inventory query could not be sent".to_owned())?;
-    reply_rx
-        .await
-        .map_err(|_| "runtime inventory response was not delivered".to_owned())
-}
-
-async fn ensure_task_runtime(
+fn ensure_task_runtime(
     db: &DbPool,
     router_tx: &RouterIngressSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
+    runtime_inventory: &FactoryRuntimeInventory,
     task_id: TaskId,
     created_runtime_kind: CreatedRuntimeKind,
 ) -> FactoryOutput {
     match load_active_task(db, &task_id) {
         Ok(_) => {
-            let inventory = match query_runtime_inventory(router_tx).await {
-                Ok(inventory) => inventory,
-                Err(message) => {
-                    return FactoryOutput::Failed(FactoryFailure {
-                        task_id: Some(task_id),
-                        kind: FactoryFailureKind::RuntimeInventoryUnavailable,
-                        message,
-                    });
-                }
-            };
-            if inventory.live_task_runtimes.contains(&task_id) {
+            if runtime_inventory.live_task_runtimes.contains(&task_id) {
                 return FactoryOutput::Failed(FactoryFailure {
                     task_id: Some(task_id),
                     kind: FactoryFailureKind::RuntimeAlreadyLive,
                     message: "task runtime is already live".to_owned(),
                 });
             }
-            if inventory.pending_task_runtime_effects.contains(&task_id) {
+            if runtime_inventory
+                .pending_task_runtime_effects
+                .contains(&task_id)
+            {
                 return FactoryOutput::Failed(FactoryFailure {
                     task_id: Some(task_id),
                     kind: FactoryFailureKind::RuntimeCreationPending,
@@ -314,18 +279,6 @@ fn spawn_task_runtime_created(
             message: spawn_error_message(error),
         }),
     }
-}
-
-async fn send_output(
-    router_tx: RouterIngressSender,
-    effect_id: FactoryEffectId,
-    output: FactoryOutput,
-) {
-    let _ = router_tx
-        .send(RouterIngressMessage::Factory(
-            RouterIngressFactoryMessage::Output(FactoryOutputEnvelope { effect_id, output }),
-        ))
-        .await;
 }
 
 fn map_load_task_failure(task_id: Option<TaskId>, error: DbError) -> FactoryFailure {

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -270,8 +270,8 @@ fn spawn_task_runtime_created(
         }) {
         Ok(spawned) => Ok(TaskRuntimeCreated {
             task_id: spawned.task_id,
-            task_runtime_instance_id: spawned.task_runtime_instance_id,
             task_runtime_tx: spawned.task_runtime_tx,
+            task_runtime_control: spawned.task_runtime_control,
             created_runtime_kind,
         }),
         Err(error) => Err(FactoryFailure {

--- a/crates/task-runtime-factory/src/lib.rs
+++ b/crates/task-runtime-factory/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use selvedge_command_model::{
     CreatedRuntimeKind, FactoryEffectId, FactoryFailure, FactoryFailureKind, FactoryOutput,
     FactoryOutputEnvelope, FactoryScanOutput, FactorySkipReason, FactorySkippedTask,
-    FactoryTaskFailure, RouterIngressSender, TaskRuntimeCreated,
+    FactoryTaskFailure, RouterIngressWeakSender, TaskRuntimeCreated,
 };
 use selvedge_core::{SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, TaskRuntimeSpawnDeps};
 use selvedge_db::{
@@ -45,7 +45,7 @@ pub struct CreateChildTaskAndRuntimeCommand {
 pub struct FactoryEffectArgs {
     pub command: FactoryCommand,
     pub db: DbPool,
-    pub router_tx: RouterIngressSender,
+    pub router_tx: RouterIngressWeakSender,
     pub core_spawn_deps: TaskRuntimeSpawnDeps,
     pub runtime_inventory: FactoryRuntimeInventory,
 }
@@ -94,7 +94,7 @@ pub fn run_factory_effect(args: FactoryEffectArgs) -> FactoryOutputEnvelope {
 
 fn create_child_task_and_runtime(
     db: &DbPool,
-    router_tx: &RouterIngressSender,
+    router_tx: &RouterIngressWeakSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
     parent_task_id: TaskId,
     child_cursor_node_id: HistoryNodeId,
@@ -125,7 +125,7 @@ fn create_child_task_and_runtime(
 
 fn ensure_missing_task_runtimes(
     db: &DbPool,
-    router_tx: &RouterIngressSender,
+    router_tx: &RouterIngressWeakSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
     runtime_inventory: &FactoryRuntimeInventory,
 ) -> FactoryOutput {
@@ -197,7 +197,7 @@ fn ensure_missing_task_runtimes(
 
 fn ensure_task_runtime(
     db: &DbPool,
-    router_tx: &RouterIngressSender,
+    router_tx: &RouterIngressWeakSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
     runtime_inventory: &FactoryRuntimeInventory,
     task_id: TaskId,
@@ -236,7 +236,7 @@ fn ensure_task_runtime(
 
 fn spawn_task_runtime(
     db: &DbPool,
-    router_tx: &RouterIngressSender,
+    router_tx: &RouterIngressWeakSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
     task_id: TaskId,
     created_runtime_kind: CreatedRuntimeKind,
@@ -255,7 +255,7 @@ fn spawn_task_runtime(
 
 fn spawn_task_runtime_created(
     db: &DbPool,
-    router_tx: &RouterIngressSender,
+    router_tx: &RouterIngressWeakSender,
     core_spawn_deps: &TaskRuntimeSpawnDeps,
     task_id: TaskId,
     created_runtime_kind: CreatedRuntimeKind,

--- a/crates/task-runtime-factory/tests/factory_contract.rs
+++ b/crates/task-runtime-factory/tests/factory_contract.rs
@@ -32,7 +32,7 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
             task_id: TaskId("task-1".to_owned()),
         }),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
@@ -117,7 +117,7 @@ async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
             effect_id: FactoryEffectId("factory-scan".to_owned()),
         }),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
@@ -188,7 +188,7 @@ async fn create_child_task_and_runtime_persists_child_and_copies_parent_settings
             child_cursor_node_id,
         }),
         db: db.clone(),
-        router_tx,
+        router_tx: router_tx.downgrade(),
         core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
@@ -265,7 +265,7 @@ async fn create_child_task_keeps_durable_child_when_runtime_spawn_fails() {
             child_cursor_node_id,
         }),
         db: db.clone(),
-        router_tx,
+        router_tx: router_tx.downgrade(),
         core_spawn_deps: TaskRuntimeSpawnDeps::with_spawner(
             TaskRuntimeConfig {
                 mailbox_capacity: 8,
@@ -349,7 +349,7 @@ async fn run_ensure_task_runtime(db: DbPool, task_id: &str) -> FactoryOutput {
             task_id: TaskId(task_id.to_owned()),
         }),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
@@ -372,7 +372,7 @@ async fn run_ensure_task_runtime_with_inventory(
             task_id: TaskId(task_id.to_owned()),
         }),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
@@ -398,7 +398,7 @@ async fn run_create_child(
             child_cursor_node_id,
         }),
         db,
-        router_tx,
+        router_tx: router_tx.downgrade(),
         core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),

--- a/crates/task-runtime-factory/tests/factory_contract.rs
+++ b/crates/task-runtime-factory/tests/factory_contract.rs
@@ -25,7 +25,7 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
     let db = open_memory_db();
     create_root(&db, "task-1");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, mut router_rx) = tokio::sync::mpsc::unbounded_channel();
     let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
             effect_id: FactoryEffectId("factory-1".to_owned()),
@@ -111,7 +111,7 @@ async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
     create_root(&db, "pending");
     create_root(&db, "missing");
 
-    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, _router_rx) = tokio::sync::mpsc::unbounded_channel();
     let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimesCommand {
             effect_id: FactoryEffectId("factory-scan".to_owned()),
@@ -180,7 +180,7 @@ async fn create_child_task_and_runtime_persists_child_and_copies_parent_settings
     .expect("create parent task");
     let child_cursor_node_id = create_message_node(&db, None, MessageRole::User, "child cursor");
 
-    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, _router_rx) = tokio::sync::mpsc::unbounded_channel();
     let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
             effect_id: FactoryEffectId("factory-child".to_owned()),
@@ -257,7 +257,7 @@ async fn create_child_task_keeps_durable_child_when_runtime_spawn_fails() {
     create_root(&db, "parent");
     let child_cursor_node_id = create_message_node(&db, None, MessageRole::User, "child cursor");
 
-    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, _router_rx) = tokio::sync::mpsc::unbounded_channel();
     let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
             effect_id: FactoryEffectId("factory-child".to_owned()),
@@ -342,7 +342,7 @@ fn open_memory_db() -> DbPool {
 }
 
 async fn run_ensure_task_runtime(db: DbPool, task_id: &str) -> FactoryOutput {
-    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, _router_rx) = tokio::sync::mpsc::unbounded_channel();
     run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
             effect_id: FactoryEffectId("factory-1".to_owned()),
@@ -365,7 +365,7 @@ async fn run_ensure_task_runtime_with_inventory(
     live_task_runtimes: Vec<TaskId>,
     pending_task_runtime_effects: Vec<TaskId>,
 ) -> FactoryOutput {
-    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, _router_rx) = tokio::sync::mpsc::unbounded_channel();
     run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
             effect_id: FactoryEffectId("factory-1".to_owned()),
@@ -390,7 +390,7 @@ async fn run_create_child(
     parent_task_id: &str,
     child_cursor_node_id: selvedge_db::HistoryNodeId,
 ) -> FactoryOutput {
-    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let (router_tx, _router_rx) = tokio::sync::mpsc::unbounded_channel();
     run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
             effect_id: FactoryEffectId("factory-child".to_owned()),

--- a/crates/task-runtime-factory/tests/factory_contract.rs
+++ b/crates/task-runtime-factory/tests/factory_contract.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use selvedge_command_model::{
     CreatedRuntimeKind, FactoryEffectId, FactoryFailureKind, FactoryOutput, FactorySkipReason,
-    RouterIngressFactoryMessage, RouterIngressMessage, RuntimeInventoryResponse,
 };
 use selvedge_core::{
     SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
@@ -19,7 +17,7 @@ use selvedge_db::{
 use selvedge_domain_model::ModelProviderProfile;
 use selvedge_task_runtime_factory::{
     CreateChildTaskAndRuntimeCommand, EnsureMissingTaskRuntimesCommand, EnsureTaskRuntimeCommand,
-    FactoryCommand, FactoryEffectArgs, spawn_factory_effect,
+    FactoryCommand, FactoryEffectArgs, FactoryRuntimeInventory, run_factory_effect,
 };
 
 #[tokio::test]
@@ -28,7 +26,7 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
     create_root(&db, "task-1");
 
     let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
+    let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
             effect_id: FactoryEffectId("factory-1".to_owned()),
             task_id: TaskId("task-1".to_owned()),
@@ -39,17 +37,8 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
-    })
-    .expect("spawn factory effect");
-
-    answer_inventory(&mut router_rx, Vec::new(), Vec::new()).await;
-    handle.await.expect("factory task joins");
-
-    let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
-        panic!("unexpected router message");
-    };
+        runtime_inventory: empty_inventory(),
+    });
     assert_eq!(envelope.effect_id, FactoryEffectId("factory-1".to_owned()));
     let FactoryOutput::RuntimeCreated(created) = envelope.output else {
         panic!("unexpected factory output");
@@ -60,9 +49,7 @@ async fn ensure_task_runtime_creates_runtime_for_existing_active_task() {
         CreatedRuntimeKind::ExistingTaskRuntime
     );
 
-    tokio::time::timeout(Duration::from_millis(25), router_rx.recv())
-        .await
-        .expect_err("factory leaves runtime idle");
+    assert!(router_rx.try_recv().is_err());
 }
 
 #[tokio::test]
@@ -124,8 +111,8 @@ async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
     create_root(&db, "pending");
     create_root(&db, "missing");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
+    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimesCommand {
             effect_id: FactoryEffectId("factory-scan".to_owned()),
         }),
@@ -135,30 +122,11 @@ async fn ensure_missing_task_runtimes_skips_live_and_pending_inventory() {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
-    })
-    .expect("spawn factory effect");
-
-    let query = tokio::time::timeout(Duration::from_millis(50), router_rx.recv())
-        .await
-        .expect("runtime inventory query")
-        .expect("runtime inventory message");
-    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
-        panic!("unexpected router message");
-    };
-    query
-        .reply_to
-        .send(RuntimeInventoryResponse {
+        runtime_inventory: FactoryRuntimeInventory {
             live_task_runtimes: vec![TaskId("live".to_owned())],
             pending_task_runtime_effects: vec![TaskId("pending".to_owned())],
-        })
-        .expect("send runtime inventory");
-
-    handle.await.expect("factory task joins");
-    let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
-        panic!("unexpected router message");
-    };
+        },
+    });
     assert_eq!(
         envelope.effect_id,
         FactoryEffectId("factory-scan".to_owned())
@@ -212,8 +180,8 @@ async fn create_child_task_and_runtime_persists_child_and_copies_parent_settings
     .expect("create parent task");
     let child_cursor_node_id = create_message_node(&db, None, MessageRole::User, "child cursor");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
+    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
             effect_id: FactoryEffectId("factory-child".to_owned()),
             parent_task_id: TaskId("parent".to_owned()),
@@ -225,15 +193,8 @@ async fn create_child_task_and_runtime_persists_child_and_copies_parent_settings
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
-    })
-    .expect("spawn factory effect");
-    handle.await.expect("factory task joins");
-
-    let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
-        panic!("unexpected router message");
-    };
+        runtime_inventory: empty_inventory(),
+    });
     assert_eq!(
         envelope.effect_id,
         FactoryEffectId("factory-child".to_owned())
@@ -261,42 +222,6 @@ async fn create_child_task_and_runtime_persists_child_and_copies_parent_settings
     assert!(edges.iter().any(|edge| {
         edge.parent_task_id == TaskId("parent".to_owned()) && edge.child_task_id == created.task_id
     }));
-}
-
-#[tokio::test]
-async fn ensure_missing_task_runtimes_reports_unavailable_inventory() {
-    let db = open_memory_db();
-    create_root(&db, "task-1");
-
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
-        command: FactoryCommand::EnsureMissingTaskRuntimes(EnsureMissingTaskRuntimesCommand {
-            effect_id: FactoryEffectId("factory-scan".to_owned()),
-        }),
-        db,
-        router_tx,
-        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
-            mailbox_capacity: 8,
-            model_profiles: model_profiles(),
-        }),
-    })
-    .expect("spawn factory effect");
-
-    let query = router_rx.recv().await.expect("runtime inventory query");
-    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
-        panic!("unexpected router message");
-    };
-    drop(query);
-
-    handle.await.expect("factory task joins");
-    let output = recv_factory_output(&mut router_rx).await;
-    let FactoryOutput::Failed(failure) = output else {
-        panic!("unexpected factory output");
-    };
-    assert_eq!(
-        failure.kind,
-        FactoryFailureKind::RuntimeInventoryUnavailable
-    );
 }
 
 #[tokio::test]
@@ -332,8 +257,8 @@ async fn create_child_task_keeps_durable_child_when_runtime_spawn_fails() {
     create_root(&db, "parent");
     let child_cursor_node_id = create_message_node(&db, None, MessageRole::User, "child cursor");
 
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
+    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    let envelope = run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
             effect_id: FactoryEffectId("factory-child".to_owned()),
             parent_task_id: TaskId("parent".to_owned()),
@@ -348,11 +273,10 @@ async fn create_child_task_keeps_durable_child_when_runtime_spawn_fails() {
             },
             Arc::new(FailingSpawner),
         ),
-    })
-    .expect("spawn factory effect");
-    handle.await.expect("factory task joins");
+        runtime_inventory: empty_inventory(),
+    });
 
-    let output = recv_factory_output(&mut router_rx).await;
+    let output = envelope.output;
     let FactoryOutput::Failed(failure) = output else {
         panic!("unexpected factory output");
     };
@@ -418,8 +342,8 @@ fn open_memory_db() -> DbPool {
 }
 
 async fn run_ensure_task_runtime(db: DbPool, task_id: &str) -> FactoryOutput {
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
+    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
             effect_id: FactoryEffectId("factory-1".to_owned()),
             task_id: TaskId(task_id.to_owned()),
@@ -430,11 +354,9 @@ async fn run_ensure_task_runtime(db: DbPool, task_id: &str) -> FactoryOutput {
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
+        runtime_inventory: empty_inventory(),
     })
-    .expect("spawn factory effect");
-    handle.await.expect("factory task joins");
-
-    recv_factory_output(&mut router_rx).await
+    .output
 }
 
 async fn run_ensure_task_runtime_with_inventory(
@@ -443,8 +365,8 @@ async fn run_ensure_task_runtime_with_inventory(
     live_task_runtimes: Vec<TaskId>,
     pending_task_runtime_effects: Vec<TaskId>,
 ) -> FactoryOutput {
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
+    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::EnsureTaskRuntime(EnsureTaskRuntimeCommand {
             effect_id: FactoryEffectId("factory-1".to_owned()),
             task_id: TaskId(task_id.to_owned()),
@@ -455,16 +377,12 @@ async fn run_ensure_task_runtime_with_inventory(
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
+        runtime_inventory: FactoryRuntimeInventory {
+            live_task_runtimes,
+            pending_task_runtime_effects,
+        },
     })
-    .expect("spawn factory effect");
-    answer_inventory(
-        &mut router_rx,
-        live_task_runtimes,
-        pending_task_runtime_effects,
-    )
-    .await;
-    handle.await.expect("factory task joins");
-    recv_factory_output(&mut router_rx).await
+    .output
 }
 
 async fn run_create_child(
@@ -472,8 +390,8 @@ async fn run_create_child(
     parent_task_id: &str,
     child_cursor_node_id: selvedge_db::HistoryNodeId,
 ) -> FactoryOutput {
-    let (router_tx, mut router_rx) = tokio::sync::mpsc::channel(8);
-    let handle = spawn_factory_effect(FactoryEffectArgs {
+    let (router_tx, _router_rx) = tokio::sync::mpsc::channel(8);
+    run_factory_effect(FactoryEffectArgs {
         command: FactoryCommand::CreateChildTaskAndRuntime(CreateChildTaskAndRuntimeCommand {
             effect_id: FactoryEffectId("factory-child".to_owned()),
             parent_task_id: TaskId(parent_task_id.to_owned()),
@@ -485,39 +403,16 @@ async fn run_create_child(
             mailbox_capacity: 8,
             model_profiles: model_profiles(),
         }),
+        runtime_inventory: empty_inventory(),
     })
-    .expect("spawn factory effect");
-    handle.await.expect("factory task joins");
-    recv_factory_output(&mut router_rx).await
+    .output
 }
 
-async fn recv_factory_output(
-    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
-) -> FactoryOutput {
-    let message = router_rx.recv().await.expect("factory output");
-    let RouterIngressMessage::Factory(RouterIngressFactoryMessage::Output(envelope)) = message
-    else {
-        panic!("unexpected router message");
-    };
-    envelope.output
-}
-
-async fn answer_inventory(
-    router_rx: &mut tokio::sync::mpsc::Receiver<RouterIngressMessage>,
-    live_task_runtimes: Vec<TaskId>,
-    pending_task_runtime_effects: Vec<TaskId>,
-) {
-    let query = router_rx.recv().await.expect("runtime inventory query");
-    let RouterIngressMessage::QueryRuntimeInventory(query) = query else {
-        panic!("unexpected router message");
-    };
-    query
-        .reply_to
-        .send(RuntimeInventoryResponse {
-            live_task_runtimes,
-            pending_task_runtime_effects,
-        })
-        .expect("send runtime inventory");
+fn empty_inventory() -> FactoryRuntimeInventory {
+    FactoryRuntimeInventory {
+        live_task_runtimes: Vec::new(),
+        pending_task_runtime_effects: Vec::new(),
+    }
 }
 
 struct FailingSpawner;


### PR DESCRIPTION
## What changed

- Implemented the selvedge router command model path across factory, router, core runtime, API, and tool execution boundaries.
- Removed router-owned client data synchronization and documented the TODO outside router scope.
- Added synchronous task runtime stop through shared control state.
- Changed router ingress to unbounded and gave internal producers weak ingress handles so sender-drop shutdown still works.
- Added task-id validation before router starts core-driven model, tool, or event side effects.

## Why

The router owns task runtime registration and command routing. Runtime stop must be a synchronous barrier, and runtime output must enqueue without being blocked by router mailbox capacity while the router is waiting for stop completion.

## Validation

- cargo test --workspace --all-targets --all-features
- just hooks
- codex-review-final main
