### PR TITLE
refactor(api): dispatch ChatGPT calls directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,16 @@ This file is for coding agents working in this repository.
 - Unless the user explicitly asks otherwise, place temporary task documents (such as specs, plans, and research notes) under `.workpad/`.
 - `.workpad/` is git-ignored on purpose and should be used for task artifacts that should not be committed.
 
+## Code Marker Comments
+
+- Allowed tags: `TODO`, `FIXME`, `HACK`, `NOTE`, `XXX`.
+- Format: `<comment marker> <TAG>(<optional issue>): <specific action or reason>`.
+- `TODO` means known follow-up work while current code is acceptable.
+- `FIXME` means a known defect that needs repair.
+- `HACK` means a temporary workaround that should be replaced by normal design.
+- `NOTE` means important context that affects code understanding.
+- `XXX` means high-risk code that needs reviewer attention.
+
 ## Project Index Workflow
 
 - Update the index with `just agents-index`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ This file is for coding agents working in this repository.
 
 - Allowed tags: `TODO`, `FIXME`, `HACK`, `NOTE`, `XXX`.
 - Format: `<comment marker> <TAG>(<optional issue>): <specific action or reason>`.
+- Marker comments must explain the intent, decision, risk, or follow-up behind the code. Do not use marker comments to restate facts already visible from the code.
 - `TODO` means known follow-up work while current code is acceptable.
 - `FIXME` means a known defect that needs repair.
 - `HACK` means a temporary workaround that should be replaced by normal design.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,17 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,11 +1396,22 @@ dependencies = [
 name = "selvedge-api"
 version = "0.0.0"
 dependencies = [
- "async-trait",
+ "async-stream",
+ "axum",
+ "base64",
+ "bytes",
+ "chatgpt-api",
+ "futures",
+ "http",
+ "selvedge-client",
  "selvedge-command-model",
+ "selvedge-config",
  "selvedge-domain-model",
+ "selvedge-logging",
  "serde_json",
+ "tempfile",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -4,14 +4,25 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1.83"
+chatgpt-api = { path = "../chatgpt-api" }
+futures = "0.3.31"
 selvedge-command-model = { path = "../command-model" }
+selvedge-client = { path = "../client" }
 selvedge-domain-model = { path = "../domain-model" }
 serde_json = "1.0.149"
 tokio = { version = "1.42.0", features = ["rt", "sync", "time"] }
+uuid = { version = "1.11.0", features = ["v4"] }
 
 [dev-dependencies]
-tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+async-stream = "0.3.6"
+axum = "0.8.6"
+base64 = "0.22.1"
+bytes = "1.10.1"
+http = "1.3.1"
+selvedge-config = { path = "../config" }
+selvedge-logging = { path = "../logging" }
+tempfile = "3.23.0"
+tokio = { version = "1.42.0", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -4,4 +4,6 @@ This crate executes one Selvedge model call and returns the completed result to 
 
 Use it to dispatch a single provider call, normalize the provider response into a model reply, classify execution failures, and spawn short-lived Tokio tasks for model calls.
 
+The public entry point is `execute_model_call(request, router_tx, config)`. Provider selection comes from `request.provider.provider_name`; `chatgpt` is dispatched directly to `chatgpt-api`.
+
 This crate is not for database access, filesystem access, task creation, task runtime mutation, router registry mutation, retries, or persistence.

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -6,4 +6,6 @@ Use it to dispatch a single provider call, normalize the provider response into 
 
 The public entry point is `execute_model_call(request, router_tx, config)`. Provider selection comes from `request.provider.provider_name`; `chatgpt` is dispatched directly to `chatgpt-api`.
 
+For ChatGPT direct dispatch, `request.provider.model_name` becomes the ChatGPT model. `request.provider.max_output_tokens` is accepted by the Selvedge request contract and ignored by this path because `chatgpt-api` exposes no request field for that control; ChatGPT `response.incomplete` with reason `max_output_tokens` returns `ModelFinishReason::Length` with accumulated output. Direct dispatch pins ChatGPT capabilities to reasoning summaries enabled, text verbosity enabled, and default reasoning effort `medium` until Selvedge has a capability source.
+
 This crate is not for database access, filesystem access, task creation, task runtime mutation, router registry mutation, retries, or persistence.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,15 +1,24 @@
 #![doc = include_str!("../README.md")]
 
-use std::{sync::Arc, time::Duration};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::time::Duration;
 
-use async_trait::async_trait;
+use chatgpt_api::{
+    ChatgptApiEndpointError, ChatgptApiError, ChatgptApiLowerLayerError, ChatgptModelCapabilities,
+    ChatgptReasoningOptions, ChatgptRequestContext, ChatgptResponseEvent, ChatgptResponsesRequest,
+    ChatgptTextOptions, ContentItem, FunctionCallItem, FunctionCallOutputItem, MessageItem,
+    ResponseItem, ToolDescriptor, ToolOutput, stream,
+};
+use futures::StreamExt;
 use selvedge_command_model::{
     ApiOutputEnvelope, ModelCallDispatchRequest, ModelCallError, ModelCallErrorKind,
     RouterIngressApiMessage, RouterIngressWeakSender, validate_dispatch_request,
 };
 use selvedge_domain_model::{
-    ConversationPath, ModelProviderProfile, ModelReply, ResponsePreference, ToolManifest,
-    validate_model_reply,
+    ConversationMessage, MessageContent, MessageRole, ModelFinishReason, ModelReply,
+    ResponsePreference, StructuredPayload, TokenUsage, ToolCallProposal, ToolManifest,
+    ToolParameterType, validate_model_reply,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -24,108 +33,49 @@ pub enum ApiCallTerminalStatus {
     RouterClosed,
 }
 
-pub trait ModelProviderRegistry: Send + Sync {
-    fn resolve(&self, provider_name: &str) -> Option<Arc<dyn ModelProviderAdapter>>;
-}
-
-#[async_trait]
-pub trait ModelProviderAdapter: Send + Sync {
-    async fn call_model(
-        &self,
-        request: ProviderModelRequest,
-        timeout: Duration,
-    ) -> Result<ProviderModelResponse, ProviderCallError>;
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct ProviderModelRequest {
-    pub provider: ModelProviderProfile,
-    pub conversation: ConversationPath,
-    pub tool_manifest: Option<ToolManifest>,
-    pub response_preference: ResponsePreference,
-    pub max_response_bytes: Option<usize>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct ProviderModelResponse {
-    pub reply: Option<ModelReply>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ProviderCallError {
-    pub kind: ProviderCallErrorKind,
-    pub message: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ProviderCallErrorKind {
-    Request,
-    Network,
-    Timeout,
-    Cancelled,
-    Response,
-}
-
 pub async fn execute_model_call(
     request: ModelCallDispatchRequest,
     router_tx: RouterIngressWeakSender,
-    provider_registry: Arc<dyn ModelProviderRegistry>,
     config: ApiExecutorConfig,
 ) -> ApiCallTerminalStatus {
-    let envelope = run_model_call(request, provider_registry, config).await;
+    let envelope = run_model_call(request, config).await;
     send_output(router_tx, envelope).await
 }
 
 pub fn spawn_model_call_tokio_task(
     request: ModelCallDispatchRequest,
     router_tx: RouterIngressWeakSender,
-    provider_registry: Arc<dyn ModelProviderRegistry>,
     config: ApiExecutorConfig,
 ) -> tokio::task::JoinHandle<ApiCallTerminalStatus> {
-    tokio::spawn(execute_model_call(
-        request,
-        router_tx,
-        provider_registry,
-        config,
-    ))
+    tokio::spawn(execute_model_call(request, router_tx, config))
 }
 
 async fn run_model_call(
     request: ModelCallDispatchRequest,
-    provider_registry: Arc<dyn ModelProviderRegistry>,
     config: ApiExecutorConfig,
 ) -> ApiOutputEnvelope {
     if let Err(error) = validate_dispatch_request(&request) {
         return failure_envelope(request, error);
     }
 
-    let Some(adapter) = provider_registry.resolve(&request.provider.provider_name) else {
-        return failure_envelope(
-            request,
-            model_call_error(
-                ModelCallErrorKind::ProviderRequest,
-                "provider adapter is not registered",
-            ),
-        );
+    let reply_result = match request.provider.provider_name.as_str() {
+        "chatgpt" => {
+            tokio::time::timeout(config.request_timeout, call_chatgpt(&request, &config)).await
+        }
+        _ => {
+            return failure_envelope(
+                request,
+                model_call_error(
+                    ModelCallErrorKind::ProviderRequest,
+                    "provider is not supported",
+                ),
+            );
+        }
     };
 
-    let provider_request = ProviderModelRequest {
-        provider: request.provider.clone(),
-        conversation: request.conversation.clone(),
-        tool_manifest: request.tool_manifest.clone(),
-        response_preference: request.response_preference.clone(),
-        max_response_bytes: config.max_response_bytes,
-    };
-
-    let response_result = tokio::time::timeout(
-        config.request_timeout,
-        adapter.call_model(provider_request, config.request_timeout),
-    )
-    .await;
-
-    let response = match response_result {
-        Ok(Ok(response)) => response,
-        Ok(Err(error)) => return failure_envelope(request, map_provider_error(error)),
+    let reply = match reply_result {
+        Ok(Ok(reply)) => reply,
+        Ok(Err(error)) => return failure_envelope(request, error),
         Err(_) => {
             return failure_envelope(
                 request,
@@ -137,29 +87,8 @@ async fn run_model_call(
         }
     };
 
-    let Some(reply) = response.reply else {
-        return failure_envelope(
-            request,
-            model_call_error(
-                ModelCallErrorKind::ProviderResponse,
-                "provider response did not contain a model reply",
-            ),
-        );
-    };
-
-    let exceeds_response_limit = match exceeds_response_limit(&reply, config.max_response_bytes) {
-        Ok(exceeds_response_limit) => exceeds_response_limit,
-        Err(error) => return failure_envelope(request, error),
-    };
-
-    if exceeds_response_limit {
-        return failure_envelope(
-            request,
-            model_call_error(
-                ModelCallErrorKind::ProviderResponse,
-                "provider response exceeded configured byte limit",
-            ),
-        );
+    if let Err(error) = enforce_response_limit(&reply, config.max_response_bytes) {
+        return failure_envelope(request, error);
     }
 
     if let Err(error) = validate_model_reply(&reply) {
@@ -176,6 +105,514 @@ async fn run_model_call(
         correlation: request.correlation,
         reply,
     }
+}
+
+async fn call_chatgpt(
+    request: &ModelCallDispatchRequest,
+    config: &ApiExecutorConfig,
+) -> Result<ModelReply, ModelCallError> {
+    let chatgpt_request = chatgpt_request_from_dispatch(request)?;
+    let mut response_stream = stream(chatgpt_request).await.map_err(map_chatgpt_error)?;
+    let mut byte_counter = config.max_response_bytes.map(BoundedByteCounter::new);
+    let mut text_parts = BTreeMap::new();
+    let mut fallback_text = String::new();
+    let mut tool_calls = Vec::new();
+    let mut usage = None;
+
+    while let Some(item) = response_stream.next().await {
+        match item.map_err(map_chatgpt_error)? {
+            ChatgptResponseEvent::OutputTextDelta {
+                output_index,
+                content_index,
+                delta,
+                ..
+            } => {
+                count_stream_bytes(&mut byte_counter, delta.as_bytes())?;
+                text_parts
+                    .entry((output_index, content_index))
+                    .or_insert_with(String::new)
+                    .push_str(&delta);
+            }
+            ChatgptResponseEvent::OutputTextDone {
+                output_index,
+                content_index,
+                text,
+                ..
+            } => {
+                let existing = text_parts
+                    .get(&(output_index, content_index))
+                    .map(String::as_str)
+                    .unwrap_or_default();
+                if text.len() > existing.len() {
+                    count_stream_bytes(&mut byte_counter, &text.as_bytes()[existing.len()..])?;
+                }
+                text_parts.insert((output_index, content_index), text);
+            }
+            ChatgptResponseEvent::OutputItemDone {
+                item: ResponseItem::Message(message),
+                ..
+            } => {
+                if text_parts.is_empty() {
+                    append_message_content(&mut fallback_text, &message, &mut byte_counter)?;
+                }
+            }
+            ChatgptResponseEvent::OutputItemDone {
+                item: ResponseItem::FunctionCall(function_call),
+                ..
+            } => {
+                count_stream_bytes(&mut byte_counter, function_call.arguments.as_bytes())?;
+                tool_calls.push(tool_call_from_chatgpt(function_call)?);
+            }
+            ChatgptResponseEvent::Completed(snapshot) => {
+                usage = snapshot.usage.and_then(|usage| {
+                    usage.input_tokens.zip(usage.output_tokens).map(
+                        |(input_tokens, output_tokens)| TokenUsage {
+                            input_tokens,
+                            output_tokens,
+                        },
+                    )
+                });
+            }
+            ChatgptResponseEvent::Created(_)
+            | ChatgptResponseEvent::OutputItemAdded { .. }
+            | ChatgptResponseEvent::ReasoningSummaryTextDelta { .. }
+            | ChatgptResponseEvent::ReasoningSummaryTextDone { .. }
+            | ChatgptResponseEvent::ReasoningTextDelta { .. }
+            | ChatgptResponseEvent::ReasoningTextDone { .. }
+            | ChatgptResponseEvent::Other(_) => {}
+            _ => {}
+        }
+    }
+
+    if request.response_preference == ResponsePreference::PlainTextOnly && !tool_calls.is_empty() {
+        return Err(model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            "chatgpt returned tool calls for a text-only request",
+        ));
+    }
+
+    let content = if text_parts.is_empty() {
+        fallback_text
+    } else {
+        text_parts.into_values().collect::<String>()
+    };
+
+    let finish_reason = if tool_calls.is_empty() {
+        ModelFinishReason::Stop
+    } else {
+        ModelFinishReason::ToolCalls
+    };
+
+    Ok(ModelReply {
+        content: (!content.trim().is_empty()).then_some(content),
+        tool_calls,
+        usage,
+        finish_reason,
+    })
+}
+
+fn chatgpt_request_from_dispatch(
+    request: &ModelCallDispatchRequest,
+) -> Result<ChatgptResponsesRequest, ModelCallError> {
+    Ok(ChatgptResponsesRequest {
+        model: request.provider.model_name.clone(),
+        // HACK: Use fixed optimistic capabilities until Selvedge owns a ChatGPT model capability table.
+        model_capabilities: ChatgptModelCapabilities {
+            supports_reasoning_summaries: true,
+            supports_text_verbosity: true,
+            default_reasoning_effort: Some("medium".to_owned()),
+        },
+        context: ChatgptRequestContext {
+            // HACK: Generate a fresh ChatGPT conversation id until task-to-ChatGPT conversation persistence exists.
+            conversation_id: uuid::Uuid::new_v4().to_string(),
+            // HACK: Keep the initial ChatGPT window generation until replay windows are modeled in Selvedge.
+            window_generation: 0,
+            // HACK: Use a fixed installation id until Selvedge has installation identity config.
+            installation_id: "550e8400-e29b-41d4-a716-446655440000".to_owned(),
+            // HACK: Leave turn state empty until Selvedge persists ChatGPT turn state between calls.
+            turn_state: None,
+            turn_metadata: None,
+            beta_features: Vec::new(),
+            subagent: None,
+            parent_thread_id: None,
+        },
+        instructions: None,
+        input: request
+            .conversation
+            .messages
+            .iter()
+            .map(chatgpt_item_from_message)
+            .collect::<Result<Vec<_>, _>>()?,
+        tools: chatgpt_tools(request.tool_manifest.as_ref(), &request.response_preference),
+        parallel_tool_calls: true,
+        reasoning: ChatgptReasoningOptions::default(),
+        text: ChatgptTextOptions::default(),
+        service_tier: None,
+    })
+}
+
+fn chatgpt_item_from_message(
+    message: &ConversationMessage,
+) -> Result<ResponseItem, ModelCallError> {
+    if let MessageContent::Structured(payload) = &message.content
+        && let Some(item) = chatgpt_tool_history_item(&message.role, payload)?
+    {
+        return Ok(item);
+    }
+
+    Ok(ResponseItem::Message(MessageItem {
+        id: message
+            .source_node_id
+            .as_ref()
+            .map(|node_id| node_id.0.clone()),
+        status: Some("completed".to_owned()),
+        role: chatgpt_role(&message.role).to_owned(),
+        content: vec![chatgpt_content_item_from_message(message)?],
+    }))
+}
+
+fn chatgpt_role(role: &MessageRole) -> &'static str {
+    match role {
+        MessageRole::System => "system",
+        MessageRole::Developer => "developer",
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::Tool => "tool",
+    }
+}
+
+fn chatgpt_content_item_from_message(
+    message: &ConversationMessage,
+) -> Result<ContentItem, ModelCallError> {
+    let text = message_content_text(&message.content)?;
+    if message.role == MessageRole::Assistant {
+        return Ok(ContentItem::OutputText {
+            text,
+            raw: serde_json::Map::new(),
+        });
+    }
+    Ok(ContentItem::InputText { text })
+}
+
+fn message_content_text(content: &MessageContent) -> Result<String, ModelCallError> {
+    match content {
+        MessageContent::Text(text) | MessageContent::ToolResultSummary(text) => Ok(text.clone()),
+        MessageContent::Structured(payload) => serde_json::to_string(payload).map_err(|error| {
+            model_call_error(
+                ModelCallErrorKind::ProviderResponse,
+                format!("structured message content could not be encoded: {error}"),
+            )
+        }),
+    }
+}
+
+fn chatgpt_tool_history_item(
+    role: &MessageRole,
+    payload: &StructuredPayload,
+) -> Result<Option<ResponseItem>, ModelCallError> {
+    let StructuredPayload::Object(object) = payload else {
+        return Ok(None);
+    };
+
+    match role {
+        MessageRole::Assistant => {
+            let Some(function_call_id) = payload_string_field(object, "function_call_id") else {
+                return Ok(None);
+            };
+            let Some(tool_name) = payload_string_field(object, "tool_name") else {
+                return Ok(None);
+            };
+            let arguments = tool_history_arguments_json(
+                object
+                    .get("arguments")
+                    .ok_or_else(|| missing_tool_history_field("arguments"))?,
+            )?;
+            Ok(Some(ResponseItem::FunctionCall(FunctionCallItem {
+                id: None,
+                status: Some("completed".to_owned()),
+                name: tool_name.to_owned(),
+                namespace: None,
+                arguments,
+                call_id: function_call_id.to_owned(),
+            })))
+        }
+        MessageRole::Tool => {
+            let Some(function_call_id) = payload_string_field(object, "function_call_id") else {
+                return Ok(None);
+            };
+            let output_text = payload_string_field(object, "output_text")
+                .ok_or_else(|| missing_tool_history_field("output_text"))?;
+            Ok(Some(ResponseItem::FunctionCallOutput(
+                FunctionCallOutputItem {
+                    id: None,
+                    status: Some("completed".to_owned()),
+                    call_id: function_call_id.to_owned(),
+                    output: ToolOutput::Text(output_text.to_owned()),
+                },
+            )))
+        }
+        MessageRole::System | MessageRole::Developer | MessageRole::User => Ok(None),
+    }
+}
+
+fn payload_string_field<'a>(
+    object: &'a BTreeMap<String, StructuredPayload>,
+    field: &str,
+) -> Option<&'a str> {
+    match object.get(field) {
+        Some(StructuredPayload::String(value)) => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+fn missing_tool_history_field(field: &str) -> ModelCallError {
+    model_call_error(
+        ModelCallErrorKind::ProviderRequest,
+        format!("tool history is missing {field}"),
+    )
+}
+
+fn tool_history_arguments_json(payload: &StructuredPayload) -> Result<String, ModelCallError> {
+    let StructuredPayload::Array(arguments) = payload else {
+        return Err(model_call_error(
+            ModelCallErrorKind::ProviderRequest,
+            "tool history arguments must be an array",
+        ));
+    };
+    let mut object = serde_json::Map::new();
+    for argument in arguments {
+        let StructuredPayload::Object(argument) = argument else {
+            return Err(model_call_error(
+                ModelCallErrorKind::ProviderRequest,
+                "tool history argument must be an object",
+            ));
+        };
+        let name = payload_string_field(argument, "name")
+            .ok_or_else(|| missing_tool_history_field("argument name"))?;
+        let value = argument
+            .get("value")
+            .ok_or_else(|| missing_tool_history_field("argument value"))?;
+        object.insert(name.to_owned(), json_value_from_structured_payload(value));
+    }
+    serde_json::to_string(&object).map_err(|error| {
+        model_call_error(
+            ModelCallErrorKind::ProviderRequest,
+            format!("tool history arguments could not be encoded: {error}"),
+        )
+    })
+}
+
+fn chatgpt_tools(
+    tool_manifest: Option<&ToolManifest>,
+    response_preference: &ResponsePreference,
+) -> Vec<ToolDescriptor> {
+    if *response_preference == ResponsePreference::PlainTextOnly {
+        return Vec::new();
+    }
+    let Some(tool_manifest) = tool_manifest else {
+        return Vec::new();
+    };
+
+    tool_manifest
+        .tools
+        .iter()
+        .map(|tool| {
+            let mut properties = serde_json::Map::new();
+            let mut required = Vec::new();
+            for parameter in &tool.parameters {
+                properties.insert(
+                    parameter.name.clone(),
+                    serde_json::json!({
+                        "type": chatgpt_parameter_type(&parameter.parameter_type),
+                        "description": parameter.description,
+                    }),
+                );
+                if parameter.required {
+                    required.push(serde_json::Value::String(parameter.name.clone()));
+                }
+            }
+
+            ToolDescriptor(serde_json::Map::from_iter([
+                ("type".to_owned(), serde_json::json!("function")),
+                ("name".to_owned(), serde_json::json!(tool.name)),
+                (
+                    "description".to_owned(),
+                    serde_json::json!(tool.description),
+                ),
+                (
+                    "parameters".to_owned(),
+                    serde_json::Value::Object(serde_json::Map::from_iter([
+                        ("type".to_owned(), serde_json::json!("object")),
+                        (
+                            "properties".to_owned(),
+                            serde_json::Value::Object(properties),
+                        ),
+                        ("required".to_owned(), serde_json::Value::Array(required)),
+                    ])),
+                ),
+            ]))
+        })
+        .collect()
+}
+
+fn chatgpt_parameter_type(parameter_type: &ToolParameterType) -> &'static str {
+    match parameter_type {
+        ToolParameterType::String => "string",
+        ToolParameterType::Integer => "integer",
+        ToolParameterType::Number => "number",
+        ToolParameterType::Boolean => "boolean",
+    }
+}
+
+fn append_message_content(
+    content: &mut String,
+    message: &MessageItem,
+    counter: &mut Option<BoundedByteCounter>,
+) -> Result<(), ModelCallError> {
+    for item in &message.content {
+        match item {
+            ContentItem::OutputText { text, .. } | ContentItem::InputText { text } => {
+                count_stream_bytes(counter, text.as_bytes())?;
+                content.push_str(text);
+            }
+            ContentItem::InputImage { .. } | ContentItem::Other { .. } => {}
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn tool_call_from_chatgpt(
+    function_call: FunctionCallItem,
+) -> Result<ToolCallProposal, ModelCallError> {
+    Ok(ToolCallProposal {
+        call_id: function_call.call_id,
+        tool_name: function_call.name,
+        arguments: structured_payload_from_json_string(&function_call.arguments)?,
+    })
+}
+
+fn structured_payload_from_json_string(raw: &str) -> Result<StructuredPayload, ModelCallError> {
+    let value = serde_json::from_str::<serde_json::Value>(raw).map_err(|error| {
+        model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            format!("chatgpt function-call arguments are invalid JSON: {error}"),
+        )
+    })?;
+    if !value.is_object() {
+        return Err(model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            "chatgpt function-call arguments must be a JSON object",
+        ));
+    }
+    Ok(structured_payload_from_json_value(value))
+}
+
+fn structured_payload_from_json_value(value: serde_json::Value) -> StructuredPayload {
+    match value {
+        serde_json::Value::Object(object) => StructuredPayload::Object(
+            object
+                .into_iter()
+                .map(|(key, value)| (key, structured_payload_from_json_value(value)))
+                .collect(),
+        ),
+        serde_json::Value::Array(values) => StructuredPayload::Array(
+            values
+                .into_iter()
+                .map(structured_payload_from_json_value)
+                .collect(),
+        ),
+        serde_json::Value::String(value) => StructuredPayload::String(value),
+        serde_json::Value::Number(value) => value
+            .as_f64()
+            .map(StructuredPayload::Number)
+            .unwrap_or(StructuredPayload::Null),
+        serde_json::Value::Bool(value) => StructuredPayload::Boolean(value),
+        serde_json::Value::Null => StructuredPayload::Null,
+    }
+}
+
+fn json_value_from_structured_payload(payload: &StructuredPayload) -> serde_json::Value {
+    match payload {
+        StructuredPayload::Object(object) => serde_json::Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| (key.clone(), json_value_from_structured_payload(value)))
+                .collect(),
+        ),
+        StructuredPayload::Array(values) => serde_json::Value::Array(
+            values
+                .iter()
+                .map(json_value_from_structured_payload)
+                .collect(),
+        ),
+        StructuredPayload::String(value) => serde_json::Value::String(value.clone()),
+        StructuredPayload::Number(value) => serde_json::json!(value),
+        StructuredPayload::Boolean(value) => serde_json::Value::Bool(*value),
+        StructuredPayload::Null => serde_json::Value::Null,
+    }
+}
+
+fn map_chatgpt_error(error: ChatgptApiError) -> ModelCallError {
+    match error {
+        ChatgptApiError::LowerLayer(ChatgptApiLowerLayerError::InvalidInput(error)) => {
+            model_call_error(
+                ModelCallErrorKind::ProviderRequest,
+                format!(
+                    "chatgpt request is invalid: {} {}",
+                    error.field, error.reason
+                ),
+            )
+        }
+        ChatgptApiError::LowerLayer(ChatgptApiLowerLayerError::Config(error)) => model_call_error(
+            ModelCallErrorKind::ProviderRequest,
+            format!("chatgpt config failed: {error}"),
+        ),
+        ChatgptApiError::LowerLayer(ChatgptApiLowerLayerError::Auth(error)) => model_call_error(
+            ModelCallErrorKind::ProviderRequest,
+            format!("chatgpt auth failed: {error:?}"),
+        ),
+        ChatgptApiError::LowerLayer(ChatgptApiLowerLayerError::StreamCompletionTimeout {
+            ..
+        })
+        | ChatgptApiError::LowerLayer(ChatgptApiLowerLayerError::Client(
+            selvedge_client::HttpError::Timeout,
+        )) => model_call_error(
+            ModelCallErrorKind::ProviderTimeout,
+            "chatgpt request timed out",
+        ),
+        ChatgptApiError::LowerLayer(ChatgptApiLowerLayerError::Client(error)) => model_call_error(
+            ModelCallErrorKind::ProviderNetwork,
+            format!("chatgpt transport failed: {error}"),
+        ),
+        ChatgptApiError::Endpoint(ChatgptApiEndpointError::Incomplete(error)) => model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            format!("chatgpt response was incomplete: {:?}", error.reason),
+        ),
+        ChatgptApiError::Endpoint(error) => model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            format!("chatgpt endpoint failed: {error}"),
+        ),
+        _ => model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            "chatgpt provider failed with an unknown error",
+        ),
+    }
+}
+
+fn count_stream_bytes(
+    counter: &mut Option<BoundedByteCounter>,
+    bytes: &[u8],
+) -> Result<(), ModelCallError> {
+    let Some(counter) = counter else {
+        return Ok(());
+    };
+    counter.write_all(bytes).map_err(|_| {
+        model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            "provider response exceeded configured byte limit",
+        )
+    })
 }
 
 async fn send_output(
@@ -198,18 +635,6 @@ fn failure_envelope(request: ModelCallDispatchRequest, error: ModelCallError) ->
     }
 }
 
-fn map_provider_error(error: ProviderCallError) -> ModelCallError {
-    let kind = match error.kind {
-        ProviderCallErrorKind::Request => ModelCallErrorKind::ProviderRequest,
-        ProviderCallErrorKind::Network => ModelCallErrorKind::ProviderNetwork,
-        ProviderCallErrorKind::Timeout => ModelCallErrorKind::ProviderTimeout,
-        ProviderCallErrorKind::Cancelled => ModelCallErrorKind::Cancelled,
-        ProviderCallErrorKind::Response => ModelCallErrorKind::ProviderResponse,
-    };
-
-    model_call_error(kind, error.message)
-}
-
 fn model_call_error(kind: ModelCallErrorKind, message: impl Into<String>) -> ModelCallError {
     ModelCallError {
         kind,
@@ -217,15 +642,22 @@ fn model_call_error(kind: ModelCallErrorKind, message: impl Into<String>) -> Mod
     }
 }
 
-fn exceeds_response_limit(
+fn enforce_response_limit(
     reply: &ModelReply,
     max_response_bytes: Option<usize>,
-) -> Result<bool, ModelCallError> {
+) -> Result<(), ModelCallError> {
     let Some(max_response_bytes) = max_response_bytes else {
-        return Ok(false);
+        return Ok(());
     };
 
-    encoded_model_reply_exceeds_limit(reply, max_response_bytes)
+    if encoded_model_reply_exceeds_limit(reply, max_response_bytes)? {
+        return Err(model_call_error(
+            ModelCallErrorKind::ProviderResponse,
+            "provider response exceeded configured byte limit",
+        ));
+    }
+
+    Ok(())
 }
 
 fn encoded_model_reply_exceeds_limit(

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -5,10 +5,11 @@ use std::io::Write;
 use std::time::Duration;
 
 use chatgpt_api::{
-    ChatgptApiEndpointError, ChatgptApiError, ChatgptApiLowerLayerError, ChatgptModelCapabilities,
-    ChatgptReasoningOptions, ChatgptRequestContext, ChatgptResponseEvent, ChatgptResponsesRequest,
-    ChatgptTextOptions, ContentItem, FunctionCallItem, FunctionCallOutputItem, MessageItem,
-    ResponseItem, ToolDescriptor, ToolOutput, stream,
+    ChatgptApiEndpointError, ChatgptApiError, ChatgptApiLowerLayerError,
+    ChatgptIncompleteEndpointError, ChatgptModelCapabilities, ChatgptReasoningOptions,
+    ChatgptRequestContext, ChatgptResponseEvent, ChatgptResponsesRequest, ChatgptTextOptions,
+    ContentItem, FunctionCallItem, FunctionCallOutputItem, MessageItem, ResponseItem,
+    ToolDescriptor, ToolOutput, stream,
 };
 use futures::StreamExt;
 use selvedge_command_model::{
@@ -118,9 +119,21 @@ async fn call_chatgpt(
     let mut fallback_text = String::new();
     let mut tool_calls = Vec::new();
     let mut usage = None;
+    let mut finish_reason = ModelFinishReason::Stop;
 
     while let Some(item) = response_stream.next().await {
-        match item.map_err(map_chatgpt_error)? {
+        let event = match item {
+            Ok(event) => event,
+            Err(ChatgptApiError::Endpoint(ChatgptApiEndpointError::Incomplete(error)))
+                if is_chatgpt_output_length_incomplete(&error) =>
+            {
+                finish_reason = ModelFinishReason::Length;
+                break;
+            }
+            Err(error) => return Err(map_chatgpt_error(error)),
+        };
+
+        match event {
             ChatgptResponseEvent::OutputTextDelta {
                 output_index,
                 content_index,
@@ -197,11 +210,9 @@ async fn call_chatgpt(
         text_parts.into_values().collect::<String>()
     };
 
-    let finish_reason = if tool_calls.is_empty() {
-        ModelFinishReason::Stop
-    } else {
-        ModelFinishReason::ToolCalls
-    };
+    if !tool_calls.is_empty() && finish_reason == ModelFinishReason::Stop {
+        finish_reason = ModelFinishReason::ToolCalls;
+    }
 
     Ok(ModelReply {
         content: (!content.trim().is_empty()).then_some(content),
@@ -214,7 +225,7 @@ async fn call_chatgpt(
 fn chatgpt_request_from_dispatch(
     request: &ModelCallDispatchRequest,
 ) -> Result<ChatgptResponsesRequest, ModelCallError> {
-    // NOTE: chatgpt-api currently has no request field for ModelProviderProfile::max_output_tokens.
+    // NOTE: ChatGPT dispatch ignores max_output_tokens because chatgpt-api has no request field for this control.
     Ok(ChatgptResponsesRequest {
         model: request.provider.model_name.clone(),
         // HACK: Use fixed optimistic capabilities until Selvedge owns a ChatGPT model capability table.
@@ -552,6 +563,10 @@ fn json_value_from_structured_payload(payload: &StructuredPayload) -> serde_json
         StructuredPayload::Boolean(value) => serde_json::Value::Bool(*value),
         StructuredPayload::Null => serde_json::Value::Null,
     }
+}
+
+fn is_chatgpt_output_length_incomplete(error: &ChatgptIncompleteEndpointError) -> bool {
+    error.reason.as_deref() == Some("max_output_tokens")
 }
 
 fn map_chatgpt_error(error: ChatgptApiError) -> ModelCallError {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -214,6 +214,7 @@ async fn call_chatgpt(
 fn chatgpt_request_from_dispatch(
     request: &ModelCallDispatchRequest,
 ) -> Result<ChatgptResponsesRequest, ModelCallError> {
+    // NOTE: chatgpt-api currently has no request field for ModelProviderProfile::max_output_tokens.
     Ok(ChatgptResponsesRequest {
         model: request.provider.model_name.clone(),
         // HACK: Use fixed optimistic capabilities until Selvedge owns a ChatGPT model capability table.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -164,10 +164,8 @@ async fn call_chatgpt(
             ChatgptResponseEvent::OutputItemDone {
                 item: ResponseItem::Message(message),
                 ..
-            } => {
-                if text_parts.is_empty() {
-                    append_message_content(&mut fallback_text, &message, &mut byte_counter)?;
-                }
+            } if text_parts.is_empty() => {
+                append_message_content(&mut fallback_text, &message, &mut byte_counter)?;
             }
             ChatgptResponseEvent::OutputItemDone {
                 item: ResponseItem::FunctionCall(function_call),

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -225,10 +225,10 @@ async fn call_chatgpt(
 fn chatgpt_request_from_dispatch(
     request: &ModelCallDispatchRequest,
 ) -> Result<ChatgptResponsesRequest, ModelCallError> {
-    // NOTE: ChatGPT dispatch ignores max_output_tokens because chatgpt-api has no request field for this control.
+    // NOTE: ChatGPT dispatch ignores max_output_tokens because chatgpt-api exposes no request field for this control; max-token incompletes are reported as Length replies.
     Ok(ChatgptResponsesRequest {
         model: request.provider.model_name.clone(),
-        // HACK: Use fixed optimistic capabilities until Selvedge owns a ChatGPT model capability table.
+        // HACK: Pin direct ChatGPT dispatch to the current Selvedge capability decision until a capability source exists.
         model_capabilities: ChatgptModelCapabilities {
             supports_reasoning_summaries: true,
             supports_text_verbosity: true,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -515,31 +515,55 @@ fn structured_payload_from_json_string(raw: &str) -> Result<StructuredPayload, M
             "chatgpt function-call arguments must be a JSON object",
         ));
     }
-    Ok(structured_payload_from_json_value(value))
+    structured_payload_from_json_value(value)
 }
 
-fn structured_payload_from_json_value(value: serde_json::Value) -> StructuredPayload {
+fn structured_payload_from_json_value(
+    value: serde_json::Value,
+) -> Result<StructuredPayload, ModelCallError> {
     match value {
-        serde_json::Value::Object(object) => StructuredPayload::Object(
+        serde_json::Value::Object(object) => Ok(StructuredPayload::Object(
             object
                 .into_iter()
-                .map(|(key, value)| (key, structured_payload_from_json_value(value)))
-                .collect(),
-        ),
-        serde_json::Value::Array(values) => StructuredPayload::Array(
+                .map(|(key, value)| Ok((key, structured_payload_from_json_value(value)?)))
+                .collect::<Result<BTreeMap<_, _>, ModelCallError>>()?,
+        )),
+        serde_json::Value::Array(values) => Ok(StructuredPayload::Array(
             values
                 .into_iter()
                 .map(structured_payload_from_json_value)
-                .collect(),
-        ),
-        serde_json::Value::String(value) => StructuredPayload::String(value),
-        serde_json::Value::Number(value) => value
-            .as_f64()
-            .map(StructuredPayload::Number)
-            .unwrap_or(StructuredPayload::Null),
-        serde_json::Value::Bool(value) => StructuredPayload::Boolean(value),
-        serde_json::Value::Null => StructuredPayload::Null,
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        serde_json::Value::String(value) => Ok(StructuredPayload::String(value)),
+        serde_json::Value::Number(value) => {
+            Ok(StructuredPayload::Number(f64_from_json_number(&value)?))
+        }
+        serde_json::Value::Bool(value) => Ok(StructuredPayload::Boolean(value)),
+        serde_json::Value::Null => Ok(StructuredPayload::Null),
     }
+}
+
+fn f64_from_json_number(value: &serde_json::Number) -> Result<f64, ModelCallError> {
+    const MAX_EXACT_INTEGER: u64 = 9_007_199_254_740_992;
+
+    if let Some(unsigned) = value.as_u64() {
+        if unsigned > MAX_EXACT_INTEGER {
+            return Err(imprecise_chatgpt_number_error());
+        }
+    } else if let Some(signed) = value.as_i64()
+        && signed.unsigned_abs() > MAX_EXACT_INTEGER
+    {
+        return Err(imprecise_chatgpt_number_error());
+    }
+
+    value.as_f64().ok_or_else(imprecise_chatgpt_number_error)
+}
+
+fn imprecise_chatgpt_number_error() -> ModelCallError {
+    model_call_error(
+        ModelCallErrorKind::ProviderResponse,
+        "chatgpt function-call arguments contain a number that cannot be represented without precision loss",
+    )
 }
 
 fn json_value_from_structured_payload(payload: &StructuredPayload) -> serde_json::Value {

--- a/crates/api/tests/api_contract.rs
+++ b/crates/api/tests/api_contract.rs
@@ -413,6 +413,83 @@ base_url = "{}"
     }
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn chatgpt_imprecise_integer_tool_argument_sends_provider_response_failure() {
+    const FLAG: &str = "SELVEDGE_API_CHATGPT_IMPRECISE_INTEGER_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "chatgpt_imprecise_integer_tool_argument_sends_provider_response_failure",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async move {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"item-1\",\"status\":\"completed\",\"name\":\"lookup\",\"arguments\":\"{\\\"id\\\":9007199254740993}\",\"call_id\":\"call-1\"}}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(serde_json::json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let request = valid_dispatch_request();
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
+
+    let status = execute_model_call(
+        request.clone(),
+        router_tx.downgrade(),
+        ApiExecutorConfig {
+            request_timeout: Duration::from_secs(5),
+            max_response_bytes: None,
+        },
+    )
+    .await;
+
+    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
+    let message = router_rx.recv().await.expect("router message");
+    assert_failure(
+        message,
+        request.correlation,
+        ModelCallErrorKind::ProviderResponse,
+    );
+}
+
 #[tokio::test]
 async fn unsupported_provider_name_sends_provider_request_failure_without_external_registry() {
     let mut request = valid_dispatch_request();

--- a/crates/api/tests/api_contract.rs
+++ b/crates/api/tests/api_contract.rs
@@ -20,9 +20,9 @@ use selvedge_command_model::{
     ModelCallErrorKind, ModelRunId, RouterIngressApiMessage, TaskId, validate_api_output_envelope,
 };
 use selvedge_domain_model::{
-    ConversationMessage, ConversationPath, MessageContent, MessageRole, ModelProviderProfile,
-    ResponsePreference, StructuredPayload, ToolManifest, ToolParameter, ToolParameterType,
-    ToolSpec,
+    ConversationMessage, ConversationPath, MessageContent, MessageRole, ModelFinishReason,
+    ModelProviderProfile, ResponsePreference, StructuredPayload, ToolManifest, ToolParameter,
+    ToolParameterType, ToolSpec,
 };
 use tempfile::TempDir;
 use tokio::{net::TcpListener, sync::mpsc, task::JoinHandle};
@@ -100,7 +100,8 @@ base_url = "{}"
         ),
     );
 
-    let request = valid_dispatch_request();
+    let mut request = valid_dispatch_request();
+    request.provider.max_output_tokens = Some(10);
     let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
@@ -148,6 +149,7 @@ base_url = "{}"
         captured_body.pointer("/reasoning/effort"),
         Some(&serde_json::json!("medium"))
     );
+    assert!(captured_body.get("max_output_tokens").is_none());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -326,6 +328,89 @@ base_url = "{}"
         captured_body.pointer("/tools/0/name"),
         Some(&serde_json::json!("search"))
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chatgpt_max_output_tokens_incomplete_returns_length_reply() {
+    const FLAG: &str = "SELVEDGE_API_CHATGPT_LENGTH_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "chatgpt_max_output_tokens_incomplete_returns_length_reply",
+            FLAG,
+        ));
+        return;
+    }
+
+    let api_server = spawn_http_server(Router::new().route(
+        "/responses",
+        post(|| async move {
+            let body = Body::from_stream(async_stream::stream! {
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"text\":\"truncated\"}\n\n",
+                ));
+                yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                    "data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp-1\",\"reason\":\"max_output_tokens\"}}\n\n",
+                ));
+            });
+
+            (
+                StatusCode::OK,
+                [(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                )],
+                body,
+            )
+        }),
+    ))
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(serde_json::json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let request = valid_dispatch_request();
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
+
+    let status = execute_model_call(
+        request,
+        router_tx.downgrade(),
+        ApiExecutorConfig {
+            request_timeout: Duration::from_secs(5),
+            max_response_bytes: None,
+        },
+    )
+    .await;
+
+    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
+    let message = router_rx.recv().await.expect("router message");
+
+    match message {
+        RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Success { reply, .. }) => {
+            assert_eq!(reply.content.as_deref(), Some("truncated"));
+            assert_eq!(reply.finish_reason, ModelFinishReason::Length);
+        }
+        _ => panic!("unexpected router message"),
+    }
 }
 
 #[tokio::test]

--- a/crates/api/tests/api_contract.rs
+++ b/crates/api/tests/api_contract.rs
@@ -1,40 +1,342 @@
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    process::{Command, Output},
+    time::Duration,
+};
 
-use async_trait::async_trait;
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::State,
+    http::{HeaderValue, StatusCode},
+    routing::post,
+};
+use base64::Engine;
 use selvedge_api::{
-    ApiCallTerminalStatus, ApiExecutorConfig, ModelProviderAdapter, ModelProviderRegistry,
-    ProviderCallError, ProviderCallErrorKind, ProviderModelRequest, ProviderModelResponse,
-    execute_model_call, spawn_model_call_tokio_task,
+    ApiCallTerminalStatus, ApiExecutorConfig, execute_model_call, spawn_model_call_tokio_task,
 };
 use selvedge_command_model::{
     ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ModelCallDispatchRequest,
     ModelCallErrorKind, ModelRunId, RouterIngressApiMessage, TaskId, validate_api_output_envelope,
 };
 use selvedge_domain_model::{
-    ConversationMessage, ConversationPath, MessageContent, MessageRole, ModelFinishReason,
-    ModelProviderProfile, ModelReply, ResponsePreference, StructuredPayload, ToolCallProposal,
+    ConversationMessage, ConversationPath, MessageContent, MessageRole, ModelProviderProfile,
+    ResponsePreference, StructuredPayload, ToolManifest, ToolParameter, ToolParameterType,
+    ToolSpec,
 };
-use tokio::sync::mpsc;
+use tempfile::TempDir;
+use tokio::{net::TcpListener, sync::mpsc, task::JoinHandle};
 
-#[tokio::test]
-async fn successful_provider_reply_is_sent_once_with_original_correlation() {
+#[tokio::test(flavor = "multi_thread")]
+async fn chatgpt_provider_name_routes_to_chatgpt_api_and_sends_success() {
+    const FLAG: &str = "SELVEDGE_API_CHATGPT_DIRECT_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "chatgpt_provider_name_routes_to_chatgpt_api_and_sends_success",
+            FLAG,
+        ));
+        return;
+    }
+
+    let captured_body = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let captured_body_for_state = std::sync::Arc::clone(&captured_body);
+    let api_server = spawn_http_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(
+                    |State(captured): State<
+                        std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+                    >,
+                     Json(body): Json<serde_json::Value>| async move {
+                        *captured.lock().expect("captured body lock") = Some(body);
+                        let body = Body::from_stream(async_stream::stream! {
+                            yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                                "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"text\":\"hello \"}\n\n",
+                            ));
+                            yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                                "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":1,\"text\":\"from chatgpt\"}\n\n",
+                            ));
+                            yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                                "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\",\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}}\n\n",
+                            ));
+                        });
+
+                        (
+                            StatusCode::OK,
+                            [(
+                                http::header::CONTENT_TYPE,
+                                HeaderValue::from_static("text/event-stream"),
+                            )],
+                            body,
+                        )
+                    },
+                ),
+            )
+            .with_state(captured_body_for_state),
+    )
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(serde_json::json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
     let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: Some("ok".to_owned()),
-                tool_calls: Vec::new(),
-                usage: None,
-                finish_reason: ModelFinishReason::Stop,
-            }),
-        },
-    )))));
     let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
         router_tx.downgrade(),
-        registry,
+        ApiExecutorConfig {
+            request_timeout: Duration::from_secs(5),
+            max_response_bytes: None,
+        },
+    )
+    .await;
+
+    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
+    let message = router_rx.recv().await.expect("router message");
+
+    match message {
+        RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Success { correlation, reply }) => {
+            assert_eq!(correlation, request.correlation);
+            assert_eq!(reply.content.as_deref(), Some("hello from chatgpt"));
+            assert!(reply.tool_calls.is_empty());
+            assert_eq!(reply.usage.expect("usage").input_tokens, 3);
+        }
+        _ => panic!("unexpected router message"),
+    }
+
+    let captured_body = captured_body
+        .lock()
+        .expect("captured body lock")
+        .clone()
+        .expect("captured request body");
+    assert_eq!(
+        captured_body.get("model"),
+        Some(&serde_json::json!("gpt-5"))
+    );
+    assert_eq!(
+        captured_body.pointer("/input/0/content/0/text"),
+        Some(&serde_json::json!("hello"))
+    );
+    assert!(
+        captured_body
+            .pointer("/client_metadata/x-codex-installation-id")
+            .is_some_and(|value| value == "550e8400-e29b-41d4-a716-446655440000")
+    );
+    assert_eq!(
+        captured_body.pointer("/reasoning/effort"),
+        Some(&serde_json::json!("medium"))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chatgpt_dispatch_preserves_tool_history_items_and_text_preference() {
+    const FLAG: &str = "SELVEDGE_API_CHATGPT_TOOL_HISTORY_CHILD";
+
+    if !child_mode(FLAG) {
+        assert_child_success(&run_child(
+            "chatgpt_dispatch_preserves_tool_history_items_and_text_preference",
+            FLAG,
+        ));
+        return;
+    }
+
+    let captured_body = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let captured_body_for_state = std::sync::Arc::clone(&captured_body);
+    let api_server = spawn_http_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(
+                    |State(captured): State<
+                        std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+                    >,
+                     Json(body): Json<serde_json::Value>| async move {
+                        *captured.lock().expect("captured body lock") = Some(body);
+                        let body = Body::from_stream(async_stream::stream! {
+                            yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                                "data: {\"type\":\"response.output_text.done\",\"item_id\":\"item-1\",\"output_index\":0,\"content_index\":0,\"text\":\"done\"}\n\n",
+                            ));
+                            yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(
+                                "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"model\":\"gpt-5\"}}\n\n",
+                            ));
+                        });
+
+                        (
+                            StatusCode::OK,
+                            [(
+                                http::header::CONTENT_TYPE,
+                                HeaderValue::from_static("text/event-stream"),
+                            )],
+                            body,
+                        )
+                    },
+                ),
+            )
+            .with_state(captured_body_for_state),
+    )
+    .await;
+
+    let tempdir = init_api_test(&format!(
+        r#"
+[llm.providers.chatgpt.auth]
+issuer = "http://127.0.0.1:1"
+
+[llm.providers.chatgpt.api]
+base_url = "{}"
+"#,
+        api_server.url("")
+    ));
+    write_auth_file(
+        &tempdir,
+        &auth_file_json(
+            &build_jwt(serde_json::json!({
+                "sub": "subject",
+                "https://api.openai.com/auth.chatgpt_account_id": "workspace-123"
+            })),
+            "opaque-access-token",
+            "refresh-token",
+        ),
+    );
+
+    let mut request = valid_dispatch_request();
+    request.conversation.messages.push(ConversationMessage {
+        role: MessageRole::Assistant,
+        content: MessageContent::Structured(StructuredPayload::Object(BTreeMap::from([
+            (
+                "function_call_id".to_owned(),
+                StructuredPayload::String("call-1".to_owned()),
+            ),
+            (
+                "tool_name".to_owned(),
+                StructuredPayload::String("search".to_owned()),
+            ),
+            (
+                "arguments".to_owned(),
+                StructuredPayload::Array(vec![StructuredPayload::Object(BTreeMap::from([
+                    (
+                        "name".to_owned(),
+                        StructuredPayload::String("query".to_owned()),
+                    ),
+                    (
+                        "value".to_owned(),
+                        StructuredPayload::String("rust".to_owned()),
+                    ),
+                ]))]),
+            ),
+        ]))),
+        source_node_id: None,
+    });
+    request.conversation.messages.push(ConversationMessage {
+        role: MessageRole::Tool,
+        content: MessageContent::Structured(StructuredPayload::Object(BTreeMap::from([
+            (
+                "function_call_id".to_owned(),
+                StructuredPayload::String("call-1".to_owned()),
+            ),
+            (
+                "tool_name".to_owned(),
+                StructuredPayload::String("search".to_owned()),
+            ),
+            (
+                "output_text".to_owned(),
+                StructuredPayload::String("result".to_owned()),
+            ),
+        ]))),
+        source_node_id: None,
+    });
+    request.conversation.messages.push(ConversationMessage {
+        role: MessageRole::Assistant,
+        content: MessageContent::Text("previous answer".to_owned()),
+        source_node_id: None,
+    });
+    request.tool_manifest = Some(ToolManifest {
+        tools: vec![ToolSpec {
+            name: "search".to_owned(),
+            description: "search".to_owned(),
+            parameters: vec![ToolParameter {
+                name: "query".to_owned(),
+                parameter_type: ToolParameterType::String,
+                description: "query".to_owned(),
+                required: true,
+            }],
+        }],
+    });
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
+
+    let status = execute_model_call(
+        request,
+        router_tx.downgrade(),
+        ApiExecutorConfig {
+            request_timeout: Duration::from_secs(5),
+            max_response_bytes: None,
+        },
+    )
+    .await;
+
+    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
+    assert!(matches!(
+        router_rx.recv().await.expect("router message"),
+        RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Success { .. })
+    ));
+
+    let captured_body = captured_body
+        .lock()
+        .expect("captured body lock")
+        .clone()
+        .expect("captured request body");
+    assert_eq!(
+        captured_body.pointer("/input/1/type"),
+        Some(&serde_json::json!("function_call"))
+    );
+    assert_eq!(
+        captured_body.pointer("/input/1/arguments"),
+        Some(&serde_json::json!("{\"query\":\"rust\"}"))
+    );
+    assert_eq!(
+        captured_body.pointer("/input/2/type"),
+        Some(&serde_json::json!("function_call_output"))
+    );
+    assert_eq!(
+        captured_body.pointer("/input/3/content/0/type"),
+        Some(&serde_json::json!("output_text"))
+    );
+    assert_eq!(
+        captured_body.pointer("/tools/0/name"),
+        Some(&serde_json::json!("search"))
+    );
+}
+
+#[tokio::test]
+async fn unsupported_provider_name_sends_provider_request_failure_without_external_registry() {
+    let mut request = valid_dispatch_request();
+    request.provider.provider_name = "unknown".to_owned();
+    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
+
+    let status = execute_model_call(
+        request.clone(),
+        router_tx.downgrade(),
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -44,39 +346,23 @@ async fn successful_provider_reply_is_sent_once_with_original_correlation() {
 
     assert_eq!(status, ApiCallTerminalStatus::OutputSent);
     let message = router_rx.recv().await.expect("router message");
-    assert!(router_rx.try_recv().is_err());
 
-    match message {
-        RouterIngressApiMessage::ApiOutput(ApiOutputEnvelope::Success { correlation, reply }) => {
-            assert_eq!(correlation.api_effect_id, request.correlation.api_effect_id);
-            assert_eq!(correlation.task_id, request.correlation.task_id);
-            assert_eq!(correlation.model_run_id, request.correlation.model_run_id);
-            assert_eq!(reply.content.as_deref(), Some("ok"));
-        }
-        _ => panic!("unexpected router message"),
-    }
+    assert_failure(
+        message,
+        request.correlation,
+        ModelCallErrorKind::ProviderRequest,
+    );
 }
 
 #[tokio::test]
-async fn invalid_dispatch_request_sends_validation_failure_without_provider_call() {
+async fn invalid_dispatch_request_sends_validation_failure_before_provider_dispatch() {
     let mut request = valid_dispatch_request();
     request.conversation.messages.clear();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: Some("unused".to_owned()),
-                tool_calls: Vec::new(),
-                usage: None,
-                finish_reason: ModelFinishReason::Stop,
-            }),
-        },
-    )))));
     let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request.clone(),
         router_tx.downgrade(),
-        registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -94,22 +380,11 @@ async fn invalid_dispatch_request_sends_validation_failure_without_provider_call
 async fn invalid_correlation_sends_validation_failure_that_satisfies_output_validation() {
     let mut request = valid_dispatch_request();
     request.correlation.api_effect_id = ApiEffectId(String::new());
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: Some("unused".to_owned()),
-                tool_calls: Vec::new(),
-                usage: None,
-                finish_reason: ModelFinishReason::Stop,
-            }),
-        },
-    )))));
     let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let status = execute_model_call(
         request,
         router_tx.downgrade(),
-        registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -135,302 +410,15 @@ async fn invalid_correlation_sends_validation_failure_that_satisfies_output_vali
 }
 
 #[tokio::test]
-async fn missing_provider_sends_provider_request_failure() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(None));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: None,
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(
-        message,
-        request.correlation,
-        ModelCallErrorKind::ProviderRequest,
-    );
-}
-
-#[tokio::test]
-async fn provider_network_failure_is_classified() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::err(
-        ProviderCallError {
-            kind: ProviderCallErrorKind::Network,
-            message: "network".to_owned(),
-        },
-    )))));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: None,
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(
-        message,
-        request.correlation,
-        ModelCallErrorKind::ProviderNetwork,
-    );
-}
-
-#[tokio::test]
-async fn provider_timeout_is_classified() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::err(
-        ProviderCallError {
-            kind: ProviderCallErrorKind::Timeout,
-            message: "timeout".to_owned(),
-        },
-    )))));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: None,
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(
-        message,
-        request.correlation,
-        ModelCallErrorKind::ProviderTimeout,
-    );
-}
-
-#[tokio::test]
-async fn provider_cancelled_failure_is_classified() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::err(
-        ProviderCallError {
-            kind: ProviderCallErrorKind::Cancelled,
-            message: "cancelled".to_owned(),
-        },
-    )))));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: None,
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(message, request.correlation, ModelCallErrorKind::Cancelled);
-}
-
-#[tokio::test]
-async fn invalid_provider_response_is_classified() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse { reply: None },
-    )))));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: None,
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(
-        message,
-        request.correlation,
-        ModelCallErrorKind::ProviderResponse,
-    );
-}
-
-#[tokio::test]
-async fn response_byte_limit_applies_to_tool_call_arguments() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: None,
-                tool_calls: vec![ToolCallProposal {
-                    call_id: "call-1".to_owned(),
-                    tool_name: "search".to_owned(),
-                    arguments: StructuredPayload::Object(BTreeMap::from([(
-                        "query".to_owned(),
-                        StructuredPayload::String("0123456789".to_owned()),
-                    )])),
-                }],
-                usage: None,
-                finish_reason: ModelFinishReason::ToolCalls,
-            }),
-        },
-    )))));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: Some(4),
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(
-        message,
-        request.correlation,
-        ModelCallErrorKind::ProviderResponse,
-    );
-}
-
-#[tokio::test]
-async fn response_byte_limit_includes_structural_payload_bytes() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: None,
-                tool_calls: vec![ToolCallProposal {
-                    call_id: "call-1".to_owned(),
-                    tool_name: "search".to_owned(),
-                    arguments: StructuredPayload::Array(vec![
-                        StructuredPayload::Array(Vec::new(),);
-                        100
-                    ]),
-                }],
-                usage: None,
-                finish_reason: ModelFinishReason::ToolCalls,
-            }),
-        },
-    )))));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: Some(40),
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(
-        message,
-        request.correlation,
-        ModelCallErrorKind::ProviderResponse,
-    );
-}
-
-#[tokio::test]
-async fn response_byte_limit_counts_escaped_structured_payload_bytes() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: None,
-                tool_calls: vec![ToolCallProposal {
-                    call_id: "call-1".to_owned(),
-                    tool_name: "search".to_owned(),
-                    arguments: StructuredPayload::Object(BTreeMap::from([(
-                        "\"".to_owned(),
-                        StructuredPayload::String("\\\n\"".to_owned()),
-                    )])),
-                }],
-                usage: None,
-                finish_reason: ModelFinishReason::ToolCalls,
-            }),
-        },
-    )))));
-    let (router_tx, mut router_rx) = mpsc::unbounded_channel();
-
-    let status = execute_model_call(
-        request.clone(),
-        router_tx.downgrade(),
-        registry,
-        ApiExecutorConfig {
-            request_timeout: Duration::from_secs(1),
-            max_response_bytes: Some(40),
-        },
-    )
-    .await;
-
-    assert_eq!(status, ApiCallTerminalStatus::OutputSent);
-    let message = router_rx.recv().await.expect("router message");
-
-    assert_failure(
-        message,
-        request.correlation,
-        ModelCallErrorKind::ProviderResponse,
-    );
-}
-
-#[tokio::test]
 async fn closed_router_mailbox_discards_completion_result() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: Some("ok".to_owned()),
-                tool_calls: Vec::new(),
-                usage: None,
-                finish_reason: ModelFinishReason::Stop,
-            }),
-        },
-    )))));
+    let mut request = valid_dispatch_request();
+    request.conversation.messages.clear();
     let (router_tx, router_rx) = mpsc::unbounded_channel();
     drop(router_rx);
 
     let status = execute_model_call(
         request,
         router_tx.downgrade(),
-        registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -443,23 +431,13 @@ async fn closed_router_mailbox_discards_completion_result() {
 
 #[tokio::test]
 async fn spawn_model_call_tokio_task_returns_terminal_status() {
-    let request = valid_dispatch_request();
-    let registry = Arc::new(StaticRegistry::new(Some(Arc::new(StaticAdapter::ok(
-        ProviderModelResponse {
-            reply: Some(ModelReply {
-                content: Some("ok".to_owned()),
-                tool_calls: Vec::new(),
-                usage: None,
-                finish_reason: ModelFinishReason::Stop,
-            }),
-        },
-    )))));
+    let mut request = valid_dispatch_request();
+    request.conversation.messages.clear();
     let (router_tx, mut router_rx) = mpsc::unbounded_channel();
 
     let handle = spawn_model_call_tokio_task(
         request,
         router_tx.downgrade(),
-        registry,
         ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -500,8 +478,8 @@ fn valid_dispatch_request() -> ModelCallDispatchRequest {
             model_run_id: ModelRunId("run-1".to_owned()),
         },
         provider: ModelProviderProfile {
-            provider_name: "provider".to_owned(),
-            model_name: "model".to_owned(),
+            provider_name: "chatgpt".to_owned(),
+            model_name: "gpt-5".to_owned(),
             temperature: None,
             max_output_tokens: None,
         },
@@ -517,47 +495,99 @@ fn valid_dispatch_request() -> ModelCallDispatchRequest {
     }
 }
 
-struct StaticRegistry {
-    adapter: Option<Arc<dyn ModelProviderAdapter>>,
+fn child_mode(flag: &str) -> bool {
+    std::env::var_os(flag).is_some()
 }
 
-impl StaticRegistry {
-    fn new(adapter: Option<Arc<dyn ModelProviderAdapter>>) -> Self {
-        Self { adapter }
+fn run_child(test_name: &str, flag: &str) -> Output {
+    let current_executable = std::env::current_exe().expect("current test executable");
+
+    Command::new(current_executable)
+        .arg("--exact")
+        .arg(test_name)
+        .env(flag, "1")
+        .output()
+        .expect("run child test")
+}
+
+fn assert_child_success(output: &Output) {
+    assert!(output.status.success(), "child test failed: {output:?}");
+}
+
+fn init_api_test(config_body: &str) -> TempDir {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_home = tempdir.path().join(".selvedge");
+    let config_path = config_home.join("config.toml");
+
+    std::fs::create_dir_all(&config_home).expect("create config home");
+    std::fs::write(&config_path, config_body).expect("write config");
+
+    selvedge_config::init_with_home(&config_home).expect("init config");
+    selvedge_logging::init().expect("init logging");
+
+    tempdir
+}
+
+fn write_auth_file(tempdir: &TempDir, auth_file_body: &str) -> std::path::PathBuf {
+    let auth_file_path = tempdir.path().join(".selvedge/auth/chatgpt-auth.json");
+    std::fs::create_dir_all(
+        auth_file_path
+            .parent()
+            .expect("auth file path must have parent"),
+    )
+    .expect("create auth dir");
+    std::fs::write(&auth_file_path, auth_file_body).expect("write auth file");
+
+    auth_file_path
+}
+
+struct TestServer {
+    addr: std::net::SocketAddr,
+    handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    fn url(&self, path: &str) -> String {
+        format!("http://{}{}", self.addr, path)
     }
 }
 
-impl ModelProviderRegistry for StaticRegistry {
-    fn resolve(&self, _provider_name: &str) -> Option<Arc<dyn ModelProviderAdapter>> {
-        self.adapter.clone()
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.handle.abort();
     }
 }
 
-struct StaticAdapter {
-    response: Result<ProviderModelResponse, ProviderCallError>,
+async fn spawn_http_server(router: Router) -> TestServer {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve test app");
+    });
+
+    TestServer { addr, handle }
 }
 
-impl StaticAdapter {
-    fn ok(response: ProviderModelResponse) -> Self {
-        Self {
-            response: Ok(response),
+fn auth_file_json(id_token: &str, access_token: &str, refresh_token: &str) -> String {
+    serde_json::json!({
+        "schema_version": 1,
+        "provider": "chatgpt",
+        "login_method": "device_code",
+        "tokens": {
+            "id_token": id_token,
+            "access_token": access_token,
+            "refresh_token": refresh_token
         }
-    }
-
-    fn err(error: ProviderCallError) -> Self {
-        Self {
-            response: Err(error),
-        }
-    }
+    })
+    .to_string()
 }
 
-#[async_trait]
-impl ModelProviderAdapter for StaticAdapter {
-    async fn call_model(
-        &self,
-        _request: ProviderModelRequest,
-        _timeout: Duration,
-    ) -> Result<ProviderModelResponse, ProviderCallError> {
-        self.response.clone()
-    }
+fn build_jwt(payload: serde_json::Value) -> String {
+    let engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = engine.encode(r#"{"alg":"none","typ":"JWT"}"#);
+    let payload = engine.encode(payload.to_string());
+
+    format!("{header}.{payload}.signature")
 }

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -6,6 +6,8 @@ Use it to spawn the process-local mailbox that routes client commands, task runt
 
 This crate does not execute provider calls, tool calls, task-local state transitions, database writes, or client delivery directly. It delegates those effects to the API, configured tool executor, task-runtime factory, core runtime, database, and events crates.
 
+`RouterStartArgs` passes API execution config to `selvedge-api`; provider selection stays in each model-call request.
+
 Router ingress is unbounded. The router is the lifecycle coordinator for task runtimes, and runtime-to-router output must enqueue without waiting for router mailbox capacity while the router is synchronously stopping a runtime. The router handle owns the strong ingress sender; runtime, API, tool, and factory producers receive weak ingress senders so dropping external ingress owners closes the router mailbox.
 
 Core output routing is task-id based. A runtime that enqueued core output before a synchronous stop still has that output routed normally; stop controls runtime registry ownership and future task command delivery.

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
-use selvedge_api::{ApiExecutorConfig, ModelProviderRegistry, spawn_model_call_tokio_task};
+use selvedge_api::{ApiExecutorConfig, spawn_model_call_tokio_task};
 use selvedge_command_model::{
     ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DebugRawEvent, DetachReason,
     DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
@@ -24,7 +24,6 @@ use tokio::task::JoinHandle;
 pub struct RouterStartArgs {
     pub db: DbPool,
     pub events_tx: EventIngressSender,
-    pub api_provider_registry: Arc<dyn ModelProviderRegistry>,
     pub api_config: ApiExecutorConfig,
     pub tool_executor: Arc<dyn ToolExecutionSpawner>,
     pub core_spawn_deps: TaskRuntimeSpawnDeps,
@@ -67,7 +66,6 @@ pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterEr
     let actor = RouterActor {
         db: args.db,
         events_tx: args.events_tx,
-        api_provider_registry: args.api_provider_registry,
         api_config: args.api_config,
         tool_executor: args.tool_executor,
         core_spawn_deps: args.core_spawn_deps,
@@ -90,7 +88,6 @@ pub fn spawn_router(args: RouterStartArgs) -> Result<RouterHandle, SpawnRouterEr
 struct RouterActor {
     db: DbPool,
     events_tx: EventIngressSender,
-    api_provider_registry: Arc<dyn ModelProviderRegistry>,
     api_config: ApiExecutorConfig,
     tool_executor: Arc<dyn ToolExecutionSpawner>,
     core_spawn_deps: TaskRuntimeSpawnDeps,
@@ -240,7 +237,6 @@ impl RouterActor {
                 let _join_handle = spawn_model_call_tokio_task(
                     request,
                     self.router_tx.clone(),
-                    self.api_provider_registry.clone(),
                     self.api_config.clone(),
                 );
                 Ok(())

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use selvedge_api::{ApiExecutorConfig, ModelProviderAdapter, ModelProviderRegistry};
+use selvedge_api::ApiExecutorConfig;
 use selvedge_command_model::{
     ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommandId,
     ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel, DomainEvent,
@@ -34,7 +34,6 @@ async fn attach_client_command_is_forwarded_to_events() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -103,7 +102,6 @@ async fn task_local_command_creates_runtime_and_flushes_deferred_user_input() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -161,7 +159,6 @@ async fn api_tool_and_stop_messages_are_routed_to_live_runtime() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -235,7 +232,6 @@ async fn stop_runtime_removes_sender_before_later_task_commands() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -334,7 +330,6 @@ async fn stale_runtime_exit_preserves_replacement_runtime() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -453,7 +448,6 @@ async fn current_runtime_exit_removes_registry_entry() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -541,7 +535,6 @@ async fn inactive_archive_is_delivered_before_runtime_start() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -597,7 +590,6 @@ async fn stale_outputs_and_runtime_ready_are_published_to_events() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -664,7 +656,6 @@ async fn data_domain_events_are_not_published_to_events() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -713,7 +704,6 @@ async fn core_tool_execution_request_uses_configured_tool_spawner() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -757,7 +747,6 @@ async fn mismatched_core_tool_task_id_is_ignored() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -801,7 +790,6 @@ async fn core_tool_execution_spawn_failure_returns_error_tool_result() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -867,7 +855,6 @@ async fn spawn_router_uses_unbounded_ingress() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -896,7 +883,6 @@ async fn router_exits_when_ingress_sender_is_dropped() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -926,7 +912,6 @@ async fn router_exits_when_ingress_sender_is_dropped_with_live_runtime() {
     let handle = spawn_router(RouterStartArgs {
         db,
         events_tx,
-        api_provider_registry: Arc::new(EmptyProviderRegistry),
         api_config: ApiExecutorConfig {
             request_timeout: Duration::from_secs(1),
             max_response_bytes: None,
@@ -1059,14 +1044,6 @@ async fn finish_stop(control: TaskRuntimeControl) {
     control
         .finish_stop(selvedge_command_model::TaskRuntimeStopResult)
         .await;
-}
-
-struct EmptyProviderRegistry;
-
-impl ModelProviderRegistry for EmptyProviderRegistry {
-    fn resolve(&self, _provider_name: &str) -> Option<Arc<dyn ModelProviderAdapter>> {
-        None
-    }
 }
 
 struct NoopToolSpawner;


### PR DESCRIPTION
## Summary
- route selvedge-api ChatGPT model calls directly into chatgpt-api from request.provider.provider_name
- remove external provider registry usage from router/api dispatch
- document ChatGPT dispatch decisions and code marker comment rules
- handle ChatGPT max_output_tokens incomplete responses as Length replies

## Verification
- cargo test -p selvedge-api
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- just agents-index-check
- codex-review-final main