### PR TITLE
Integrate local server, client, UI, and web stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-client/,local-protocol/,logging/,router/,server/,systemd/,task-runtime-factory/,web/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-client/,local-protocol/,logging/,router/,server/,systemd/,task-runtime-factory/,tui/,web/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -137,6 +137,9 @@ This file is for coding agents working in this repository.
 |crates/task-runtime-factory:{src/,tests/,Cargo.toml,README.md}
 |crates/task-runtime-factory/src:{lib.rs}
 |crates/task-runtime-factory/tests:{factory_contract.rs}
+|crates/tui:{src/,tests/,Cargo.toml,README.md}
+|crates/tui/src:{lib.rs}
+|crates/tui/tests:{tui_contract.rs}
 |crates/web:{src/,tests/,Cargo.toml,README.md}
 |crates/web/src:{lib.rs}
 |crates/web/tests:{web_contract.rs}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-protocol/,logging/,router/,server/,task-runtime-factory/,web/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-client/,local-protocol/,logging/,router/,server/,task-runtime-factory/,web/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -117,6 +117,9 @@ This file is for coding agents working in this repository.
 |crates/events:{src/,tests/,Cargo.toml,README.md}
 |crates/events/src:{lib.rs}
 |crates/events/tests:{events_contract.rs}
+|crates/local-client:{src/,tests/,Cargo.toml,README.md}
+|crates/local-client/src:{lib.rs}
+|crates/local-client/tests:{local_client_contract.rs}
 |crates/local-protocol:{src/,tests/,Cargo.toml,README.md}
 |crates/local-protocol/src:{lib.rs}
 |crates/local-protocol/tests:{local_protocol_contract.rs}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-client/,local-protocol/,logging/,router/,server/,task-runtime-factory/,web/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-client/,local-protocol/,logging/,router/,server/,systemd/,task-runtime-factory/,web/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -131,6 +131,9 @@ This file is for coding agents working in this repository.
 |crates/server:{src/,tests/,Cargo.toml,README.md}
 |crates/server/src:{lib.rs}
 |crates/server/tests:{server_contract.rs}
+|crates/systemd:{src/,tests/,Cargo.toml,README.md}
+|crates/systemd/src:{lib.rs}
+|crates/systemd/tests:{systemd_contract.rs}
 |crates/task-runtime-factory:{src/,tests/,Cargo.toml,README.md}
 |crates/task-runtime-factory/src:{lib.rs}
 |crates/task-runtime-factory/tests:{factory_contract.rs}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-protocol/,logging/,router/,task-runtime-factory/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-protocol/,logging/,router/,task-runtime-factory/,web/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -89,6 +89,9 @@ This file is for coding agents working in this repository.
 |crates/chatgpt-login/tests:{support/,complete_login_integration.rs,device_code_start_integration.rs,public_api.rs}
 |crates/chatgpt-login/tests/support:{mod.rs}
 |crates/client:{src/,tests/,Cargo.toml,README.md}
+|crates/client-sync:{src/,tests/,Cargo.toml,README.md}
+|crates/client-sync/src:{lib.rs}
+|crates/client-sync/tests:{client_sync_contract.rs}
 |crates/client/src:{config_resolution.rs,lib.rs,redaction.rs,redirect_runtime.rs,request_prep.rs,runtime.rs,single_hop.rs}
 |crates/client/tests:{support/,http_integration.rs}
 |crates/client/tests/support:{mod.rs}
@@ -125,6 +128,9 @@ This file is for coding agents working in this repository.
 |crates/task-runtime-factory:{src/,tests/,Cargo.toml,README.md}
 |crates/task-runtime-factory/src:{lib.rs}
 |crates/task-runtime-factory/tests:{factory_contract.rs}
+|crates/web:{src/,tests/,Cargo.toml,README.md}
+|crates/web/src:{lib.rs}
+|crates/web/tests:{web_contract.rs}
 |scripts:{bootstrap.sh,create-worktree.sh}
 |src:{lib.rs,main.rs}
 |tests:{config_integration.rs,stdout_stderr_integration.rs,worktree_tool_integration.rs}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,logging/,router/,task-runtime-factory/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-protocol/,logging/,router/,task-runtime-factory/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -114,6 +114,9 @@ This file is for coding agents working in this repository.
 |crates/events:{src/,tests/,Cargo.toml,README.md}
 |crates/events/src:{lib.rs}
 |crates/events/tests:{events_contract.rs}
+|crates/local-protocol:{src/,tests/,Cargo.toml,README.md}
+|crates/local-protocol/src:{lib.rs}
+|crates/local-protocol/tests:{local_protocol_contract.rs}
 |crates/logging:{src/,Cargo.toml,README.md}
 |crates/logging/src:{lib.rs}
 |crates/router:{src/,tests/,Cargo.toml,README.md}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ This file is for coding agents working in this repository.
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{ci.yml}
-|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-protocol/,logging/,router/,task-runtime-factory/,web/}
+|crates:{api/,chatgpt-api/,chatgpt-auth/,chatgpt-login/,client-sync/,client/,command-model/,config-model/,config/,core/,db/,domain-model/,events/,local-protocol/,logging/,router/,server/,task-runtime-factory/,web/}
 |crates/api:{src/,tests/,Cargo.toml,README.md}
 |crates/api/src:{lib.rs}
 |crates/api/tests:{api_contract.rs}
@@ -125,6 +125,9 @@ This file is for coding agents working in this repository.
 |crates/router:{src/,tests/,Cargo.toml,README.md}
 |crates/router/src:{lib.rs}
 |crates/router/tests:{router_contract.rs}
+|crates/server:{src/,tests/,Cargo.toml,README.md}
+|crates/server/src:{lib.rs}
+|crates/server/tests:{server_contract.rs}
 |crates/task-runtime-factory:{src/,tests/,Cargo.toml,README.md}
 |crates/task-runtime-factory/src:{lib.rs}
 |crates/task-runtime-factory/tests:{factory_contract.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-client-sync"
+version = "0.0.0"
+dependencies = [
+ "selvedge-command-model",
+ "selvedge-domain-model",
+ "tokio",
+]
+
+[[package]]
 name = "selvedge-command-model"
 version = "0.0.0"
 dependencies = [
@@ -1544,6 +1553,16 @@ dependencies = [
  "selvedge-domain-model",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "selvedge-web"
+version = "0.0.0"
+dependencies = [
+ "futures-core",
+ "selvedge-local-protocol",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,7 @@ name = "selvedge-web"
 version = "0.0.0"
 dependencies = [
  "futures-core",
+ "futures-util",
  "selvedge-local-protocol",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-local-client"
+version = "0.0.0"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "selvedge-local-protocol",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "selvedge-local-protocol"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-server"
+version = "0.0.0"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "selvedge-api",
+ "selvedge-client-sync",
+ "selvedge-command-model",
+ "selvedge-config",
+ "selvedge-core",
+ "selvedge-db",
+ "selvedge-domain-model",
+ "selvedge-events",
+ "selvedge-local-protocol",
+ "selvedge-logging",
+ "selvedge-router",
+ "selvedge-web",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "selvedge-task-runtime-factory"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-local-protocol"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "selvedge-logging"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-tui"
+version = "0.0.0"
+dependencies = [
+ "futures-util",
+ "selvedge-local-client",
+ "selvedge-local-protocol",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "selvedge-web"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "selvedge-systemd"
+version = "0.0.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "selvedge-task-runtime-factory"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,6 +1547,7 @@ dependencies = [
 name = "selvedge-server"
 version = "0.0.0"
 dependencies = [
+ "fs2",
  "futures-core",
  "futures-util",
  "selvedge-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
  "selvedge-local-protocol",
  "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1894,6 +1895,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/domain-model",
     "crates/events",
     "crates/logging",
+    "crates/local-protocol",
     "crates/router",
     "crates/task-runtime-factory",
     "xtask",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/chatgpt-auth",
     "crates/chatgpt-login",
     "crates/client",
+    "crates/client-sync",
     "crates/command-model",
     "crates/config",
     "crates/config-model",
@@ -16,6 +17,7 @@ members = [
     "crates/local-protocol",
     "crates/router",
     "crates/task-runtime-factory",
+    "crates/web",
     "xtask",
 ]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/local-protocol",
     "crates/router",
     "crates/server",
+    "crates/systemd",
     "crates/task-runtime-factory",
     "crates/web",
     "xtask",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/logging",
     "crates/local-protocol",
     "crates/router",
+    "crates/server",
     "crates/task-runtime-factory",
     "crates/web",
     "xtask",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/domain-model",
     "crates/events",
     "crates/logging",
+    "crates/local-client",
     "crates/local-protocol",
     "crates/router",
     "crates/server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/server",
     "crates/systemd",
     "crates/task-runtime-factory",
+    "crates/tui",
     "crates/web",
     "xtask",
 ]

--- a/crates/client-sync/Cargo.toml
+++ b/crates/client-sync/Cargo.toml
@@ -9,7 +9,7 @@ tokio = { version = "1.42.0", features = ["rt", "sync"] }
 
 [dev-dependencies]
 selvedge-domain-model = { path = "../domain-model" }
-tokio = { version = "1.42.0", features = ["macros", "rt", "sync"] }
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/client-sync/Cargo.toml
+++ b/crates/client-sync/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 
 [dependencies]
 selvedge-command-model = { path = "../command-model" }
-tokio = { version = "1.42.0", features = ["rt", "sync"] }
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync"] }
 
 [dev-dependencies]
 selvedge-domain-model = { path = "../domain-model" }

--- a/crates/client-sync/Cargo.toml
+++ b/crates/client-sync/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "selvedge-client-sync"
+edition = "2024"
+publish = false
+
+[dependencies]
+selvedge-command-model = { path = "../command-model" }
+tokio = { version = "1.42.0", features = ["rt", "sync"] }
+
+[dev-dependencies]
+selvedge-domain-model = { path = "../domain-model" }
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/client-sync/README.md
+++ b/crates/client-sync/README.md
@@ -1,0 +1,7 @@
+# client-sync
+
+This crate defines the client hydration synchronization boundary used by the server and router attach path.
+
+Use it to pass hydration starts, cancellation, shutdown signals, snapshot builder requests, snapshot builder results, client-sync errors, and the client-sync task handle across package boundaries.
+
+This crate currently provides the stable public interface and lifecycle handle needed by `selvedge-server`. Hydration ordering, current-request replacement, failure notice delivery, and late-result handling are implemented when the full client-sync package is advanced in the package sequence.

--- a/crates/client-sync/README.md
+++ b/crates/client-sync/README.md
@@ -4,4 +4,12 @@ This crate defines the client hydration synchronization boundary used by the ser
 
 Use it to pass hydration starts, cancellation, shutdown signals, snapshot builder requests, snapshot builder results, client-sync errors, and the client-sync task handle across package boundaries.
 
-This crate currently provides the stable public interface and lifecycle handle needed by `selvedge-server`. Hydration ordering, current-request replacement, failure notice delivery, and late-result handling are implemented when the full client-sync package is advanced in the package sequence.
+## Hydration Model
+
+`spawn_client_sync` starts one ingress loop. That loop owns the current hydration map keyed by `ClientId`; builder tasks only return snapshot results to the loop. This keeps replacement, cancellation, shutdown, and stale-result dropping in one ordering point.
+
+`ClientSyncIngress::StartHydration` sends `BeginClientHydration` to the events mailbox first. Snapshot building starts after that send succeeds. A closed events mailbox is a fatal client-sync exit, and the builder is left untouched for that request.
+
+Only the current `(ClientId, ClientCommandId)` may deliver its builder result. A new command for the same client replaces the old command. A duplicate start for the current command is ignored. `CancelHydration` removes the matching current command. `Shutdown` stops the loop and drops late builder results.
+
+Successful builder results are forwarded as `DeliverSnapshot` exactly as built. Builder errors are forwarded as an error `DeliverNotice` followed by `DetachClient` with `DetachReason::DeliveryFailed`. If either events send fails, the sync loop exits with `ClientSyncExitStatus::Fatal`.

--- a/crates/client-sync/src/lib.rs
+++ b/crates/client-sync/src/lib.rs
@@ -1,12 +1,14 @@
 #![doc = include_str!("../README.md")]
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use selvedge_command_model::{
-    BeginClientHydration, ClientCommandId, ClientId, ClientSnapshot, ClientSubscription,
-    EventIngressSender,
+    BeginClientHydration, ClientCommandId, ClientId, ClientNotice, ClientNoticeLevel,
+    ClientSnapshot, ClientSubscription, DeliverNotice, DeliverSnapshot, DetachClient, DetachReason,
+    EventControlMessage, EventIngress, EventIngressSender,
 };
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -74,6 +76,11 @@ pub trait ClientSnapshotBuilder: Send + Sync + 'static {
     fn build_snapshot(&self, request: ClientSnapshotBuildRequest) -> ClientSnapshotBuildFuture;
 }
 
+struct HydrationBuildResult {
+    request: ClientSnapshotBuildRequest,
+    result: Result<ClientSnapshot, ClientSyncError>,
+}
+
 pub fn spawn_client_sync(
     args: ClientSyncStartArgs,
 ) -> Result<ClientSyncHandle, SpawnClientSyncError> {
@@ -82,20 +89,162 @@ pub fn spawn_client_sync(
     }
 
     let (ingress_tx, mut ingress_rx) = mpsc::channel(args.ingress_capacity);
-    let _events_tx = args.events_tx;
-    let _snapshot_builder = args.snapshot_builder;
-    let join_handle = tokio::spawn(async move {
-        while let Some(message) = ingress_rx.recv().await {
-            if matches!(message, ClientSyncIngress::Shutdown) {
-                return ClientSyncExitStatus::Stopped;
+    let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+    let events_tx = args.events_tx;
+    let snapshot_builder = args.snapshot_builder;
+    let handle = tokio::runtime::Handle::try_current()
+        .map_err(|_| SpawnClientSyncError::TokioSpawnFailed)?;
+    let join_handle = handle.spawn(async move {
+        let mut current = HashMap::<ClientId, ClientCommandId>::new();
+
+        loop {
+            tokio::select! {
+                message = ingress_rx.recv() => {
+                    match message {
+                        Some(ClientSyncIngress::StartHydration(begin)) => {
+                            let client_id = begin.client_id.clone();
+                            let client_command_id = begin.client_command_id.clone();
+
+                            if current.get(&client_id) == Some(&client_command_id) {
+                                continue;
+                            }
+
+                            current.insert(client_id.clone(), client_command_id.clone());
+                            let request = ClientSnapshotBuildRequest {
+                                client_id,
+                                client_command_id,
+                                subscription: begin.subscription.clone(),
+                            };
+
+                            // NOTE: Begin is the state handoff to events. Snapshot building starts after
+                            // that mailbox accepts Begin, so a closed events mailbox is a fatal hydration
+                            // boundary failure and the builder remains untouched.
+                            if send_control(
+                                &events_tx,
+                                EventControlMessage::BeginClientHydration(begin),
+                            )
+                            .await
+                            .is_err()
+                            {
+                                current.clear();
+                                return ClientSyncExitStatus::Fatal(
+                                    "events mailbox closed while beginning client hydration".to_owned(),
+                                );
+                            }
+
+                            spawn_snapshot_build(
+                                snapshot_builder.clone(),
+                                result_tx.clone(),
+                                request,
+                            );
+                        }
+                        Some(ClientSyncIngress::CancelHydration(cancel)) => {
+                            if current.get(&cancel.client_id) == Some(&cancel.client_command_id) {
+                                current.remove(&cancel.client_id);
+                            }
+                        }
+                        Some(ClientSyncIngress::Shutdown) => {
+                            current.clear();
+                            return ClientSyncExitStatus::Stopped;
+                        }
+                        None => {
+                            current.clear();
+                            return ClientSyncExitStatus::IngressClosed;
+                        }
+                    }
+                }
+                Some(build_result) = result_rx.recv() => {
+                    // NOTE: This loop owns the current hydration map. Builder results deliver only
+                    // while their client command is still current after replacement or cancellation.
+                    if current.get(&build_result.request.client_id)
+                        != Some(&build_result.request.client_command_id)
+                    {
+                        continue;
+                    }
+                    let result_client_id = build_result.request.client_id.clone();
+
+                    let stage = deliver_build_result(
+                        &events_tx,
+                        build_result,
+                    )
+                    .await
+                    .err();
+
+                    if let Some(stage) = stage {
+                        current.clear();
+                        return ClientSyncExitStatus::Fatal(format!(
+                            "events mailbox closed while {stage}"
+                        ));
+                    }
+
+                    current.remove(&result_client_id);
+                }
             }
         }
-
-        ClientSyncExitStatus::IngressClosed
     });
 
     Ok(ClientSyncHandle {
         ingress_tx,
         join_handle,
     })
+}
+
+fn spawn_snapshot_build(
+    snapshot_builder: Arc<dyn ClientSnapshotBuilder>,
+    result_tx: mpsc::UnboundedSender<HydrationBuildResult>,
+    request: ClientSnapshotBuildRequest,
+) {
+    tokio::spawn(async move {
+        let result = snapshot_builder.build_snapshot(request.clone()).await;
+        let _ = result_tx.send(HydrationBuildResult { request, result });
+    });
+}
+
+async fn deliver_build_result(
+    events_tx: &EventIngressSender,
+    build_result: HydrationBuildResult,
+) -> Result<(), &'static str> {
+    match build_result.result {
+        Ok(snapshot) => send_control(
+            events_tx,
+            EventControlMessage::DeliverSnapshot(DeliverSnapshot {
+                client_id: build_result.request.client_id,
+                client_command_id: build_result.request.client_command_id,
+                snapshot,
+            }),
+        )
+        .await
+        .map_err(|_| "delivering client snapshot"),
+        Err(error) => {
+            let notice = DeliverNotice {
+                client_id: build_result.request.client_id.clone(),
+                client_command_id: build_result.request.client_command_id.clone(),
+                notice: ClientNotice {
+                    level: ClientNoticeLevel::Error,
+                    message_text: format!("client snapshot build failed: {error:?}"),
+                },
+            };
+            send_control(events_tx, EventControlMessage::DeliverNotice(notice))
+                .await
+                .map_err(|_| "delivering client hydration failure notice")?;
+
+            send_control(
+                events_tx,
+                EventControlMessage::DetachClient(DetachClient {
+                    client_id: build_result.request.client_id,
+                    client_command_id: build_result.request.client_command_id,
+                    reason: DetachReason::DeliveryFailed,
+                }),
+            )
+            .await
+            .map_err(|_| "detaching failed client hydration")
+        }
+    }
+}
+
+async fn send_control(
+    events_tx: &EventIngressSender,
+    control: EventControlMessage,
+) -> Result<(), mpsc::error::SendError<EventIngress>> {
+    events_tx.send(EventIngress::Control(control)).await
 }

--- a/crates/client-sync/src/lib.rs
+++ b/crates/client-sync/src/lib.rs
@@ -99,6 +99,9 @@ pub fn spawn_client_sync(
 
         loop {
             tokio::select! {
+                biased;
+                // NOTE: Queued controls are applied before builder results. This preserves
+                // replacement, cancellation, and shutdown decisions that reached client-sync first.
                 message = ingress_rx.recv() => {
                     match message {
                         Some(ClientSyncIngress::StartHydration(begin)) => {

--- a/crates/client-sync/src/lib.rs
+++ b/crates/client-sync/src/lib.rs
@@ -1,0 +1,101 @@
+#![doc = include_str!("../README.md")]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use selvedge_command_model::{
+    BeginClientHydration, ClientCommandId, ClientId, ClientSnapshot, ClientSubscription,
+    EventIngressSender,
+};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+#[derive(Clone)]
+pub struct ClientSyncStartArgs {
+    pub events_tx: EventIngressSender,
+    pub snapshot_builder: Arc<dyn ClientSnapshotBuilder>,
+    pub ingress_capacity: usize,
+}
+
+#[derive(Debug)]
+pub struct ClientSyncHandle {
+    pub ingress_tx: ClientSyncSender,
+    pub join_handle: JoinHandle<ClientSyncExitStatus>,
+}
+
+pub type ClientSyncSender = mpsc::Sender<ClientSyncIngress>;
+
+#[derive(Debug)]
+pub enum ClientSyncIngress {
+    StartHydration(BeginClientHydration),
+    CancelHydration(CancelHydration),
+    Shutdown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CancelHydration {
+    pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClientSyncExitStatus {
+    Stopped,
+    IngressClosed,
+    Fatal(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpawnClientSyncError {
+    InvalidIngressCapacity,
+    TokioSpawnFailed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClientSyncError {
+    EventsMailboxClosed,
+    SnapshotBuildFailed(String),
+    RequestCancelled,
+    StaleHydrationResult,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientSnapshotBuildRequest {
+    pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
+    pub subscription: ClientSubscription,
+}
+
+pub type ClientSnapshotBuildFuture =
+    Pin<Box<dyn Future<Output = Result<ClientSnapshot, ClientSyncError>> + Send>>;
+
+pub trait ClientSnapshotBuilder: Send + Sync + 'static {
+    fn build_snapshot(&self, request: ClientSnapshotBuildRequest) -> ClientSnapshotBuildFuture;
+}
+
+pub fn spawn_client_sync(
+    args: ClientSyncStartArgs,
+) -> Result<ClientSyncHandle, SpawnClientSyncError> {
+    if args.ingress_capacity == 0 {
+        return Err(SpawnClientSyncError::InvalidIngressCapacity);
+    }
+
+    let (ingress_tx, mut ingress_rx) = mpsc::channel(args.ingress_capacity);
+    let _events_tx = args.events_tx;
+    let _snapshot_builder = args.snapshot_builder;
+    let join_handle = tokio::spawn(async move {
+        while let Some(message) = ingress_rx.recv().await {
+            if matches!(message, ClientSyncIngress::Shutdown) {
+                return ClientSyncExitStatus::Stopped;
+            }
+        }
+
+        ClientSyncExitStatus::IngressClosed
+    });
+
+    Ok(ClientSyncHandle {
+        ingress_tx,
+        join_handle,
+    })
+}

--- a/crates/client-sync/tests/client_sync_contract.rs
+++ b/crates/client-sync/tests/client_sync_contract.rs
@@ -1,6 +1,5 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
+use std::collections::{BTreeSet, VecDeque};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use selvedge_client_sync::{
     CancelHydration, ClientSnapshotBuildFuture, ClientSnapshotBuildRequest, ClientSnapshotBuilder,
@@ -8,110 +7,512 @@ use selvedge_client_sync::{
     SpawnClientSyncError, spawn_client_sync,
 };
 use selvedge_command_model::{
-    ClientCommandId, ClientId, ClientSnapshot, ClientSubscription, DetailLevel, EventIngress,
-    EventIngressSender, TaskScope,
+    BeginClientHydration, ClientCommandId, ClientFrame, ClientId, ClientNoticeLevel,
+    ClientSnapshot, ClientSubscription, DetachReason, DetailLevel, EventControlMessage,
+    EventIngress, TaskScope,
 };
+use selvedge_domain_model::UnixTs;
+use tokio::sync::{Mutex as AsyncMutex, mpsc, oneshot};
+use tokio::time::{Duration, timeout};
 
-#[test]
-fn snapshot_builder_trait_returns_boxed_snapshot_future() {
-    let builder = StaticSnapshotBuilder;
-    let request = build_request("client-1", "attach-1");
-    let future = builder.build_snapshot(request);
+static TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
 
-    let _future: ClientSnapshotBuildFuture = future;
+#[tokio::test]
+async fn successful_hydration_sends_begin_before_snapshot() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Ready(Ok(
+        empty_snapshot(),
+    ))]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder.clone(),
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send start");
+
+    let begin = recv_control(&mut events_rx).await;
+    assert_begin(&begin, "client-1", "attach-1");
+    let snapshot = recv_control(&mut events_rx).await;
+    assert_snapshot(&snapshot, "client-1", "attach-1");
+    assert_eq!(builder.requests(), vec![request("client-1", "attach-1")]);
+
+    shutdown(handle).await;
 }
 
 #[tokio::test]
-async fn spawn_client_sync_exposes_ingress_handle_and_shutdown_status() {
-    let args = ClientSyncStartArgs {
-        events_tx: event_sender(),
-        snapshot_builder: Arc::new(StaticSnapshotBuilder),
-        ingress_capacity: 4,
-    };
+async fn builder_failure_sends_error_notice_then_detach() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Ready(Err(
+        ClientSyncError::SnapshotBuildFailed("db unavailable".to_owned()),
+    ))]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder,
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
 
-    let handle = spawn_client_sync(args).expect("valid client-sync start args");
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send start");
+
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-1");
+    let notice = recv_control(&mut events_rx).await;
+    match notice {
+        EventControlMessage::DeliverNotice(notice) => {
+            assert_eq!(notice.client_id, ClientId("client-1".to_owned()));
+            assert_eq!(
+                notice.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+            assert_eq!(notice.notice.level, ClientNoticeLevel::Error);
+            assert!(notice.notice.message_text.contains("db unavailable"));
+        }
+        other => panic!("expected notice, got {other:?}"),
+    }
+    let detach = recv_control(&mut events_rx).await;
+    match detach {
+        EventControlMessage::DetachClient(detach) => {
+            assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+            assert_eq!(
+                detach.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+            assert_eq!(detach.reason, DetachReason::DeliveryFailed);
+        }
+        other => panic!("expected detach, got {other:?}"),
+    }
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn begin_send_failure_does_not_call_builder() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, events_rx) = mpsc::channel(1);
+    drop(events_rx);
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Ready(Ok(
+        empty_snapshot(),
+    ))]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder.clone(),
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send start");
+
+    let status = handle.join_handle.await.expect("join client sync");
+    assert!(matches!(
+        status,
+        ClientSyncExitStatus::Fatal(message)
+            if message.contains("beginning client hydration")
+    ));
+    assert!(builder.requests().is_empty());
+}
+
+#[tokio::test]
+async fn snapshot_delivery_send_failure_is_fatal() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let (release_tx, release_rx) = oneshot::channel();
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Wait(release_rx)]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder,
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send start");
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-1");
+    drop(events_rx);
+
+    release_tx
+        .send(Ok(empty_snapshot()))
+        .expect("release builder");
+
+    expect_fatal_contains(handle, "delivering client snapshot").await;
+}
+
+#[tokio::test]
+async fn builder_failure_notice_send_failure_is_fatal() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let (release_tx, release_rx) = oneshot::channel();
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Wait(release_rx)]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder,
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send start");
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-1");
+    drop(events_rx);
+
+    release_tx
+        .send(Err(ClientSyncError::SnapshotBuildFailed(
+            "db unavailable".to_owned(),
+        )))
+        .expect("release builder");
+
+    expect_fatal_contains(handle, "delivering client hydration failure notice").await;
+}
+
+#[tokio::test]
+async fn duplicate_same_command_does_not_start_second_builder() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let (_release_tx, release_rx) = oneshot::channel();
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Wait(release_rx)]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder.clone(),
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send first start");
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send duplicate start");
+
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-1");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(builder.requests().len(), 1);
+    assert!(recv_control_timeout(&mut events_rx).await.is_none());
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn new_command_replaces_old_late_builder_result() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let (old_tx, old_rx) = oneshot::channel();
+    let (new_tx, new_rx) = oneshot::channel();
+    let builder = Arc::new(RecordingBuilder::new(vec![
+        BuildAction::Wait(old_rx),
+        BuildAction::Wait(new_rx),
+    ]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder,
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send old start");
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-1");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-2",
+        )))
+        .await
+        .expect("send new start");
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-2");
+
+    old_tx.send(Ok(empty_snapshot())).expect("release old");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert!(recv_control_timeout(&mut events_rx).await.is_none());
+
+    new_tx.send(Ok(empty_snapshot())).expect("release new");
+    assert_snapshot(&recv_control(&mut events_rx).await, "client-1", "attach-2");
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn cancel_drops_late_builder_result() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let (release_tx, release_rx) = oneshot::channel();
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Wait(release_rx)]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder,
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send start");
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-1");
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::CancelHydration(CancelHydration {
+            client_id: ClientId("client-1".to_owned()),
+            client_command_id: ClientCommandId("attach-1".to_owned()),
+        }))
+        .await
+        .expect("send cancel");
+
+    release_tx
+        .send(Ok(empty_snapshot()))
+        .expect("release builder");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert!(recv_control_timeout(&mut events_rx).await.is_none());
+
+    shutdown(handle).await;
+}
+
+#[tokio::test]
+async fn shutdown_stops_task_and_discards_late_builder_result() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, mut events_rx) = mpsc::channel(8);
+    let (release_tx, release_rx) = oneshot::channel();
+    let builder = Arc::new(RecordingBuilder::new(vec![BuildAction::Wait(release_rx)]));
+    let handle = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder,
+        ingress_capacity: 8,
+    })
+    .expect("spawn client sync");
+
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::StartHydration(begin(
+            "client-1", "attach-1",
+        )))
+        .await
+        .expect("send start");
+    assert_begin(&recv_control(&mut events_rx).await, "client-1", "attach-1");
     handle
         .ingress_tx
         .send(ClientSyncIngress::Shutdown)
         .await
         .expect("send shutdown");
-
     assert_eq!(
-        handle.join_handle.await.expect("join client-sync task"),
+        handle.join_handle.await.expect("join client sync"),
         ClientSyncExitStatus::Stopped
     );
+
+    release_tx
+        .send(Ok(empty_snapshot()))
+        .expect("release builder");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert!(recv_control_timeout(&mut events_rx).await.is_none());
 }
 
-#[test]
-fn spawn_client_sync_rejects_empty_ingress_capacity() {
-    let args = ClientSyncStartArgs {
-        events_tx: event_sender(),
-        snapshot_builder: Arc::new(StaticSnapshotBuilder),
+#[tokio::test]
+async fn invalid_ingress_capacity_is_rejected() {
+    let _guard = TEST_LOCK.lock().await;
+    let (events_tx, _events_rx) = mpsc::channel(8);
+    let builder = Arc::new(RecordingBuilder::new(Vec::new()));
+
+    let result = spawn_client_sync(ClientSyncStartArgs {
+        events_tx,
+        snapshot_builder: builder,
         ingress_capacity: 0,
-    };
+    });
 
     assert!(matches!(
-        spawn_client_sync(args),
+        result,
         Err(SpawnClientSyncError::InvalidIngressCapacity)
     ));
 }
 
-#[test]
-fn client_sync_ingress_carries_cancellation_identity() {
-    let cancel = CancelHydration {
-        client_id: ClientId("client-1".to_owned()),
-        client_command_id: ClientCommandId("attach-1".to_owned()),
-    };
+enum BuildAction {
+    Ready(Result<ClientSnapshot, ClientSyncError>),
+    Wait(oneshot::Receiver<Result<ClientSnapshot, ClientSyncError>>),
+}
 
-    match ClientSyncIngress::CancelHydration(cancel) {
-        ClientSyncIngress::CancelHydration(cancel) => {
-            assert_eq!(cancel.client_id, ClientId("client-1".to_owned()));
-            assert_eq!(
-                cancel.client_command_id,
-                ClientCommandId("attach-1".to_owned())
-            );
+struct RecordingBuilder {
+    actions: Mutex<VecDeque<BuildAction>>,
+    requests: Mutex<Vec<ClientSnapshotBuildRequest>>,
+}
+
+impl RecordingBuilder {
+    fn new(actions: Vec<BuildAction>) -> Self {
+        Self {
+            actions: Mutex::new(actions.into()),
+            requests: Mutex::new(Vec::new()),
         }
-        _ => panic!("unexpected ingress"),
+    }
+
+    fn requests(&self) -> Vec<ClientSnapshotBuildRequest> {
+        self.requests.lock().expect("requests lock").clone()
     }
 }
 
-struct StaticSnapshotBuilder;
-
-impl ClientSnapshotBuilder for StaticSnapshotBuilder {
+impl ClientSnapshotBuilder for RecordingBuilder {
     fn build_snapshot(&self, request: ClientSnapshotBuildRequest) -> ClientSnapshotBuildFuture {
-        assert_eq!(request.client_id.0.trim(), request.client_id.0);
-        Box::pin(snapshot_future())
+        self.requests.lock().expect("requests lock").push(request);
+        let action = self
+            .actions
+            .lock()
+            .expect("actions lock")
+            .pop_front()
+            .expect("builder action");
+
+        Box::pin(async move {
+            match action {
+                BuildAction::Ready(result) => result,
+                BuildAction::Wait(rx) => rx.await.unwrap_or(Err(ClientSyncError::RequestCancelled)),
+            }
+        })
     }
 }
 
-fn snapshot_future() -> Pin<Box<dyn Future<Output = Result<ClientSnapshot, ClientSyncError>> + Send>>
-{
-    Box::pin(async {
-        Ok(ClientSnapshot {
-            generated_at: selvedge_domain_model::UnixTs(1),
-            tasks: Vec::new(),
-            task_parent_edges: Vec::new(),
-            history_nodes: Vec::new(),
-            task_versions: Vec::new(),
-        })
-    })
+fn begin(client_id: &str, command_id: &str) -> BeginClientHydration {
+    let (outbound, _rx) = mpsc::channel::<ClientFrame>(8);
+    BeginClientHydration {
+        client_id: ClientId(client_id.to_owned()),
+        client_command_id: ClientCommandId(command_id.to_owned()),
+        outbound,
+        subscription: subscription(),
+    }
 }
 
-fn build_request(client_id: &str, client_command_id: &str) -> ClientSnapshotBuildRequest {
+fn request(client_id: &str, command_id: &str) -> ClientSnapshotBuildRequest {
     ClientSnapshotBuildRequest {
         client_id: ClientId(client_id.to_owned()),
-        client_command_id: ClientCommandId(client_command_id.to_owned()),
-        subscription: ClientSubscription {
-            task_scope: TaskScope::AllTasks,
-            detail_level: DetailLevel::Summary,
-            include_model_call_status: false,
-            include_tool_execution_status: false,
-            include_debug_notices: false,
-        },
+        client_command_id: ClientCommandId(command_id.to_owned()),
+        subscription: subscription(),
     }
 }
 
-fn event_sender() -> EventIngressSender {
-    let (tx, _rx) = tokio::sync::mpsc::channel::<EventIngress>(4);
-    tx
+fn subscription() -> ClientSubscription {
+    ClientSubscription {
+        task_scope: TaskScope::TaskIds(BTreeSet::new()),
+        detail_level: DetailLevel::Summary,
+        include_model_call_status: false,
+        include_tool_execution_status: false,
+        include_debug_notices: false,
+    }
+}
+
+fn empty_snapshot() -> ClientSnapshot {
+    ClientSnapshot {
+        generated_at: UnixTs(1),
+        tasks: Vec::new(),
+        task_parent_edges: Vec::new(),
+        history_nodes: Vec::new(),
+        task_versions: Vec::new(),
+    }
+}
+
+async fn recv_control(rx: &mut mpsc::Receiver<EventIngress>) -> EventControlMessage {
+    match timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("event timeout")
+        .expect("event")
+    {
+        EventIngress::Control(control) => control,
+        EventIngress::Raw(_) => panic!("expected control event"),
+    }
+}
+
+async fn recv_control_timeout(
+    rx: &mut mpsc::Receiver<EventIngress>,
+) -> Option<EventControlMessage> {
+    match timeout(Duration::from_millis(10), rx.recv()).await {
+        Ok(Some(EventIngress::Control(control))) => Some(control),
+        Ok(Some(EventIngress::Raw(_))) => panic!("expected control event"),
+        Ok(None) | Err(_) => None,
+    }
+}
+
+fn assert_begin(control: &EventControlMessage, client_id: &str, command_id: &str) {
+    match control {
+        EventControlMessage::BeginClientHydration(begin) => {
+            assert_eq!(begin.client_id, ClientId(client_id.to_owned()));
+            assert_eq!(
+                begin.client_command_id,
+                ClientCommandId(command_id.to_owned())
+            );
+        }
+        other => panic!("expected begin, got {other:?}"),
+    }
+}
+
+fn assert_snapshot(control: &EventControlMessage, client_id: &str, command_id: &str) {
+    match control {
+        EventControlMessage::DeliverSnapshot(snapshot) => {
+            assert_eq!(snapshot.client_id, ClientId(client_id.to_owned()));
+            assert_eq!(
+                snapshot.client_command_id,
+                ClientCommandId(command_id.to_owned())
+            );
+        }
+        other => panic!("expected snapshot, got {other:?}"),
+    }
+}
+
+async fn shutdown(handle: selvedge_client_sync::ClientSyncHandle) {
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::Shutdown)
+        .await
+        .expect("send shutdown");
+    assert_eq!(
+        handle.join_handle.await.expect("join client sync"),
+        ClientSyncExitStatus::Stopped
+    );
+}
+
+async fn expect_fatal_contains(handle: selvedge_client_sync::ClientSyncHandle, expected: &str) {
+    let status = handle.join_handle.await.expect("join client sync");
+    assert!(matches!(
+        status,
+        ClientSyncExitStatus::Fatal(message) if message.contains(expected)
+    ));
 }

--- a/crates/client-sync/tests/client_sync_contract.rs
+++ b/crates/client-sync/tests/client_sync_contract.rs
@@ -1,0 +1,117 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use selvedge_client_sync::{
+    CancelHydration, ClientSnapshotBuildFuture, ClientSnapshotBuildRequest, ClientSnapshotBuilder,
+    ClientSyncError, ClientSyncExitStatus, ClientSyncIngress, ClientSyncStartArgs,
+    SpawnClientSyncError, spawn_client_sync,
+};
+use selvedge_command_model::{
+    ClientCommandId, ClientId, ClientSnapshot, ClientSubscription, DetailLevel, EventIngress,
+    EventIngressSender, TaskScope,
+};
+
+#[test]
+fn snapshot_builder_trait_returns_boxed_snapshot_future() {
+    let builder = StaticSnapshotBuilder;
+    let request = build_request("client-1", "attach-1");
+    let future = builder.build_snapshot(request);
+
+    let _future: ClientSnapshotBuildFuture = future;
+}
+
+#[tokio::test]
+async fn spawn_client_sync_exposes_ingress_handle_and_shutdown_status() {
+    let args = ClientSyncStartArgs {
+        events_tx: event_sender(),
+        snapshot_builder: Arc::new(StaticSnapshotBuilder),
+        ingress_capacity: 4,
+    };
+
+    let handle = spawn_client_sync(args).expect("valid client-sync start args");
+    handle
+        .ingress_tx
+        .send(ClientSyncIngress::Shutdown)
+        .await
+        .expect("send shutdown");
+
+    assert_eq!(
+        handle.join_handle.await.expect("join client-sync task"),
+        ClientSyncExitStatus::Stopped
+    );
+}
+
+#[test]
+fn spawn_client_sync_rejects_empty_ingress_capacity() {
+    let args = ClientSyncStartArgs {
+        events_tx: event_sender(),
+        snapshot_builder: Arc::new(StaticSnapshotBuilder),
+        ingress_capacity: 0,
+    };
+
+    assert!(matches!(
+        spawn_client_sync(args),
+        Err(SpawnClientSyncError::InvalidIngressCapacity)
+    ));
+}
+
+#[test]
+fn client_sync_ingress_carries_cancellation_identity() {
+    let cancel = CancelHydration {
+        client_id: ClientId("client-1".to_owned()),
+        client_command_id: ClientCommandId("attach-1".to_owned()),
+    };
+
+    match ClientSyncIngress::CancelHydration(cancel) {
+        ClientSyncIngress::CancelHydration(cancel) => {
+            assert_eq!(cancel.client_id, ClientId("client-1".to_owned()));
+            assert_eq!(
+                cancel.client_command_id,
+                ClientCommandId("attach-1".to_owned())
+            );
+        }
+        _ => panic!("unexpected ingress"),
+    }
+}
+
+struct StaticSnapshotBuilder;
+
+impl ClientSnapshotBuilder for StaticSnapshotBuilder {
+    fn build_snapshot(&self, request: ClientSnapshotBuildRequest) -> ClientSnapshotBuildFuture {
+        assert_eq!(request.client_id.0.trim(), request.client_id.0);
+        Box::pin(snapshot_future())
+    }
+}
+
+fn snapshot_future() -> Pin<Box<dyn Future<Output = Result<ClientSnapshot, ClientSyncError>> + Send>>
+{
+    Box::pin(async {
+        Ok(ClientSnapshot {
+            generated_at: selvedge_domain_model::UnixTs(1),
+            tasks: Vec::new(),
+            task_parent_edges: Vec::new(),
+            history_nodes: Vec::new(),
+            task_versions: Vec::new(),
+        })
+    })
+}
+
+fn build_request(client_id: &str, client_command_id: &str) -> ClientSnapshotBuildRequest {
+    ClientSnapshotBuildRequest {
+        client_id: ClientId(client_id.to_owned()),
+        client_command_id: ClientCommandId(client_command_id.to_owned()),
+        subscription: ClientSubscription {
+            task_scope: TaskScope::AllTasks,
+            detail_level: DetailLevel::Summary,
+            include_model_call_status: false,
+            include_tool_execution_status: false,
+            include_debug_notices: false,
+        },
+    }
+}
+
+fn event_sender() -> EventIngressSender {
+    let (tx, _rx) = tokio::sync::mpsc::channel::<EventIngress>(4);
+    tx
+}

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -14,5 +14,6 @@ This crate is not for network access, database access, filesystem access, provid
 `CoreOutputEnvelope` carries `task_id` for task-based router routing.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
+`DetachReason::ClientRequested` represents an explicit detach command. `DetachReason::ClientDisconnected` represents the server observing the attach stream close.
 
 Factory output envelopes are returned by synchronous factory calls. Runtime inventory is supplied to the factory by the router from router-owned live and pending task runtime state.

--- a/crates/command-model/README.md
+++ b/crates/command-model/README.md
@@ -14,6 +14,7 @@ This crate is not for network access, database access, filesystem access, provid
 `CoreOutputEnvelope` carries `task_id` for task-based router routing.
 
 `EventIngressSender` is owned by the router. `ClientFrameSender` is supplied by the router for a single client session. Delivery sequencing and hydration buffering live in `selvedge-events`.
+`RouterCommand::AttachClient` carries an admission responder. The router must answer it after events reserves the client session slot; server uses that response as the attach accepted boundary before starting client-sync hydration.
 `DetachReason::ClientRequested` represents an explicit detach command. `DetachReason::ClientDisconnected` represents the server observing the attach stream close.
 
 Factory output envelopes are returned by synchronous factory calls. Runtime inventory is supplied to the factory by the router from router-owned live and pending task runtime state.

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -516,6 +516,7 @@ pub enum ToolExecutionStatusPhase {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DetachReason {
     ClientRequested,
+    ClientDisconnected,
     ReplacedByNewHydration,
     DeliveryFailed,
     HydrationBufferOverflow,

--- a/crates/command-model/src/lib.rs
+++ b/crates/command-model/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::{Mutex, Notify, mpsc};
+use tokio::sync::{Mutex, Notify, mpsc, oneshot};
 
 use selvedge_domain_model::{
     ApiDomainValidationError, ConversationPath, FunctionCallId, HistoryNodeId, MessageRole,
@@ -86,6 +86,8 @@ pub type TaskRuntimeSender = mpsc::Sender<TaskRuntimeCommand>;
 pub type ModelCallRequest = ModelCallDispatchRequest;
 pub type EventIngressSender = mpsc::Sender<EventIngress>;
 pub type ClientFrameSender = mpsc::Sender<ClientFrame>;
+pub type RouterAttachAdmissionSender = oneshot::Sender<RouterAttachAdmissionResult>;
+pub type EventClientReservationSender = oneshot::Sender<EventClientReservationResult>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FactoryEffectId(pub String);
@@ -104,6 +106,7 @@ pub enum RouterCommand {
         client_command_id: ClientCommandId,
         outbound: ClientFrameSender,
         subscription: ClientSubscription,
+        admission_tx: RouterAttachAdmissionSender,
     },
     DetachClient {
         client_id: ClientId,
@@ -132,6 +135,14 @@ pub enum RouterCommand {
         parent_task_id: TaskId,
         child_cursor_node_id: HistoryNodeId,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RouterAttachAdmissionResult {
+    Accepted,
+    DuplicateAttach,
+    ClientRegistryFull,
+    EventsMailboxClosed,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -237,11 +248,26 @@ pub enum EventIngress {
 
 #[derive(Debug)]
 pub enum EventControlMessage {
+    ReserveClientSession(ReserveClientSession),
     BeginClientHydration(BeginClientHydration),
     DeliverSnapshot(DeliverSnapshot),
     DeliverNotice(DeliverNotice),
     UpdateSubscription(UpdateSubscription),
     DetachClient(DetachClient),
+}
+
+#[derive(Debug)]
+pub struct ReserveClientSession {
+    pub client_id: ClientId,
+    pub client_command_id: ClientCommandId,
+    pub result_tx: EventClientReservationSender,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EventClientReservationResult {
+    Reserved,
+    DuplicateAttach,
+    ClientRegistryFull,
 }
 
 #[derive(Debug)]

--- a/crates/command-model/tests/command_contract.rs
+++ b/crates/command-model/tests/command_contract.rs
@@ -264,6 +264,7 @@ fn router_command_validation_enforces_envelope_and_task_payload_contract() {
         include_tool_execution_status: true,
         include_debug_notices: true,
     };
+    let (admission_tx, _admission_rx) = tokio::sync::oneshot::channel();
 
     let attach = RouterCommandEnvelope {
         client_id: Some(ClientId("client-1".to_owned())),
@@ -273,6 +274,7 @@ fn router_command_validation_enforces_envelope_and_task_payload_contract() {
             client_command_id: ClientCommandId("attach-1".to_owned()),
             outbound,
             subscription,
+            admission_tx,
         },
     };
     validate_router_command(&attach).expect("valid attach command");

--- a/crates/events/README.md
+++ b/crates/events/README.md
@@ -5,3 +5,5 @@ This crate runs the client outbound event aggregator task.
 Use it from the router to register client outbound channels, deliver attach snapshots, update subscriptions, detach clients, and fan out raw command-model events as client frames.
 
 This crate only receives router-mediated ingress and only sends `ClientFrame` values through router-provided client channels. It does not access the database, filesystem, network, API providers, tools, or task runtimes.
+
+Client session capacity is admitted by `ReserveClientSession`. A matching `BeginClientHydration` consumes the reservation and installs or replaces the active session; stale begin, snapshot, notice, update, and detach controls are filtered by `ClientCommandId`.

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -118,25 +118,12 @@ impl EventsTask {
     }
 
     fn begin_hydration(&mut self, begin: BeginClientHydration) {
-        if self
-            .reservations
-            .get(&begin.client_id)
-            .is_some_and(|reserved| reserved != &begin.client_command_id)
-        {
-            return;
-        }
-
         let reserved = self.reservations.get(&begin.client_id) == Some(&begin.client_command_id);
-        if !self.sessions.contains_key(&begin.client_id)
-            && !reserved
-            && self.sessions.len() + self.reservations.len() >= self.client_registry_capacity
-        {
+        if !reserved {
             return;
         }
 
-        if reserved {
-            self.reservations.remove(&begin.client_id);
-        }
+        self.reservations.remove(&begin.client_id);
         self.sessions.insert(
             begin.client_id,
             ClientSession {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -96,6 +96,14 @@ impl EventsTask {
     }
 
     fn reserve_client_session(&mut self, reservation: ReserveClientSession) {
+        // NOTE: A replacement reservation for an active ClientId shares that
+        // ClientId's registry slot until BeginClientHydration installs it.
+        let occupied_client_slots = self.sessions.len()
+            + self
+                .reservations
+                .keys()
+                .filter(|client_id| !self.sessions.contains_key(*client_id))
+                .count();
         let result = if self
             .sessions
             .get(&reservation.client_id)
@@ -105,7 +113,7 @@ impl EventsTask {
             EventClientReservationResult::DuplicateAttach
         } else if !self.sessions.contains_key(&reservation.client_id)
             && !self.reservations.contains_key(&reservation.client_id)
-            && self.sessions.len() + self.reservations.len() >= self.client_registry_capacity
+            && occupied_client_slots >= self.client_registry_capacity
         {
             EventClientReservationResult::ClientRegistryFull
         } else {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -60,7 +60,7 @@ pub fn spawn_events_task(args: EventsStartArgs) -> Result<EventsHandle, SpawnEve
 
 struct EventsTask {
     sessions: HashMap<ClientId, ClientSession>,
-    reservations: HashMap<ClientId, selvedge_command_model::ClientCommandId>,
+    reservations: HashMap<ClientId, Vec<selvedge_command_model::ClientCommandId>>,
     client_registry_capacity: usize,
     hydration_buffer_capacity: usize,
 }
@@ -113,7 +113,11 @@ impl EventsTask {
             .sessions
             .get(&client_id)
             .is_some_and(|session| session.client_command_id == client_command_id)
-            || self.reservations.get(&client_id) == Some(&client_command_id)
+            || self
+                .reservations
+                .get(&client_id)
+                .and_then(|stack| stack.last())
+                == Some(&client_command_id)
         {
             EventClientReservationResult::DuplicateAttach
         } else if !self.sessions.contains_key(&client_id)
@@ -123,20 +127,30 @@ impl EventsTask {
             EventClientReservationResult::ClientRegistryFull
         } else {
             self.reservations
-                .insert(client_id.clone(), client_command_id.clone());
+                .entry(client_id.clone())
+                .or_default()
+                .push(client_command_id.clone());
             EventClientReservationResult::Reserved
         };
 
         if result_tx.send(result.clone()).is_err()
             && result == EventClientReservationResult::Reserved
-            && self.reservations.get(&client_id) == Some(&client_command_id)
+            && self
+                .reservations
+                .get(&client_id)
+                .and_then(|stack| stack.last())
+                == Some(&client_command_id)
         {
-            self.reservations.remove(&client_id);
+            self.pop_current_reservation(&client_id);
         }
     }
 
     fn begin_hydration(&mut self, begin: BeginClientHydration) {
-        let reserved = self.reservations.get(&begin.client_id) == Some(&begin.client_command_id);
+        let reserved = self
+            .reservations
+            .get(&begin.client_id)
+            .and_then(|stack| stack.last())
+            == Some(&begin.client_command_id);
         if !reserved {
             return;
         }
@@ -242,8 +256,13 @@ impl EventsTask {
     }
 
     fn detach_client(&mut self, detach: selvedge_command_model::DetachClient) {
-        if self.reservations.get(&detach.client_id) == Some(&detach.client_command_id) {
-            self.reservations.remove(&detach.client_id);
+        if self
+            .reservations
+            .get(&detach.client_id)
+            .and_then(|stack| stack.last())
+            == Some(&detach.client_command_id)
+        {
+            self.pop_current_reservation(&detach.client_id);
         }
 
         let Some(session) = self.sessions.get(&detach.client_id) else {
@@ -255,6 +274,16 @@ impl EventsTask {
         }
 
         self.sessions.remove(&detach.client_id);
+    }
+
+    fn pop_current_reservation(&mut self, client_id: &ClientId) {
+        let Some(stack) = self.reservations.get_mut(client_id) else {
+            return;
+        };
+        stack.pop();
+        if stack.is_empty() {
+            self.reservations.remove(client_id);
+        }
     }
 
     async fn handle_raw(&mut self, raw: RawEvent) {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -282,6 +282,8 @@ impl EventsTask {
             == Some(&detach.client_command_id)
         {
             self.pop_current_reservation(&detach.client_id);
+        } else {
+            self.remove_hidden_reservation(&detach.client_id, &detach.client_command_id);
         }
 
         let Some(session) = self.sessions.get(&detach.client_id) else {
@@ -317,6 +319,28 @@ impl EventsTask {
             restored_command_id.expect("restored command id"),
         )) {
             self.install_begin_hydration(begin);
+        }
+    }
+
+    fn remove_hidden_reservation(
+        &mut self,
+        client_id: &ClientId,
+        client_command_id: &selvedge_command_model::ClientCommandId,
+    ) {
+        let Some(stack) = self.reservations.get_mut(client_id) else {
+            return;
+        };
+        let Some(index) = stack
+            .iter()
+            .position(|stacked_command_id| stacked_command_id == client_command_id)
+        else {
+            return;
+        };
+        stack.remove(index);
+        self.pending_begins
+            .remove(&(client_id.clone(), client_command_id.clone()));
+        if stack.is_empty() {
+            self.reservations.remove(client_id);
         }
     }
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -119,8 +119,7 @@ impl EventsTask {
             || self
                 .reservations
                 .get(&client_id)
-                .and_then(|stack| stack.last())
-                == Some(&client_command_id)
+                .is_some_and(|stack| stack.contains(&client_command_id))
         {
             EventClientReservationResult::DuplicateAttach
         } else if !self.sessions.contains_key(&client_id)

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -96,6 +96,11 @@ impl EventsTask {
     }
 
     fn reserve_client_session(&mut self, reservation: ReserveClientSession) {
+        let ReserveClientSession {
+            client_id,
+            client_command_id,
+            result_tx,
+        } = reservation;
         // NOTE: A replacement reservation for an active ClientId shares that
         // ClientId's registry slot until BeginClientHydration installs it.
         let occupied_client_slots = self.sessions.len()
@@ -106,23 +111,28 @@ impl EventsTask {
                 .count();
         let result = if self
             .sessions
-            .get(&reservation.client_id)
-            .is_some_and(|session| session.client_command_id == reservation.client_command_id)
-            || self.reservations.get(&reservation.client_id) == Some(&reservation.client_command_id)
+            .get(&client_id)
+            .is_some_and(|session| session.client_command_id == client_command_id)
+            || self.reservations.get(&client_id) == Some(&client_command_id)
         {
             EventClientReservationResult::DuplicateAttach
-        } else if !self.sessions.contains_key(&reservation.client_id)
-            && !self.reservations.contains_key(&reservation.client_id)
+        } else if !self.sessions.contains_key(&client_id)
+            && !self.reservations.contains_key(&client_id)
             && occupied_client_slots >= self.client_registry_capacity
         {
             EventClientReservationResult::ClientRegistryFull
         } else {
             self.reservations
-                .insert(reservation.client_id, reservation.client_command_id);
+                .insert(client_id.clone(), client_command_id.clone());
             EventClientReservationResult::Reserved
         };
 
-        let _ = reservation.result_tx.send(result);
+        if result_tx.send(result.clone()).is_err()
+            && result == EventClientReservationResult::Reserved
+            && self.reservations.get(&client_id) == Some(&client_command_id)
+        {
+            self.reservations.remove(&client_id);
+        }
     }
 
     fn begin_hydration(&mut self, begin: BeginClientHydration) {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -5,8 +5,8 @@ use std::collections::{BTreeMap, HashMap};
 use selvedge_command_model::{
     BeginClientHydration, ClientEvent, ClientEventFrame, ClientFrame, ClientFrameSender, ClientId,
     ClientNoticeFrame, ClientSnapshot, ClientSnapshotFrame, ClientSubscription, DeliverNotice,
-    DeliverSnapshot, DetailLevel, EventControlMessage, EventIngress, EventIngressSender, RawEvent,
-    TaskId, TaskScope, UpdateSubscription,
+    DeliverSnapshot, DetailLevel, EventClientReservationResult, EventControlMessage, EventIngress,
+    EventIngressSender, RawEvent, ReserveClientSession, TaskId, TaskScope, UpdateSubscription,
 };
 use tokio::sync::mpsc::{self, error::TrySendError};
 
@@ -60,6 +60,7 @@ pub fn spawn_events_task(args: EventsStartArgs) -> Result<EventsHandle, SpawnEve
 
 struct EventsTask {
     sessions: HashMap<ClientId, ClientSession>,
+    reservations: HashMap<ClientId, selvedge_command_model::ClientCommandId>,
     client_registry_capacity: usize,
     hydration_buffer_capacity: usize,
 }
@@ -68,6 +69,7 @@ impl EventsTask {
     fn new(args: EventsStartArgs) -> Self {
         Self {
             sessions: HashMap::with_capacity(args.client_registry_capacity),
+            reservations: HashMap::with_capacity(args.client_registry_capacity),
             client_registry_capacity: args.client_registry_capacity,
             hydration_buffer_capacity: args.hydration_buffer_capacity,
         }
@@ -82,6 +84,9 @@ impl EventsTask {
 
     async fn handle_control(&mut self, control: EventControlMessage) {
         match control {
+            EventControlMessage::ReserveClientSession(reservation) => {
+                self.reserve_client_session(reservation)
+            }
             EventControlMessage::BeginClientHydration(begin) => self.begin_hydration(begin),
             EventControlMessage::DeliverSnapshot(snapshot) => self.deliver_snapshot(snapshot).await,
             EventControlMessage::DeliverNotice(notice) => self.deliver_notice(notice).await,
@@ -90,13 +95,48 @@ impl EventsTask {
         }
     }
 
+    fn reserve_client_session(&mut self, reservation: ReserveClientSession) {
+        let result = if self
+            .sessions
+            .get(&reservation.client_id)
+            .is_some_and(|session| session.client_command_id == reservation.client_command_id)
+            || self.reservations.get(&reservation.client_id) == Some(&reservation.client_command_id)
+        {
+            EventClientReservationResult::DuplicateAttach
+        } else if !self.sessions.contains_key(&reservation.client_id)
+            && !self.reservations.contains_key(&reservation.client_id)
+            && self.sessions.len() + self.reservations.len() >= self.client_registry_capacity
+        {
+            EventClientReservationResult::ClientRegistryFull
+        } else {
+            self.reservations
+                .insert(reservation.client_id, reservation.client_command_id);
+            EventClientReservationResult::Reserved
+        };
+
+        let _ = reservation.result_tx.send(result);
+    }
+
     fn begin_hydration(&mut self, begin: BeginClientHydration) {
-        if !self.sessions.contains_key(&begin.client_id)
-            && self.sessions.len() >= self.client_registry_capacity
+        if self
+            .reservations
+            .get(&begin.client_id)
+            .is_some_and(|reserved| reserved != &begin.client_command_id)
         {
             return;
         }
 
+        let reserved = self.reservations.get(&begin.client_id) == Some(&begin.client_command_id);
+        if !self.sessions.contains_key(&begin.client_id)
+            && !reserved
+            && self.sessions.len() + self.reservations.len() >= self.client_registry_capacity
+        {
+            return;
+        }
+
+        if reserved {
+            self.reservations.remove(&begin.client_id);
+        }
         self.sessions.insert(
             begin.client_id,
             ClientSession {
@@ -197,6 +237,10 @@ impl EventsTask {
     }
 
     fn detach_client(&mut self, detach: selvedge_command_model::DetachClient) {
+        if self.reservations.get(&detach.client_id) == Some(&detach.client_command_id) {
+            self.reservations.remove(&detach.client_id);
+        }
+
         let Some(session) = self.sessions.get(&detach.client_id) else {
             return;
         };

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -61,6 +61,8 @@ pub fn spawn_events_task(args: EventsStartArgs) -> Result<EventsHandle, SpawnEve
 struct EventsTask {
     sessions: HashMap<ClientId, ClientSession>,
     reservations: HashMap<ClientId, Vec<selvedge_command_model::ClientCommandId>>,
+    pending_begins:
+        HashMap<(ClientId, selvedge_command_model::ClientCommandId), BeginClientHydration>,
     client_registry_capacity: usize,
     hydration_buffer_capacity: usize,
 }
@@ -70,6 +72,7 @@ impl EventsTask {
         Self {
             sessions: HashMap::with_capacity(args.client_registry_capacity),
             reservations: HashMap::with_capacity(args.client_registry_capacity),
+            pending_begins: HashMap::new(),
             client_registry_capacity: args.client_registry_capacity,
             hydration_buffer_capacity: args.hydration_buffer_capacity,
         }
@@ -151,11 +154,28 @@ impl EventsTask {
             .get(&begin.client_id)
             .and_then(|stack| stack.last())
             == Some(&begin.client_command_id);
-        if !reserved {
+        if reserved {
+            self.install_begin_hydration(begin);
             return;
         }
 
-        self.reservations.remove(&begin.client_id);
+        let hidden_by_replacement = self
+            .reservations
+            .get(&begin.client_id)
+            .is_some_and(|stack| stack.contains(&begin.client_command_id));
+        if hidden_by_replacement {
+            self.pending_begins.insert(
+                (begin.client_id.clone(), begin.client_command_id.clone()),
+                begin,
+            );
+        }
+    }
+
+    fn install_begin_hydration(&mut self, begin: BeginClientHydration) {
+        let client_id = begin.client_id.clone();
+        self.reservations.remove(&client_id);
+        self.pending_begins
+            .retain(|(pending_client_id, _), _| pending_client_id != &client_id);
         self.sessions.insert(
             begin.client_id,
             ClientSession {
@@ -281,8 +301,23 @@ impl EventsTask {
             return;
         };
         stack.pop();
-        if stack.is_empty() {
+        let restored_command_id = if stack.is_empty() {
+            None
+        } else {
+            stack.last().cloned()
+        };
+        if restored_command_id.is_none() {
             self.reservations.remove(client_id);
+            self.pending_begins
+                .retain(|(pending_client_id, _), _| pending_client_id != client_id);
+            return;
+        }
+
+        if let Some(begin) = self.pending_begins.remove(&(
+            client_id.clone(),
+            restored_command_id.expect("restored command id"),
+        )) {
+            self.install_begin_hydration(begin);
         }
     }
 

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -396,6 +396,56 @@ async fn reservation_capacity_rejects_new_clients_after_limit() {
 }
 
 #[tokio::test]
+async fn replacement_reservation_shares_existing_client_capacity_slot() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 2,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, _rx) = mpsc::channel(8);
+
+    begin_named_client_with_command(
+        &handle.ingress_tx,
+        ClientId("client-1".to_owned()),
+        outbound,
+        ClientCommandId("attach-1".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-2".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-2".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-3".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::ClientRegistryFull
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
 async fn reserved_client_session_is_consumed_by_matching_begin() {
     let handle = spawn_events_task(EventsStartArgs {
         ingress_capacity: 8,

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -65,18 +65,7 @@ async fn hydrating_client_receives_snapshot_before_uncovered_buffered_events() {
     .expect("valid events task");
     let (outbound, mut outbound_rx) = mpsc::channel(8);
 
-    handle
-        .ingress_tx
-        .send(EventIngress::Control(
-            EventControlMessage::BeginClientHydration(BeginClientHydration {
-                client_id: client_id(),
-                client_command_id: ClientCommandId("attach-1".to_owned()),
-                outbound,
-                subscription: verbose_all_tasks(),
-            }),
-        ))
-        .await
-        .expect("send begin hydration");
+    begin_client(&handle.ingress_tx, outbound, verbose_all_tasks()).await;
 
     handle
         .ingress_tx
@@ -450,6 +439,57 @@ async fn reserved_client_session_is_consumed_by_matching_begin() {
         tokio::time::timeout(Duration::from_secs(1), blocked_rx.recv())
             .await
             .expect("blocked client channel closes")
+            .is_none()
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn begin_without_matching_reservation_does_not_create_session() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut rx) = mpsc::channel(8);
+
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DetachClient(
+            DetachClient {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                reason: DetachReason::ClientDisconnected,
+            },
+        )))
+        .await
+        .expect("send detach");
+    begin_named_client_with_command_without_reservation(
+        &handle.ingress_tx,
+        ClientId("client-1".to_owned()),
+        outbound,
+        ClientCommandId("attach-1".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("client-1".to_owned())).await;
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("unreserved begin channel closes")
             .is_none()
     );
 
@@ -879,6 +919,24 @@ async fn begin_named_client(
 }
 
 async fn begin_named_client_with_command(
+    ingress_tx: &selvedge_command_model::EventIngressSender,
+    client_id: ClientId,
+    outbound: selvedge_command_model::ClientFrameSender,
+    client_command_id: ClientCommandId,
+    subscription: ClientSubscription,
+) {
+    let _ = reserve_client_session(ingress_tx, client_id.clone(), client_command_id.clone()).await;
+    begin_named_client_with_command_without_reservation(
+        ingress_tx,
+        client_id,
+        outbound,
+        client_command_id,
+        subscription,
+    )
+    .await;
+}
+
+async fn begin_named_client_with_command_without_reservation(
     ingress_tx: &selvedge_command_model::EventIngressSender,
     client_id: ClientId,
     outbound: selvedge_command_model::ClientFrameSender,

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -446,6 +446,42 @@ async fn replacement_reservation_shares_existing_client_capacity_slot() {
 }
 
 #[tokio::test]
+async fn dropped_reservation_waiter_does_not_consume_capacity() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    drop(result_rx);
+
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(
+            EventControlMessage::ReserveClientSession(ReserveClientSession {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                result_tx,
+            }),
+        ))
+        .await
+        .expect("send abandoned reservation");
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-2".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
 async fn reserved_client_session_is_consumed_by_matching_begin() {
     let handle = spawn_events_task(EventsStartArgs {
         ingress_capacity: 8,

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -598,6 +598,47 @@ async fn hidden_begin_hydrates_after_failed_pending_replacement() {
 }
 
 #[tokio::test]
+async fn hidden_reservation_duplicate_is_rejected() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-2".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::DuplicateAttach
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
 async fn reserved_client_session_is_consumed_by_matching_begin() {
     let handle = spawn_events_task(EventsStartArgs {
         ingress_capacity: 8,

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -482,6 +482,64 @@ async fn dropped_reservation_waiter_does_not_consume_capacity() {
 }
 
 #[tokio::test]
+async fn failed_pending_replacement_restores_previous_reservation() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut rx) = mpsc::channel(8);
+
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-2".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DetachClient(
+            DetachClient {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-2".to_owned()),
+                reason: DetachReason::ClientDisconnected,
+            },
+        )))
+        .await
+        .expect("send failed replacement cleanup");
+    begin_named_client_with_command_without_reservation(
+        &handle.ingress_tx,
+        ClientId("client-1".to_owned()),
+        outbound,
+        ClientCommandId("attach-1".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("client-1".to_owned())).await;
+
+    assert!(matches!(
+        recv_frame(&mut rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
 async fn reserved_client_session_is_consumed_by_matching_begin() {
     let handle = spawn_events_task(EventsStartArgs {
         ingress_capacity: 8,

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -3,9 +3,10 @@ use std::{collections::BTreeSet, time::Duration};
 use selvedge_command_model::{
     BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
     ClientNoticeLevel, ClientSnapshot, ClientSubscription, DebugRawEvent, DeliverNotice,
-    DeliverSnapshot, DetachClient, DetachReason, DetailLevel, EventControlMessage, EventIngress,
-    HistoryAppendedRawEvent, RawEvent, SnapshotTaskVersion, TaskChangedRawEvent, TaskProjection,
-    TaskProjectionStatus, TaskScope, UpdateSubscription,
+    DeliverSnapshot, DetachClient, DetachReason, DetailLevel, EventClientReservationResult,
+    EventControlMessage, EventIngress, HistoryAppendedRawEvent, RawEvent, ReserveClientSession,
+    SnapshotTaskVersion, TaskChangedRawEvent, TaskProjection, TaskProjectionStatus, TaskScope,
+    UpdateSubscription,
 };
 use selvedge_domain_model::{HistoryNodeId, ModelProfileKey, ReasoningEffort, TaskId, UnixTs};
 use selvedge_events::{EventsStartArgs, SpawnEventsError, spawn_events_task};
@@ -368,6 +369,89 @@ async fn registry_capacity_rejects_new_clients_after_limit() {
         recv_frame(&mut first_rx).await,
         ClientFrame::Snapshot(_)
     ));
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn reservation_capacity_rejects_new_clients_after_limit() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-2".to_owned()),
+            ClientCommandId("attach-2".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::ClientRegistryFull
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
+async fn reserved_client_session_is_consumed_by_matching_begin() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (reserved_outbound, mut reserved_rx) = mpsc::channel(8);
+    let (blocked_outbound, mut blocked_rx) = mpsc::channel(8);
+
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    begin_named_client(
+        &handle.ingress_tx,
+        ClientId("client-2".to_owned()),
+        blocked_outbound,
+        verbose_all_tasks(),
+    )
+    .await;
+    begin_named_client(
+        &handle.ingress_tx,
+        ClientId("client-1".to_owned()),
+        reserved_outbound,
+        verbose_all_tasks(),
+    )
+    .await;
+
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("client-1".to_owned())).await;
+    assert!(matches!(
+        recv_frame(&mut reserved_rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), blocked_rx.recv())
+            .await
+            .expect("blocked client channel closes")
+            .is_none()
+    );
 
     drop(handle.ingress_tx);
     handle.join_handle.await.expect("events task exits cleanly");
@@ -812,6 +896,25 @@ async fn begin_named_client_with_command(
         ))
         .await
         .expect("send begin hydration");
+}
+
+async fn reserve_client_session(
+    ingress_tx: &selvedge_command_model::EventIngressSender,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+) -> EventClientReservationResult {
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    ingress_tx
+        .send(EventIngress::Control(
+            EventControlMessage::ReserveClientSession(ReserveClientSession {
+                client_id,
+                client_command_id,
+                result_tx,
+            }),
+        ))
+        .await
+        .expect("send reservation");
+    result_rx.await.expect("reservation result")
 }
 
 async fn deliver_empty_snapshot(ingress_tx: &selvedge_command_model::EventIngressSender) {

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -639,6 +639,82 @@ async fn hidden_reservation_duplicate_is_rejected() {
 }
 
 #[tokio::test]
+async fn hidden_reservation_detach_prevents_later_restore() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut rx) = mpsc::channel(8);
+
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-2".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    begin_named_client_with_command_without_reservation(
+        &handle.ingress_tx,
+        ClientId("client-1".to_owned()),
+        outbound,
+        ClientCommandId("attach-1".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DetachClient(
+            DetachClient {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                reason: DetachReason::ClientDisconnected,
+            },
+        )))
+        .await
+        .expect("send hidden detach");
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DetachClient(
+            DetachClient {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-2".to_owned()),
+                reason: DetachReason::ClientDisconnected,
+            },
+        )))
+        .await
+        .expect("send top detach");
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("client-1".to_owned())).await;
+    if let Ok(Some(_)) = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await {
+        panic!("detached hidden reservation should not receive frames");
+    }
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-2".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
 async fn reserved_client_session_is_consumed_by_matching_begin() {
     let handle = spawn_events_task(EventsStartArgs {
         ingress_capacity: 8,

--- a/crates/events/tests/events_contract.rs
+++ b/crates/events/tests/events_contract.rs
@@ -540,6 +540,64 @@ async fn failed_pending_replacement_restores_previous_reservation() {
 }
 
 #[tokio::test]
+async fn hidden_begin_hydrates_after_failed_pending_replacement() {
+    let handle = spawn_events_task(EventsStartArgs {
+        ingress_capacity: 8,
+        client_registry_capacity: 1,
+        hydration_buffer_capacity: 4,
+    })
+    .expect("valid events task");
+    let (outbound, mut rx) = mpsc::channel(8);
+
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-1".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_client_session(
+            &handle.ingress_tx,
+            ClientId("client-1".to_owned()),
+            ClientCommandId("attach-2".to_owned()),
+        )
+        .await,
+        EventClientReservationResult::Reserved
+    );
+    begin_named_client_with_command_without_reservation(
+        &handle.ingress_tx,
+        ClientId("client-1".to_owned()),
+        outbound,
+        ClientCommandId("attach-1".to_owned()),
+        verbose_all_tasks(),
+    )
+    .await;
+    handle
+        .ingress_tx
+        .send(EventIngress::Control(EventControlMessage::DetachClient(
+            DetachClient {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-2".to_owned()),
+                reason: DetachReason::ClientDisconnected,
+            },
+        )))
+        .await
+        .expect("send failed replacement cleanup");
+    deliver_named_empty_snapshot(&handle.ingress_tx, ClientId("client-1".to_owned())).await;
+
+    assert!(matches!(
+        recv_frame(&mut rx).await,
+        ClientFrame::Snapshot(_)
+    ));
+
+    drop(handle.ingress_tx);
+    handle.join_handle.await.expect("events task exits cleanly");
+}
+
+#[tokio::test]
 async fn reserved_client_session_is_consumed_by_matching_begin() {
     let handle = spawn_events_task(EventsStartArgs {
         ingress_capacity: 8,

--- a/crates/local-client/Cargo.toml
+++ b/crates/local-client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "selvedge-local-client"
+edition = "2024"
+publish = false
+
+[dependencies]
+futures-core = "0.3.31"
+selvedge-local-protocol = { path = "../local-protocol" }
+tokio = { version = "1.42.0", features = ["rt", "sync", "time"] }
+
+[dev-dependencies]
+futures-util = "0.3.31"
+serde_json = "1.0.145"
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/local-client/README.md
+++ b/crates/local-client/README.md
@@ -1,0 +1,9 @@
+# local-client
+
+This crate owns the process-local client handle for talking to an existing Selvedge localhost server.
+
+Use it to validate localhost endpoint configuration, connect through a caller-provided `LocalTransport`, run ready probes, submit local protocol commands, open one attach stream, and close the underlying transport.
+
+`LocalEndpoint` is structured as loopback TCP by construction: `TcpIpv4 { port }` means `127.0.0.1:<port>`, and `TcpIpv6 { port }` means `[::1]:<port>`. Port `0` is invalid.
+
+This crate does not start the server, call systemd, select an IPC transport, inspect command payload schemas, cache snapshots, or access router/events/client-sync mailboxes directly.

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -212,6 +212,9 @@ impl<T: LocalTransport> LocalClient<T> {
         match state.state {
             LocalClientState::Closed => return Err(LocalClientError::Closed),
             LocalClientState::Closing => return Err(LocalClientError::Closing),
+            LocalClientState::CommandPending | LocalClientState::AttachPending => {
+                return Err(LocalClientError::Busy);
+            }
             _ => {}
         }
 
@@ -408,7 +411,11 @@ impl Stream for ClientFrameStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         match this.inner.as_mut().poll_next(cx) {
-            Poll::Ready(Some(frame)) => Poll::Ready(Some(frame)),
+            Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+            Poll::Ready(Some(Err(error))) => {
+                clear_attached_state(&this.state, this.attach_generation);
+                Poll::Ready(Some(Err(error)))
+            }
             Poll::Ready(None) if !this.closed_reported => {
                 this.closed_reported = true;
                 clear_attached_state(&this.state, this.attach_generation);

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -220,6 +220,7 @@ impl<T: LocalTransport> LocalClient<T> {
 
         let previous_state = state.state.clone();
         let previous_attach_open = state.attach_open;
+        let previous_recent_error = state.recent_error.clone();
         state.state = LocalClientState::Closing;
         state.recent_error = None;
 
@@ -228,6 +229,7 @@ impl<T: LocalTransport> LocalClient<T> {
             previous_state,
             previous_attach_open,
             previous_attach_generation: state.attach_generation,
+            previous_recent_error,
             active: true,
         })
     }
@@ -333,6 +335,7 @@ struct CloseGuard {
     previous_state: LocalClientState,
     previous_attach_open: bool,
     previous_attach_generation: u64,
+    previous_recent_error: Option<LocalClientError>,
     active: bool,
 }
 
@@ -361,6 +364,7 @@ impl Drop for CloseGuard {
                 && state.attach_generation == self.previous_attach_generation;
             state.attach_open = attach_still_open;
             state.state = resolved_state(self.previous_state.clone(), attach_still_open);
+            state.recent_error = self.previous_recent_error.clone();
         }
     }
 }
@@ -414,8 +418,11 @@ impl Stream for ClientFrameStream {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+        if this.closed_reported {
+            return Poll::Ready(None);
+        }
+
         match this.inner.as_mut().poll_next(cx) {
-            Poll::Ready(Some(_)) if this.closed_reported => Poll::Ready(None),
             Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
             Poll::Ready(Some(Err(error))) => {
                 clear_attached_state(&this.state, this.attach_generation);

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -1,0 +1,379 @@
+#![doc = include_str!("../README.md")]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures_core::Stream;
+use selvedge_local_protocol::{
+    AttachAccepted, AttachRejected, AttachRequest, CommandRequest, CommandResponse,
+    LocalClientFrame, ReadyRequest, ReadyResponse, validate_attach_request,
+    validate_command_request, validate_ready_request,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalClientConfig {
+    pub endpoint: LocalEndpoint,
+    pub request_timeout: Duration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LocalEndpoint {
+    TcpIpv4 { port: u16 },
+    TcpIpv6 { port: u16 },
+}
+
+pub struct LocalClient<T: LocalTransport> {
+    pub transport: T,
+    request_timeout: Duration,
+    inner: Arc<Mutex<ClientState>>,
+}
+
+pub type LocalFrameStream =
+    Pin<Box<dyn Stream<Item = Result<LocalClientFrame, LocalClientError>> + Send>>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LocalClientState {
+    Disconnected,
+    Ready,
+    CommandPending,
+    AttachPending,
+    Attached,
+    Closing,
+    Closed,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LocalClientError {
+    NotConnected,
+    AlreadyConnected,
+    AlreadyAttached,
+    Busy,
+    Closing,
+    Closed,
+    ConnectFailed(String),
+    Timeout,
+    ProtocolValidationFailed(String),
+    ServerRejected(String),
+    StreamClosed,
+    TransportClosed,
+    TransportFailed(String),
+}
+
+pub trait LocalTransport: Send + Sync + 'static {
+    fn connect(
+        config: LocalClientConfig,
+    ) -> impl Future<Output = Result<Self, LocalClientError>> + Send
+    where
+        Self: Sized;
+
+    fn ready(
+        &self,
+        request: ReadyRequest,
+    ) -> impl Future<Output = Result<ReadyResponse, LocalClientError>> + Send;
+
+    fn submit_command(
+        &self,
+        request: CommandRequest,
+    ) -> impl Future<Output = Result<CommandResponse, LocalClientError>> + Send;
+
+    fn attach(
+        &self,
+        request: AttachRequest,
+    ) -> impl Future<
+        Output = Result<(AttachAccepted, LocalFrameStream), AttachRejectedOrClientError>,
+    > + Send;
+
+    fn close(&self) -> impl Future<Output = ()> + Send;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AttachRejectedOrClientError {
+    Rejected(AttachRejected),
+    Client(LocalClientError),
+}
+
+#[derive(Debug)]
+struct ClientState {
+    state: LocalClientState,
+    recent_error: Option<LocalClientError>,
+}
+
+impl ClientState {
+    fn ready() -> Self {
+        Self {
+            state: LocalClientState::Ready,
+            recent_error: None,
+        }
+    }
+}
+
+pub async fn connect<T: LocalTransport>(
+    config: LocalClientConfig,
+) -> Result<LocalClient<T>, LocalClientError> {
+    validate_endpoint(&config.endpoint)?;
+    let request_timeout = config.request_timeout;
+    let transport = T::connect(config).await?;
+
+    Ok(LocalClient {
+        transport,
+        request_timeout,
+        inner: Arc::new(Mutex::new(ClientState::ready())),
+    })
+}
+
+impl<T: LocalTransport> LocalClient<T> {
+    pub async fn state(&self) -> LocalClientState {
+        self.inner
+            .lock()
+            .expect("local client state lock")
+            .state
+            .clone()
+    }
+
+    pub async fn ready(&self, request: ReadyRequest) -> Result<ReadyResponse, LocalClientError> {
+        validate_ready_request(&request)
+            .map_err(|error| LocalClientError::ProtocolValidationFailed(format!("{error:?}")))?;
+        let guard = self.begin_request(LocalClientState::CommandPending)?;
+        let result = tokio::time::timeout(guard.timeout, self.transport.ready(request)).await;
+        self.finish_request_result(guard, result)
+    }
+
+    pub async fn submit_command(
+        &self,
+        request: CommandRequest,
+    ) -> Result<CommandResponse, LocalClientError> {
+        validate_command_request(&request)
+            .map_err(|error| LocalClientError::ProtocolValidationFailed(format!("{error:?}")))?;
+        let guard = self.begin_request(LocalClientState::CommandPending)?;
+        let result =
+            tokio::time::timeout(guard.timeout, self.transport.submit_command(request)).await;
+        self.finish_request_result(guard, result)
+    }
+
+    pub async fn attach(
+        &self,
+        request: AttachRequest,
+    ) -> Result<(AttachAccepted, LocalFrameStream), AttachRejectedOrClientError> {
+        validate_attach_request(&request).map_err(|error| {
+            AttachRejectedOrClientError::Client(LocalClientError::ProtocolValidationFailed(
+                format!("{error:?}"),
+            ))
+        })?;
+        let guard = self
+            .begin_attach()
+            .map_err(AttachRejectedOrClientError::Client)?;
+        let result = tokio::time::timeout(guard.timeout, self.transport.attach(request)).await;
+
+        match result {
+            Ok(Ok((accepted, stream))) => {
+                guard.complete_as(LocalClientState::Attached);
+                let stream = Box::pin(ClientFrameStream {
+                    inner: stream,
+                    state: Arc::clone(&self.inner),
+                    closed_reported: false,
+                });
+                Ok((accepted, stream))
+            }
+            Ok(Err(AttachRejectedOrClientError::Rejected(rejected))) => {
+                let return_state = guard.return_state.clone();
+                guard.complete_as(return_state);
+                Err(AttachRejectedOrClientError::Rejected(rejected))
+            }
+            Ok(Err(AttachRejectedOrClientError::Client(error))) => {
+                let error = self.finish_client_error(guard, error);
+                Err(AttachRejectedOrClientError::Client(error))
+            }
+            Err(_) => {
+                let error = self.finish_client_error(guard, LocalClientError::Timeout);
+                Err(AttachRejectedOrClientError::Client(error))
+            }
+        }
+    }
+
+    pub async fn close(&self) -> Result<(), LocalClientError> {
+        {
+            let mut state = self.inner.lock().expect("local client state lock");
+            match state.state {
+                LocalClientState::Closed => return Err(LocalClientError::Closed),
+                LocalClientState::Closing => return Err(LocalClientError::Closing),
+                _ => {
+                    state.state = LocalClientState::Closing;
+                    state.recent_error = None;
+                }
+            }
+        }
+
+        self.transport.close().await;
+        let mut state = self.inner.lock().expect("local client state lock");
+        state.state = LocalClientState::Closed;
+        Ok(())
+    }
+
+    fn begin_request(&self, pending: LocalClientState) -> Result<RequestGuard, LocalClientError> {
+        let mut state = self.inner.lock().expect("local client state lock");
+        let return_state = match &state.state {
+            LocalClientState::Ready => LocalClientState::Ready,
+            LocalClientState::Attached => LocalClientState::Attached,
+            LocalClientState::CommandPending | LocalClientState::AttachPending => {
+                return Err(LocalClientError::Busy);
+            }
+            LocalClientState::Closing => return Err(LocalClientError::Closing),
+            LocalClientState::Closed => return Err(LocalClientError::Closed),
+            LocalClientState::Failed => {
+                return Err(state.recent_error.clone().unwrap_or(
+                    LocalClientError::TransportFailed("client failed".to_owned()),
+                ));
+            }
+            LocalClientState::Disconnected => return Err(LocalClientError::NotConnected),
+        };
+
+        state.state = pending.clone();
+        Ok(RequestGuard {
+            state: Arc::clone(&self.inner),
+            pending,
+            return_state,
+            timeout: self.request_timeout,
+            active: true,
+        })
+    }
+
+    fn begin_attach(&self) -> Result<RequestGuard, LocalClientError> {
+        let mut state = self.inner.lock().expect("local client state lock");
+        let return_state = match &state.state {
+            LocalClientState::Ready => LocalClientState::Ready,
+            LocalClientState::Attached => return Err(LocalClientError::AlreadyAttached),
+            LocalClientState::CommandPending | LocalClientState::AttachPending => {
+                return Err(LocalClientError::Busy);
+            }
+            LocalClientState::Closing => return Err(LocalClientError::Closing),
+            LocalClientState::Closed => return Err(LocalClientError::Closed),
+            LocalClientState::Failed => {
+                return Err(state.recent_error.clone().unwrap_or(
+                    LocalClientError::TransportFailed("client failed".to_owned()),
+                ));
+            }
+            LocalClientState::Disconnected => return Err(LocalClientError::NotConnected),
+        };
+
+        state.state = LocalClientState::AttachPending;
+        Ok(RequestGuard {
+            state: Arc::clone(&self.inner),
+            pending: LocalClientState::AttachPending,
+            return_state,
+            timeout: self.request_timeout,
+            active: true,
+        })
+    }
+
+    fn finish_request_result<R>(
+        &self,
+        guard: RequestGuard,
+        result: Result<Result<R, LocalClientError>, tokio::time::error::Elapsed>,
+    ) -> Result<R, LocalClientError> {
+        match result {
+            Ok(Ok(response)) => {
+                let return_state = guard.return_state.clone();
+                guard.complete_as(return_state);
+                Ok(response)
+            }
+            Ok(Err(error)) => Err(self.finish_client_error(guard, error)),
+            Err(_) => Err(self.finish_client_error(guard, LocalClientError::Timeout)),
+        }
+    }
+
+    fn finish_client_error(
+        &self,
+        mut guard: RequestGuard,
+        error: LocalClientError,
+    ) -> LocalClientError {
+        let mut state = self.inner.lock().expect("local client state lock");
+        if state.state == guard.pending {
+            state.state = LocalClientState::Failed;
+            state.recent_error = Some(error.clone());
+        }
+        guard.active = false;
+        error
+    }
+}
+
+struct RequestGuard {
+    state: Arc<Mutex<ClientState>>,
+    pending: LocalClientState,
+    return_state: LocalClientState,
+    timeout: Duration,
+    active: bool,
+}
+
+impl RequestGuard {
+    fn complete_as(mut self, next_state: LocalClientState) {
+        let mut state = self.state.lock().expect("local client state lock");
+        if state.state == self.pending {
+            state.state = next_state;
+            state.recent_error = None;
+        }
+        self.active = false;
+    }
+}
+
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+
+        let mut state = self.state.lock().expect("local client state lock");
+        if state.state == self.pending {
+            state.state = self.return_state.clone();
+        }
+    }
+}
+
+struct ClientFrameStream {
+    inner: LocalFrameStream,
+    state: Arc<Mutex<ClientState>>,
+    closed_reported: bool,
+}
+
+impl Stream for ClientFrameStream {
+    type Item = Result<LocalClientFrame, LocalClientError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(frame)) => Poll::Ready(Some(frame)),
+            Poll::Ready(None) if !this.closed_reported => {
+                this.closed_reported = true;
+                clear_attached_state(&this.state);
+                Poll::Ready(Some(Err(LocalClientError::StreamClosed)))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for ClientFrameStream {
+    fn drop(&mut self) {
+        clear_attached_state(&self.state);
+    }
+}
+
+fn clear_attached_state(state: &Arc<Mutex<ClientState>>) {
+    let mut state = state.lock().expect("local client state lock");
+    if state.state == LocalClientState::Attached {
+        state.state = LocalClientState::Ready;
+    }
+}
+
+fn validate_endpoint(endpoint: &LocalEndpoint) -> Result<(), LocalClientError> {
+    match endpoint {
+        LocalEndpoint::TcpIpv4 { port } | LocalEndpoint::TcpIpv6 { port } if *port == 0 => Err(
+            LocalClientError::ProtocolValidationFailed("endpoint port must be nonzero".to_owned()),
+        ),
+        LocalEndpoint::TcpIpv4 { .. } | LocalEndpoint::TcpIpv6 { .. } => Ok(()),
+    }
+}

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -26,7 +26,7 @@ pub enum LocalEndpoint {
 }
 
 pub struct LocalClient<T: LocalTransport> {
-    pub transport: T,
+    transport: T,
     request_timeout: Duration,
     inner: Arc<Mutex<ClientState>>,
 }

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -228,6 +228,7 @@ impl<T: LocalTransport> LocalClient<T> {
             state: Arc::clone(&self.inner),
             previous_state,
             previous_attach_open,
+            previous_attach_generation: state.attach_generation,
             active: true,
         })
     }
@@ -332,6 +333,7 @@ struct CloseGuard {
     state: Arc<Mutex<ClientState>>,
     previous_state: LocalClientState,
     previous_attach_open: bool,
+    previous_attach_generation: u64,
     active: bool,
 }
 
@@ -355,8 +357,11 @@ impl Drop for CloseGuard {
 
         let mut state = self.state.lock().expect("local client state lock");
         if state.state == LocalClientState::Closing {
-            state.state = self.previous_state.clone();
-            state.attach_open = self.previous_attach_open;
+            let attach_still_open = self.previous_attach_open
+                && state.attach_open
+                && state.attach_generation == self.previous_attach_generation;
+            state.attach_open = attach_still_open;
+            state.state = resolved_state(self.previous_state.clone(), attach_still_open);
         }
     }
 }
@@ -411,9 +416,11 @@ impl Stream for ClientFrameStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(_)) if this.closed_reported => Poll::Ready(None),
             Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
             Poll::Ready(Some(Err(error))) => {
                 clear_attached_state(&this.state, this.attach_generation);
+                this.closed_reported = true;
                 Poll::Ready(Some(Err(error)))
             }
             Poll::Ready(None) if !this.closed_reported => {

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -221,7 +221,6 @@ impl<T: LocalTransport> LocalClient<T> {
         let previous_state = state.state.clone();
         let previous_attach_open = state.attach_open;
         state.state = LocalClientState::Closing;
-        state.attach_open = false;
         state.recent_error = None;
 
         Ok(CloseGuard {

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -99,6 +99,7 @@ pub enum AttachRejectedOrClientError {
 #[derive(Debug)]
 struct ClientState {
     state: LocalClientState,
+    attach_open: bool,
     recent_error: Option<LocalClientError>,
 }
 
@@ -106,6 +107,7 @@ impl ClientState {
     fn ready() -> Self {
         Self {
             state: LocalClientState::Ready,
+            attach_open: false,
             recent_error: None,
         }
     }
@@ -202,6 +204,7 @@ impl<T: LocalTransport> LocalClient<T> {
                 LocalClientState::Closing => return Err(LocalClientError::Closing),
                 _ => {
                     state.state = LocalClientState::Closing;
+                    state.attach_open = false;
                     state.recent_error = None;
                 }
             }
@@ -293,6 +296,7 @@ impl<T: LocalTransport> LocalClient<T> {
         let mut state = self.inner.lock().expect("local client state lock");
         if state.state == guard.pending {
             state.state = LocalClientState::Failed;
+            state.attach_open = false;
             state.recent_error = Some(error.clone());
         }
         guard.active = false;
@@ -312,7 +316,12 @@ impl RequestGuard {
     fn complete_as(mut self, next_state: LocalClientState) {
         let mut state = self.state.lock().expect("local client state lock");
         if state.state == self.pending {
-            state.state = next_state;
+            if next_state == LocalClientState::Attached {
+                state.attach_open = true;
+                state.state = LocalClientState::Attached;
+            } else {
+                state.state = resolved_state(next_state, state.attach_open);
+            }
             state.recent_error = None;
         }
         self.active = false;
@@ -327,7 +336,7 @@ impl Drop for RequestGuard {
 
         let mut state = self.state.lock().expect("local client state lock");
         if state.state == self.pending {
-            state.state = self.return_state.clone();
+            state.state = resolved_state(self.return_state.clone(), state.attach_open);
         }
     }
 }
@@ -364,8 +373,17 @@ impl Drop for ClientFrameStream {
 
 fn clear_attached_state(state: &Arc<Mutex<ClientState>>) {
     let mut state = state.lock().expect("local client state lock");
+    state.attach_open = false;
     if state.state == LocalClientState::Attached {
         state.state = LocalClientState::Ready;
+    }
+}
+
+fn resolved_state(next_state: LocalClientState, attach_open: bool) -> LocalClientState {
+    if next_state == LocalClientState::Attached && !attach_open {
+        LocalClientState::Ready
+    } else {
+        next_state
     }
 }
 

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -100,6 +100,7 @@ pub enum AttachRejectedOrClientError {
 struct ClientState {
     state: LocalClientState,
     attach_open: bool,
+    attach_generation: u64,
     recent_error: Option<LocalClientError>,
 }
 
@@ -108,6 +109,7 @@ impl ClientState {
         Self {
             state: LocalClientState::Ready,
             attach_open: false,
+            attach_generation: 0,
             recent_error: None,
         }
     }
@@ -172,10 +174,11 @@ impl<T: LocalTransport> LocalClient<T> {
 
         match result {
             Ok(Ok((accepted, stream))) => {
-                guard.complete_attach_success();
+                let attach_generation = guard.complete_attach_success();
                 let stream = Box::pin(ClientFrameStream {
                     inner: stream,
                     state: Arc::clone(&self.inner),
+                    attach_generation,
                     closed_reported: false,
                 });
                 Ok((accepted, stream))
@@ -322,14 +325,17 @@ impl RequestGuard {
         self.active = false;
     }
 
-    fn complete_attach_success(mut self) {
+    fn complete_attach_success(mut self) -> u64 {
         let mut state = self.state.lock().expect("local client state lock");
         if state.state == self.pending {
+            state.attach_generation = state.attach_generation.wrapping_add(1);
             state.attach_open = true;
             state.state = LocalClientState::Attached;
             state.recent_error = None;
         }
+        let attach_generation = state.attach_generation;
         self.active = false;
+        attach_generation
     }
 }
 
@@ -349,6 +355,7 @@ impl Drop for RequestGuard {
 struct ClientFrameStream {
     inner: LocalFrameStream,
     state: Arc<Mutex<ClientState>>,
+    attach_generation: u64,
     closed_reported: bool,
 }
 
@@ -361,7 +368,7 @@ impl Stream for ClientFrameStream {
             Poll::Ready(Some(frame)) => Poll::Ready(Some(frame)),
             Poll::Ready(None) if !this.closed_reported => {
                 this.closed_reported = true;
-                clear_attached_state(&this.state);
+                clear_attached_state(&this.state, this.attach_generation);
                 Poll::Ready(Some(Err(LocalClientError::StreamClosed)))
             }
             Poll::Ready(None) => Poll::Ready(None),
@@ -372,12 +379,15 @@ impl Stream for ClientFrameStream {
 
 impl Drop for ClientFrameStream {
     fn drop(&mut self) {
-        clear_attached_state(&self.state);
+        clear_attached_state(&self.state, self.attach_generation);
     }
 }
 
-fn clear_attached_state(state: &Arc<Mutex<ClientState>>) {
+fn clear_attached_state(state: &Arc<Mutex<ClientState>>, attach_generation: u64) {
     let mut state = state.lock().expect("local client state lock");
+    if state.attach_generation != attach_generation {
+        return;
+    }
     state.attach_open = false;
     if state.state == LocalClientState::Attached {
         state.state = LocalClientState::Ready;

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -172,7 +172,7 @@ impl<T: LocalTransport> LocalClient<T> {
 
         match result {
             Ok(Ok((accepted, stream))) => {
-                guard.complete_as(LocalClientState::Attached);
+                guard.complete_attach_success();
                 let stream = Box::pin(ClientFrameStream {
                     inner: stream,
                     state: Arc::clone(&self.inner),
@@ -316,12 +316,17 @@ impl RequestGuard {
     fn complete_as(mut self, next_state: LocalClientState) {
         let mut state = self.state.lock().expect("local client state lock");
         if state.state == self.pending {
-            if next_state == LocalClientState::Attached {
-                state.attach_open = true;
-                state.state = LocalClientState::Attached;
-            } else {
-                state.state = resolved_state(next_state, state.attach_open);
-            }
+            state.state = resolved_state(next_state, state.attach_open);
+            state.recent_error = None;
+        }
+        self.active = false;
+    }
+
+    fn complete_attach_success(mut self) {
+        let mut state = self.state.lock().expect("local client state lock");
+        if state.state == self.pending {
+            state.attach_open = true;
+            state.state = LocalClientState::Attached;
             state.recent_error = None;
         }
         self.active = false;

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -421,6 +421,10 @@ impl Stream for ClientFrameStream {
         if this.closed_reported {
             return Poll::Ready(None);
         }
+        if stream_is_closed_by_client(&this.state, this.attach_generation) {
+            this.closed_reported = true;
+            return Poll::Ready(None);
+        }
 
         match this.inner.as_mut().poll_next(cx) {
             Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
@@ -455,6 +459,12 @@ fn clear_attached_state(state: &Arc<Mutex<ClientState>>, attach_generation: u64)
     if state.state == LocalClientState::Attached {
         state.state = LocalClientState::Ready;
     }
+}
+
+fn stream_is_closed_by_client(state: &Arc<Mutex<ClientState>>, attach_generation: u64) -> bool {
+    let state = state.lock().expect("local client state lock");
+    state.state == LocalClientState::Closed
+        || (state.attach_generation == attach_generation && !state.attach_open)
 }
 
 fn resolved_state(next_state: LocalClientState, attach_open: bool) -> LocalClientState {

--- a/crates/local-client/src/lib.rs
+++ b/crates/local-client/src/lib.rs
@@ -200,23 +200,33 @@ impl<T: LocalTransport> LocalClient<T> {
     }
 
     pub async fn close(&self) -> Result<(), LocalClientError> {
-        {
-            let mut state = self.inner.lock().expect("local client state lock");
-            match state.state {
-                LocalClientState::Closed => return Err(LocalClientError::Closed),
-                LocalClientState::Closing => return Err(LocalClientError::Closing),
-                _ => {
-                    state.state = LocalClientState::Closing;
-                    state.attach_open = false;
-                    state.recent_error = None;
-                }
-            }
-        }
+        let guard = self.begin_close()?;
 
         self.transport.close().await;
-        let mut state = self.inner.lock().expect("local client state lock");
-        state.state = LocalClientState::Closed;
+        guard.complete_closed();
         Ok(())
+    }
+
+    fn begin_close(&self) -> Result<CloseGuard, LocalClientError> {
+        let mut state = self.inner.lock().expect("local client state lock");
+        match state.state {
+            LocalClientState::Closed => return Err(LocalClientError::Closed),
+            LocalClientState::Closing => return Err(LocalClientError::Closing),
+            _ => {}
+        }
+
+        let previous_state = state.state.clone();
+        let previous_attach_open = state.attach_open;
+        state.state = LocalClientState::Closing;
+        state.attach_open = false;
+        state.recent_error = None;
+
+        Ok(CloseGuard {
+            state: Arc::clone(&self.inner),
+            previous_state,
+            previous_attach_open,
+            active: true,
+        })
     }
 
     fn begin_request(&self, pending: LocalClientState) -> Result<RequestGuard, LocalClientError> {
@@ -313,6 +323,39 @@ struct RequestGuard {
     return_state: LocalClientState,
     timeout: Duration,
     active: bool,
+}
+
+struct CloseGuard {
+    state: Arc<Mutex<ClientState>>,
+    previous_state: LocalClientState,
+    previous_attach_open: bool,
+    active: bool,
+}
+
+impl CloseGuard {
+    fn complete_closed(mut self) {
+        let mut state = self.state.lock().expect("local client state lock");
+        if state.state == LocalClientState::Closing {
+            state.state = LocalClientState::Closed;
+            state.attach_open = false;
+            state.recent_error = None;
+        }
+        self.active = false;
+    }
+}
+
+impl Drop for CloseGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+
+        let mut state = self.state.lock().expect("local client state lock");
+        if state.state == LocalClientState::Closing {
+            state.state = self.previous_state.clone();
+            state.attach_open = self.previous_attach_open;
+        }
+    }
 }
 
 impl RequestGuard {

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -459,6 +459,72 @@ async fn dropping_exhausted_old_stream_does_not_clear_newer_attach_stream() {
 }
 
 #[tokio::test]
+async fn attach_stream_error_clears_attached_state_before_returning_error() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::iter(vec![Err(LocalClientError::TransportClosed)])),
+        ))));
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-2").expect("command id"),
+            },
+            Box::pin(stream::empty()),
+        ))));
+    }
+    let client = connected_client(state.clone()).await;
+    let (_accepted, mut frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+
+    assert_eq!(
+        frames.next().await,
+        Some(Err(LocalClientError::TransportClosed))
+    );
+    assert_eq!(client.state().await, LocalClientState::Ready);
+
+    let (_accepted, _frames) = client
+        .attach(valid_attach("attach-2"))
+        .await
+        .expect("reattach");
+    assert_eq!(state.lock().expect("fake state").attach_calls, 2);
+}
+
+#[tokio::test]
+async fn close_returns_busy_while_request_is_pending() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .command_responses
+        .push_back(CommandAction::Hang);
+    let client = connected_client(state).await;
+    let mut command = Box::pin(client.submit_command(valid_command("command-1")));
+    assert!(
+        timeout(Duration::from_millis(5), command.as_mut())
+            .await
+            .is_err()
+    );
+
+    assert_eq!(client.close().await, Err(LocalClientError::Busy));
+    assert_eq!(client.state().await, LocalClientState::CommandPending);
+
+    drop(command);
+    assert_eq!(client.state().await, LocalClientState::Ready);
+}
+
+#[tokio::test]
 async fn attach_validates_request_before_transport() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -1,0 +1,594 @@
+use std::collections::VecDeque;
+use std::fs;
+use std::future;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use futures_util::stream;
+use selvedge_local_client::{
+    AttachRejectedOrClientError, LocalClientConfig, LocalClientError, LocalClientState,
+    LocalEndpoint, LocalFrameStream, LocalTransport, connect,
+};
+use selvedge_local_protocol::{
+    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
+    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientFrame, LocalClientId,
+    LocalClientSubscription, LocalDetailLevel, LocalNotice, LocalNoticeLevel, LocalTaskScope,
+    ReadyRequest, ReadyResponse, ReadyState, current_protocol_version,
+};
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::time::timeout;
+
+static TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
+static CONNECT_PLAN: LazyLock<Mutex<Option<Result<FakeTransportStateHandle, LocalClientError>>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+type FakeTransportStateHandle = Arc<Mutex<FakeTransportState>>;
+
+#[tokio::test]
+async fn connect_validates_structured_localhost_endpoint_before_transport_connect() {
+    let _guard = TEST_LOCK.lock().await;
+    install_connect_plan(Ok(FakeTransportState::new_handle()));
+
+    let invalid = connect::<FakeTransport>(LocalClientConfig {
+        endpoint: LocalEndpoint::TcpIpv4 { port: 0 },
+        request_timeout: Duration::from_secs(1),
+    })
+    .await;
+
+    assert!(matches!(
+        invalid,
+        Err(LocalClientError::ProtocolValidationFailed(_))
+    ));
+    assert!(connect_plan_is_some());
+
+    let state = FakeTransportState::new_handle();
+    install_connect_plan(Ok(state.clone()));
+    let client = connect::<FakeTransport>(LocalClientConfig {
+        endpoint: LocalEndpoint::TcpIpv6 { port: 17691 },
+        request_timeout: Duration::from_secs(1),
+    })
+    .await
+    .expect("connect client");
+
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    assert_eq!(
+        state.lock().expect("fake state").connected_configs,
+        vec![LocalClientConfig {
+            endpoint: LocalEndpoint::TcpIpv6 { port: 17691 },
+            request_timeout: Duration::from_secs(1),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn connect_failure_returns_transport_connect_error() {
+    let _guard = TEST_LOCK.lock().await;
+    install_connect_plan(Err(LocalClientError::ConnectFailed("refused".to_owned())));
+
+    let error = match connect::<FakeTransport>(valid_config()).await {
+        Ok(_) => panic!("connect should fail"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error, LocalClientError::ConnectFailed("refused".to_owned()));
+}
+
+#[tokio::test]
+async fn ready_returns_server_state_and_restores_idle_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .ready_responses
+        .push_back(ReadyAction::Response(Ok(ReadyResponse {
+            protocol_version: current_protocol_version(),
+            state: ReadyState::NotReady,
+        })));
+    let client = connected_client(state.clone()).await;
+
+    let response = client
+        .ready(ReadyRequest {
+            protocol_version: current_protocol_version(),
+        })
+        .await
+        .expect("ready response");
+
+    assert_eq!(response.state, ReadyState::NotReady);
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    assert_eq!(state.lock().expect("fake state").ready_calls, 1);
+}
+
+#[tokio::test]
+async fn command_submit_validates_request_before_transport_and_preserves_server_rejection() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .command_responses
+        .push_back(CommandAction::Response(Ok(CommandResponse {
+            protocol_version: current_protocol_version(),
+            client_command_id: LocalClientCommandId::new("command-2").expect("command id"),
+            outcome: CommandOutcome::Rejected(CommandRejectReason::ServerNotReady),
+        })));
+    let client = connected_client(state.clone()).await;
+
+    let invalid = client
+        .submit_command(CommandRequest {
+            command_name: " ".to_owned(),
+            ..valid_command("command-1")
+        })
+        .await;
+    assert!(matches!(
+        invalid,
+        Err(LocalClientError::ProtocolValidationFailed(_))
+    ));
+    assert_eq!(state.lock().expect("fake state").command_calls, 0);
+
+    let response = client
+        .submit_command(valid_command("command-2"))
+        .await
+        .expect("command response");
+    assert_eq!(
+        response.outcome,
+        CommandOutcome::Rejected(CommandRejectReason::ServerNotReady)
+    );
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    assert_eq!(state.lock().expect("fake state").command_calls, 1);
+}
+
+#[tokio::test]
+async fn transport_closed_error_moves_client_to_failed_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .command_responses
+        .push_back(CommandAction::Response(Err(
+            LocalClientError::TransportClosed,
+        )));
+    let client = connected_client(state).await;
+
+    let error = client.submit_command(valid_command("command-1")).await;
+
+    assert_eq!(error, Err(LocalClientError::TransportClosed));
+    assert_eq!(client.state().await, LocalClientState::Failed);
+    assert_eq!(
+        client
+            .ready(ReadyRequest {
+                protocol_version: current_protocol_version(),
+            })
+            .await,
+        Err(LocalClientError::TransportClosed)
+    );
+}
+
+#[tokio::test]
+async fn cancelling_pending_command_restores_ready_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .command_responses
+        .push_back(CommandAction::Hang);
+    let client = connected_client(state).await;
+
+    let mut command = Box::pin(client.submit_command(valid_command("command-1")));
+    assert!(
+        timeout(Duration::from_millis(5), command.as_mut())
+            .await
+            .is_err()
+    );
+    assert_eq!(client.state().await, LocalClientState::CommandPending);
+    assert_eq!(
+        client
+            .ready(ReadyRequest {
+                protocol_version: current_protocol_version(),
+            })
+            .await,
+        Err(LocalClientError::Busy)
+    );
+
+    drop(command);
+    assert_eq!(client.state().await, LocalClientState::Ready);
+}
+
+#[tokio::test]
+async fn cancelling_pending_attach_restores_ready_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Hang);
+    let client = connected_client(state).await;
+
+    let mut attach = Box::pin(client.attach(valid_attach("attach-1")));
+    assert!(
+        timeout(Duration::from_millis(5), attach.as_mut())
+            .await
+            .is_err()
+    );
+    assert_eq!(client.state().await, LocalClientState::AttachPending);
+    assert!(matches!(
+        client.submit_command(valid_command("command-1")).await,
+        Err(LocalClientError::Busy)
+    ));
+
+    drop(attach);
+    assert_eq!(client.state().await, LocalClientState::Ready);
+}
+
+#[tokio::test]
+async fn request_timeout_sets_failed_state_and_recent_error() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .ready_responses
+        .push_back(ReadyAction::Hang);
+    let client = connected_client_with_timeout(state, Duration::from_millis(5)).await;
+
+    let error = client
+        .ready(ReadyRequest {
+            protocol_version: current_protocol_version(),
+        })
+        .await;
+
+    assert_eq!(error, Err(LocalClientError::Timeout));
+    assert_eq!(client.state().await, LocalClientState::Failed);
+    assert_eq!(
+        client
+            .submit_command(valid_command("after-timeout"))
+            .await
+            .expect_err("failed client returns recent error"),
+        LocalClientError::Timeout
+    );
+}
+
+#[tokio::test]
+async fn attach_allows_one_active_stream_and_reports_stream_closed_after_ordered_frames() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::iter(vec![Ok(notice_frame(1)), Ok(notice_frame(2))])),
+        ))));
+    let client = connected_client(state.clone()).await;
+
+    let (_accepted, mut frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+    assert_eq!(client.state().await, LocalClientState::Attached);
+    assert!(matches!(
+        client.attach(valid_attach("attach-2")).await,
+        Err(AttachRejectedOrClientError::Client(
+            LocalClientError::AlreadyAttached
+        ))
+    ));
+
+    assert_eq!(next_seq(&mut frames).await, Ok(1));
+    assert_eq!(next_seq(&mut frames).await, Ok(2));
+    assert_eq!(
+        frames.next().await,
+        Some(Err(LocalClientError::StreamClosed))
+    );
+    assert_eq!(frames.next().await, None);
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    assert_eq!(state.lock().expect("fake state").attach_calls, 1);
+}
+
+#[tokio::test]
+async fn attach_validates_request_before_transport() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    let client = connected_client(state.clone()).await;
+
+    let error = client
+        .attach(AttachRequest {
+            subscription: LocalClientSubscription {
+                task_scope: LocalTaskScope::TaskIds(vec![" ".to_owned()]),
+                ..valid_attach("attach-1").subscription
+            },
+            ..valid_attach("attach-1")
+        })
+        .await;
+
+    assert!(matches!(
+        error,
+        Err(AttachRejectedOrClientError::Client(
+            LocalClientError::ProtocolValidationFailed(_)
+        ))
+    ));
+    assert_eq!(state.lock().expect("fake state").attach_calls, 0);
+    assert_eq!(client.state().await, LocalClientState::Ready);
+}
+
+#[tokio::test]
+async fn attach_rejection_restores_idle_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Response(Err(
+            AttachRejectedOrClientError::Rejected(AttachRejected {
+                protocol_version: current_protocol_version(),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+                reason: CommandRejectReason::ServerNotReady,
+            }),
+        )));
+    let client = connected_client(state).await;
+
+    let rejected = match client.attach(valid_attach("attach-1")).await {
+        Ok(_) => panic!("attach should be rejected"),
+        Err(rejected) => rejected,
+    };
+
+    assert!(matches!(
+        rejected,
+        AttachRejectedOrClientError::Rejected(AttachRejected {
+            reason: CommandRejectReason::ServerNotReady,
+            ..
+        })
+    ));
+    assert_eq!(client.state().await, LocalClientState::Ready);
+}
+
+#[tokio::test]
+async fn close_closes_transport_and_later_methods_return_closed() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    let client = connected_client(state.clone()).await;
+
+    client.close().await.expect("close client");
+
+    assert_eq!(client.state().await, LocalClientState::Closed);
+    assert_eq!(state.lock().expect("fake state").close_calls, 1);
+    assert_eq!(
+        client
+            .ready(ReadyRequest {
+                protocol_version: current_protocol_version(),
+            })
+            .await,
+        Err(LocalClientError::Closed)
+    );
+}
+
+#[test]
+fn crate_has_no_systemd_dependency() {
+    let manifest = fs::read_to_string(format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR")))
+        .expect("read manifest");
+
+    assert!(!manifest.contains("systemd"));
+}
+
+#[derive(Clone)]
+struct FakeTransport {
+    state: FakeTransportStateHandle,
+}
+
+struct FakeTransportState {
+    connected_configs: Vec<LocalClientConfig>,
+    ready_calls: usize,
+    command_calls: usize,
+    attach_calls: usize,
+    close_calls: usize,
+    ready_responses: VecDeque<ReadyAction>,
+    command_responses: VecDeque<CommandAction>,
+    attach_responses: VecDeque<AttachAction>,
+}
+
+enum ReadyAction {
+    Response(Result<ReadyResponse, LocalClientError>),
+    Hang,
+}
+
+enum CommandAction {
+    Response(Result<CommandResponse, LocalClientError>),
+    Hang,
+}
+
+enum AttachAction {
+    Response(Result<(AttachAccepted, LocalFrameStream), AttachRejectedOrClientError>),
+    Hang,
+}
+
+impl FakeTransportState {
+    fn new_handle() -> FakeTransportStateHandle {
+        Arc::new(Mutex::new(Self {
+            connected_configs: Vec::new(),
+            ready_calls: 0,
+            command_calls: 0,
+            attach_calls: 0,
+            close_calls: 0,
+            ready_responses: VecDeque::new(),
+            command_responses: VecDeque::new(),
+            attach_responses: VecDeque::new(),
+        }))
+    }
+}
+
+impl LocalTransport for FakeTransport {
+    async fn connect(config: LocalClientConfig) -> Result<Self, LocalClientError> {
+        let state = CONNECT_PLAN
+            .lock()
+            .expect("connect plan lock")
+            .take()
+            .expect("connect plan installed")?;
+        state
+            .lock()
+            .expect("fake state")
+            .connected_configs
+            .push(config);
+        Ok(Self { state })
+    }
+
+    async fn ready(&self, _request: ReadyRequest) -> Result<ReadyResponse, LocalClientError> {
+        let action = {
+            let mut state = self.state.lock().expect("fake state");
+            state.ready_calls += 1;
+            state
+                .ready_responses
+                .pop_front()
+                .unwrap_or(ReadyAction::Response(Ok(ReadyResponse {
+                    protocol_version: current_protocol_version(),
+                    state: ReadyState::Ready,
+                })))
+        };
+
+        match action {
+            ReadyAction::Response(response) => response,
+            ReadyAction::Hang => future::pending().await,
+        }
+    }
+
+    async fn submit_command(
+        &self,
+        _request: CommandRequest,
+    ) -> Result<CommandResponse, LocalClientError> {
+        let action = {
+            let mut state = self.state.lock().expect("fake state");
+            state.command_calls += 1;
+            state.command_responses.pop_front().unwrap_or_else(|| {
+                CommandAction::Response(Ok(CommandResponse {
+                    protocol_version: current_protocol_version(),
+                    client_command_id: LocalClientCommandId::new("command-1").expect("command id"),
+                    outcome: CommandOutcome::Accepted,
+                }))
+            })
+        };
+
+        match action {
+            CommandAction::Response(response) => response,
+            CommandAction::Hang => future::pending().await,
+        }
+    }
+
+    async fn attach(
+        &self,
+        _request: AttachRequest,
+    ) -> Result<(AttachAccepted, LocalFrameStream), AttachRejectedOrClientError> {
+        let action = {
+            let mut state = self.state.lock().expect("fake state");
+            state.attach_calls += 1;
+            state.attach_responses.pop_front().unwrap_or_else(|| {
+                AttachAction::Response(Ok((
+                    AttachAccepted {
+                        protocol_version: current_protocol_version(),
+                        client_id: LocalClientId::new("client-1").expect("client id"),
+                        client_command_id: LocalClientCommandId::new("attach-1")
+                            .expect("command id"),
+                    },
+                    Box::pin(stream::empty()),
+                )))
+            })
+        };
+
+        match action {
+            AttachAction::Response(response) => response,
+            AttachAction::Hang => future::pending().await,
+        }
+    }
+
+    async fn close(&self) {
+        self.state.lock().expect("fake state").close_calls += 1;
+    }
+}
+
+async fn connected_client(
+    state: FakeTransportStateHandle,
+) -> selvedge_local_client::LocalClient<FakeTransport> {
+    connected_client_with_timeout(state, Duration::from_secs(1)).await
+}
+
+async fn connected_client_with_timeout(
+    state: FakeTransportStateHandle,
+    request_timeout: Duration,
+) -> selvedge_local_client::LocalClient<FakeTransport> {
+    install_connect_plan(Ok(state));
+    connect::<FakeTransport>(LocalClientConfig {
+        endpoint: LocalEndpoint::TcpIpv4 { port: 17691 },
+        request_timeout,
+    })
+    .await
+    .expect("connect client")
+}
+
+fn install_connect_plan(plan: Result<FakeTransportStateHandle, LocalClientError>) {
+    *CONNECT_PLAN.lock().expect("connect plan lock") = Some(plan);
+}
+
+fn connect_plan_is_some() -> bool {
+    CONNECT_PLAN.lock().expect("connect plan lock").is_some()
+}
+
+fn valid_config() -> LocalClientConfig {
+    LocalClientConfig {
+        endpoint: LocalEndpoint::TcpIpv4 { port: 17691 },
+        request_timeout: Duration::from_secs(1),
+    }
+}
+
+fn valid_command(command_id: &str) -> CommandRequest {
+    CommandRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("client id"),
+        client_command_id: LocalClientCommandId::new(command_id).expect("command id"),
+        command_name: "send-user-input".to_owned(),
+        payload: serde_json::json!({"message": "hello"}),
+    }
+}
+
+fn valid_attach(command_id: &str) -> AttachRequest {
+    AttachRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("client id"),
+        client_command_id: LocalClientCommandId::new(command_id).expect("command id"),
+        subscription: LocalClientSubscription {
+            task_scope: LocalTaskScope::AllTasks,
+            detail_level: LocalDetailLevel::Summary,
+            include_model_call_status: false,
+            include_tool_execution_status: false,
+            include_debug_notices: false,
+        },
+    }
+}
+
+fn notice_frame(seq: u64) -> LocalClientFrame {
+    LocalClientFrame::Notice(selvedge_local_protocol::LocalClientNoticeFrame {
+        delivery_seq: seq,
+        client_command_id: LocalClientCommandId::new(format!("notice-{seq}")).expect("command id"),
+        notice: LocalNotice {
+            level: LocalNoticeLevel::Info,
+            message_text: format!("notice {seq}"),
+        },
+    })
+}
+
+async fn next_seq(stream: &mut LocalFrameStream) -> Result<u64, LocalClientError> {
+    match stream.next().await {
+        Some(Ok(LocalClientFrame::Notice(frame))) => Ok(frame.delivery_seq),
+        Some(Ok(_)) => Err(LocalClientError::TransportFailed(
+            "unexpected frame kind".to_owned(),
+        )),
+        Some(Err(error)) => Err(error),
+        None => Err(LocalClientError::StreamClosed),
+    }
+}

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -536,6 +536,36 @@ async fn close_closes_transport_and_later_methods_return_closed() {
     );
 }
 
+#[tokio::test]
+async fn cancelling_pending_close_restores_previous_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state.lock().expect("fake state").close_action = CloseAction::Hang;
+    let client = connected_client(state).await;
+
+    let mut close = Box::pin(client.close());
+    assert!(
+        timeout(Duration::from_millis(5), close.as_mut())
+            .await
+            .is_err()
+    );
+    assert_eq!(client.state().await, LocalClientState::Closing);
+
+    drop(close);
+
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    assert_eq!(
+        client
+            .ready(ReadyRequest {
+                protocol_version: current_protocol_version(),
+            })
+            .await
+            .expect("ready after close cancellation")
+            .state,
+        ReadyState::Ready
+    );
+}
+
 #[test]
 fn crate_has_no_systemd_dependency() {
     let manifest = fs::read_to_string(format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR")))
@@ -555,9 +585,16 @@ struct FakeTransportState {
     command_calls: usize,
     attach_calls: usize,
     close_calls: usize,
+    close_action: CloseAction,
     ready_responses: VecDeque<ReadyAction>,
     command_responses: VecDeque<CommandAction>,
     attach_responses: VecDeque<AttachAction>,
+}
+
+#[derive(Clone, Copy)]
+enum CloseAction {
+    Complete,
+    Hang,
 }
 
 enum ReadyAction {
@@ -587,6 +624,7 @@ impl FakeTransportState {
             command_calls: 0,
             attach_calls: 0,
             close_calls: 0,
+            close_action: CloseAction::Complete,
             ready_responses: VecDeque::new(),
             command_responses: VecDeque::new(),
             attach_responses: VecDeque::new(),
@@ -684,7 +722,16 @@ impl LocalTransport for FakeTransport {
     }
 
     async fn close(&self) {
-        self.state.lock().expect("fake state").close_calls += 1;
+        let action = {
+            let mut state = self.state.lock().expect("fake state");
+            state.close_calls += 1;
+            state.close_action
+        };
+
+        match action {
+            CloseAction::Complete => {}
+            CloseAction::Hang => future::pending().await,
+        }
     }
 }
 

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -401,6 +401,64 @@ async fn attach_closure_during_pending_command_restores_ready_after_command_succ
 }
 
 #[tokio::test]
+async fn dropping_exhausted_old_stream_does_not_clear_newer_attach_stream() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::empty()),
+        ))));
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-2").expect("command id"),
+            },
+            Box::pin(stream::pending()),
+        ))));
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-3").expect("command id"),
+            },
+            Box::pin(stream::empty()),
+        ))));
+    }
+    let client = connected_client(state.clone()).await;
+    let (_accepted, mut old_frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+    assert_eq!(
+        old_frames.next().await,
+        Some(Err(LocalClientError::StreamClosed))
+    );
+    assert_eq!(client.state().await, LocalClientState::Ready);
+
+    let (_accepted, _new_frames) = client
+        .attach(valid_attach("attach-2"))
+        .await
+        .expect("second attach");
+    drop(old_frames);
+
+    assert_eq!(client.state().await, LocalClientState::Attached);
+    assert!(matches!(
+        client.attach(valid_attach("attach-3")).await,
+        Err(AttachRejectedOrClientError::Client(
+            LocalClientError::AlreadyAttached
+        ))
+    ));
+    assert_eq!(state.lock().expect("fake state").attach_calls, 2);
+}
+
+#[tokio::test]
 async fn attach_validates_request_before_transport() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -294,6 +294,55 @@ async fn attach_allows_one_active_stream_and_reports_stream_closed_after_ordered
 }
 
 #[tokio::test]
+async fn attach_closure_during_pending_command_restores_ready_after_command_cancel() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::pending()),
+        ))));
+        state.command_responses.push_back(CommandAction::Hang);
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-2").expect("command id"),
+            },
+            Box::pin(stream::empty()),
+        ))));
+    }
+    let client = connected_client(state.clone()).await;
+    let (_accepted, frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+
+    let mut command = Box::pin(client.submit_command(valid_command("command-1")));
+    assert!(
+        timeout(Duration::from_millis(5), command.as_mut())
+            .await
+            .is_err()
+    );
+    assert_eq!(client.state().await, LocalClientState::CommandPending);
+
+    drop(frames);
+    drop(command);
+
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    let (_accepted, _frames) = client
+        .attach(valid_attach("attach-2"))
+        .await
+        .expect("reattach");
+    assert_eq!(state.lock().expect("fake state").attach_calls, 2);
+}
+
+#[tokio::test]
 async fn attach_validates_request_before_transport() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -525,6 +525,97 @@ async fn close_returns_busy_while_request_is_pending() {
 }
 
 #[tokio::test]
+async fn cancelling_close_after_stream_drop_restores_ready_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.close_action = CloseAction::Hang;
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::pending()),
+        ))));
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-2").expect("command id"),
+            },
+            Box::pin(stream::empty()),
+        ))));
+    }
+    let client = connected_client(state.clone()).await;
+    let (_accepted, frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+    let mut close = Box::pin(client.close());
+    assert!(
+        timeout(Duration::from_millis(5), close.as_mut())
+            .await
+            .is_err()
+    );
+
+    drop(frames);
+    drop(close);
+
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    let (_accepted, _frames) = client
+        .attach(valid_attach("attach-2"))
+        .await
+        .expect("reattach after close cancellation");
+    assert_eq!(state.lock().expect("fake state").attach_calls, 2);
+}
+
+#[tokio::test]
+async fn attach_stream_error_terminates_old_stream() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::iter(vec![
+                Err(LocalClientError::TransportClosed),
+                Ok(notice_frame(1)),
+            ])),
+        ))));
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-2").expect("command id"),
+            },
+            Box::pin(stream::pending()),
+        ))));
+    }
+    let client = connected_client(state).await;
+    let (_accepted, mut old_frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+    assert_eq!(
+        old_frames.next().await,
+        Some(Err(LocalClientError::TransportClosed))
+    );
+    let (_accepted, _new_frames) = client
+        .attach(valid_attach("attach-2"))
+        .await
+        .expect("reattach");
+
+    assert_eq!(old_frames.next().await, None);
+    assert_eq!(client.state().await, LocalClientState::Attached);
+}
+
+#[tokio::test]
 async fn attach_validates_request_before_transport() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -664,6 +664,76 @@ async fn attach_stream_error_terminates_old_stream() {
 }
 
 #[tokio::test]
+async fn attach_stream_error_fuses_even_when_inner_stream_stays_pending() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(
+                stream::iter(vec![Err(LocalClientError::TransportClosed)]).chain(stream::pending()),
+            ),
+        ))));
+    let client = connected_client(state).await;
+    let (_accepted, mut frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+
+    assert_eq!(
+        frames.next().await,
+        Some(Err(LocalClientError::TransportClosed))
+    );
+    assert_eq!(
+        timeout(Duration::from_millis(5), frames.next()).await,
+        Ok(None)
+    );
+}
+
+#[tokio::test]
+async fn cancelled_close_from_failed_state_preserves_recent_error() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.close_action = CloseAction::Hang;
+        state.ready_responses.push_back(ReadyAction::Hang);
+    }
+    let client = connected_client_with_timeout(state, Duration::from_millis(5)).await;
+    assert_eq!(
+        client
+            .ready(ReadyRequest {
+                protocol_version: current_protocol_version(),
+            })
+            .await,
+        Err(LocalClientError::Timeout)
+    );
+    let mut close = Box::pin(client.close());
+    assert!(
+        timeout(Duration::from_millis(5), close.as_mut())
+            .await
+            .is_err()
+    );
+
+    drop(close);
+
+    assert_eq!(client.state().await, LocalClientState::Failed);
+    assert_eq!(
+        client
+            .submit_command(valid_command("after-failed-close"))
+            .await,
+        Err(LocalClientError::Timeout)
+    );
+}
+
+#[tokio::test]
 async fn attach_validates_request_before_transport() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -11,10 +11,10 @@ use selvedge_local_client::{
     LocalEndpoint, LocalFrameStream, LocalTransport, connect,
 };
 use selvedge_local_protocol::{
-    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
-    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientFrame, LocalClientId,
-    LocalClientSubscription, LocalDetailLevel, LocalNotice, LocalNoticeLevel, LocalTaskScope,
-    ReadyRequest, ReadyResponse, ReadyState, current_protocol_version,
+    AttachAccepted, AttachRejectReason, AttachRejected, AttachRequest, CommandOutcome,
+    CommandRejectReason, CommandRequest, CommandResponse, LocalClientCommandId, LocalClientFrame,
+    LocalClientId, LocalClientSubscription, LocalDetailLevel, LocalNotice, LocalNoticeLevel,
+    LocalTaskScope, ReadyRequest, ReadyResponse, ReadyState, current_protocol_version,
 };
 use tokio::sync::{Mutex as AsyncMutex, oneshot};
 use tokio::time::timeout;
@@ -771,7 +771,7 @@ async fn attach_rejection_restores_idle_state() {
             AttachRejectedOrClientError::Rejected(AttachRejected {
                 protocol_version: current_protocol_version(),
                 client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
-                reason: CommandRejectReason::ServerNotReady,
+                reason: AttachRejectReason::ServerNotReady,
             }),
         )));
     let client = connected_client(state).await;
@@ -784,7 +784,7 @@ async fn attach_rejection_restores_idle_state() {
     assert!(matches!(
         rejected,
         AttachRejectedOrClientError::Rejected(AttachRejected {
-            reason: CommandRejectReason::ServerNotReady,
+            reason: AttachRejectReason::ServerNotReady,
             ..
         })
     ));

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -572,6 +572,54 @@ async fn cancelling_close_after_stream_drop_restores_ready_state() {
 }
 
 #[tokio::test]
+async fn cancelling_close_with_live_stream_restores_attached_state() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.close_action = CloseAction::Hang;
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::pending()),
+        ))));
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-2").expect("command id"),
+            },
+            Box::pin(stream::empty()),
+        ))));
+    }
+    let client = connected_client(state.clone()).await;
+    let (_accepted, _frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+    let mut close = Box::pin(client.close());
+    assert!(
+        timeout(Duration::from_millis(5), close.as_mut())
+            .await
+            .is_err()
+    );
+
+    drop(close);
+
+    assert_eq!(client.state().await, LocalClientState::Attached);
+    assert!(matches!(
+        client.attach(valid_attach("attach-2")).await,
+        Err(AttachRejectedOrClientError::Client(
+            LocalClientError::AlreadyAttached
+        ))
+    ));
+    assert_eq!(state.lock().expect("fake state").attach_calls, 1);
+}
+
+#[tokio::test]
 async fn attach_stream_error_terminates_old_stream() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -812,6 +812,34 @@ async fn close_closes_transport_and_later_methods_return_closed() {
 }
 
 #[tokio::test]
+async fn close_fuses_existing_attach_stream() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::iter(vec![Ok(notice_frame(1))])),
+        ))));
+    let client = connected_client(state).await;
+    let (_accepted, mut frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+
+    client.close().await.expect("close client");
+
+    assert_eq!(frames.next().await, None);
+    assert_eq!(client.state().await, LocalClientState::Closed);
+}
+
+#[tokio::test]
 async fn cancelling_pending_close_restores_previous_state() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();

--- a/crates/local-client/tests/local_client_contract.rs
+++ b/crates/local-client/tests/local_client_contract.rs
@@ -16,7 +16,7 @@ use selvedge_local_protocol::{
     LocalClientSubscription, LocalDetailLevel, LocalNotice, LocalNoticeLevel, LocalTaskScope,
     ReadyRequest, ReadyResponse, ReadyState, current_protocol_version,
 };
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, oneshot};
 use tokio::time::timeout;
 
 static TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
@@ -343,6 +343,64 @@ async fn attach_closure_during_pending_command_restores_ready_after_command_canc
 }
 
 #[tokio::test]
+async fn attach_closure_during_pending_command_restores_ready_after_command_success() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    let (release_tx, release_rx) = oneshot::channel();
+    {
+        let mut state = state.lock().expect("fake state");
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            },
+            Box::pin(stream::pending()),
+        ))));
+        state
+            .command_responses
+            .push_back(CommandAction::WaitForRelease {
+                release_rx,
+                response: Ok(CommandResponse {
+                    protocol_version: current_protocol_version(),
+                    client_command_id: LocalClientCommandId::new("command-1").expect("command id"),
+                    outcome: CommandOutcome::Accepted,
+                }),
+            });
+        state.attach_responses.push_back(AttachAction::Response(Ok((
+            AttachAccepted {
+                protocol_version: current_protocol_version(),
+                client_id: LocalClientId::new("client-1").expect("client id"),
+                client_command_id: LocalClientCommandId::new("attach-2").expect("command id"),
+            },
+            Box::pin(stream::empty()),
+        ))));
+    }
+    let client = connected_client(state.clone()).await;
+    let (_accepted, frames) = client
+        .attach(valid_attach("attach-1"))
+        .await
+        .expect("attach");
+
+    let mut command = Box::pin(client.submit_command(valid_command("command-1")));
+    assert!(
+        timeout(Duration::from_millis(5), command.as_mut())
+            .await
+            .is_err()
+    );
+    drop(frames);
+    release_tx.send(()).expect("release command");
+    command.await.expect("command response");
+
+    assert_eq!(client.state().await, LocalClientState::Ready);
+    let (_accepted, _frames) = client
+        .attach(valid_attach("attach-2"))
+        .await
+        .expect("reattach");
+    assert_eq!(state.lock().expect("fake state").attach_calls, 2);
+}
+
+#[tokio::test]
 async fn attach_validates_request_before_transport() {
     let _guard = TEST_LOCK.lock().await;
     let state = FakeTransportState::new_handle();
@@ -451,6 +509,10 @@ enum ReadyAction {
 
 enum CommandAction {
     Response(Result<CommandResponse, LocalClientError>),
+    WaitForRelease {
+        release_rx: oneshot::Receiver<()>,
+        response: Result<CommandResponse, LocalClientError>,
+    },
     Hang,
 }
 
@@ -526,6 +588,13 @@ impl LocalTransport for FakeTransport {
 
         match action {
             CommandAction::Response(response) => response,
+            CommandAction::WaitForRelease {
+                release_rx,
+                response,
+            } => {
+                let _ = release_rx.await;
+                response
+            }
             CommandAction::Hang => future::pending().await,
         }
     }

--- a/crates/local-protocol/Cargo.toml
+++ b/crates/local-protocol/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "selvedge-local-protocol"
+edition = "2024"
+publish = false
+
+[dependencies]
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.145"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/local-protocol/README.md
+++ b/crates/local-protocol/README.md
@@ -1,0 +1,7 @@
+# local-protocol
+
+This crate defines the localhost protocol data model shared by the Selvedge server, root CLI, local client, TUI, and web client.
+
+Use it for serializable ready probes, command submission envelopes, attach requests, attach responses, client subscriptions, client frames, snapshots, projections, events, and validation errors.
+
+This crate does not access the network, database, filesystem, runtime, or mailbox. Transport limits, authentication, concrete command support, payload schemas, and task existence checks are enforced by the crates that own those boundaries.

--- a/crates/local-protocol/README.md
+++ b/crates/local-protocol/README.md
@@ -5,3 +5,5 @@ This crate defines the localhost protocol data model shared by the Selvedge serv
 Use it for serializable ready probes, command submission envelopes, attach requests, attach responses, client subscriptions, client frames, snapshots, projections, events, and validation errors.
 
 This crate does not access the network, database, filesystem, runtime, or mailbox. Transport limits, authentication, concrete command support, payload schemas, and task existence checks are enforced by the crates that own those boundaries.
+
+Command rejection and attach rejection use separate reason enums. Attach rejection must cover protocol mismatch, malformed request, server not ready, duplicate active attach, client registry capacity exhaustion, router mailbox closure, client-sync unavailability, attach channel creation failure, and internal failure.

--- a/crates/local-protocol/src/lib.rs
+++ b/crates/local-protocol/src/lib.rs
@@ -308,7 +308,7 @@ pub enum LocalToolArgumentValue {
     Boolean(bool),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LocalProtocolValidationError {
     ProtocolVersionMismatch,
     EmptyClientId,
@@ -427,6 +427,11 @@ pub fn validate_snapshot(
 ) -> Result<(), LocalProtocolValidationError> {
     for task in &snapshot.tasks {
         validate_task_projection(task)?;
+    }
+
+    for parent_edge in &snapshot.task_parent_edges {
+        validate_task_id(&parent_edge.parent_task_id)?;
+        validate_task_id(&parent_edge.child_task_id)?;
     }
 
     for history_node in &snapshot.history_nodes {
@@ -562,13 +567,28 @@ fn validate_client_event(event: &LocalClientEvent) -> Result<(), LocalProtocolVa
     match event {
         LocalClientEvent::TaskChanged(event) => validate_task_projection(&event.task),
         LocalClientEvent::HistoryAppended(event) => {
+            validate_task_id(&event.task_id)?;
             for node in &event.appended_nodes {
                 validate_history_node(node)?;
             }
             Ok(())
         }
-        LocalClientEvent::ModelCallStatus(_)
-        | LocalClientEvent::ToolExecutionStatus(_)
-        | LocalClientEvent::DebugNotice(_) => Ok(()),
+        LocalClientEvent::ModelCallStatus(event) => validate_task_id(&event.task_id),
+        LocalClientEvent::ToolExecutionStatus(event) => {
+            validate_task_id(&event.task_id)?;
+            if event.function_call_node_id <= 0 {
+                return Err(LocalProtocolValidationError::InvalidHistoryNodeId);
+            }
+            validate_tool_name(&event.tool_name)
+        }
+        LocalClientEvent::DebugNotice(event) => {
+            if let Some(task_id) = &event.task_id {
+                validate_task_id(task_id)?;
+            }
+            if event.message_text.trim().is_empty() {
+                return Err(LocalProtocolValidationError::EmptyNoticeText);
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/local-protocol/src/lib.rs
+++ b/crates/local-protocol/src/lib.rs
@@ -1,0 +1,574 @@
+#![doc = include_str!("../README.md")]
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+pub const LOCAL_PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolVersion(pub u32);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct LocalClientId(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct LocalClientCommandId(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadyRequest {
+    pub protocol_version: ProtocolVersion,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadyResponse {
+    pub protocol_version: ProtocolVersion,
+    pub state: ReadyState,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReadyState {
+    Ready,
+    NotReady,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CommandRequest {
+    pub protocol_version: ProtocolVersion,
+    pub client_id: LocalClientId,
+    pub client_command_id: LocalClientCommandId,
+    pub command_name: String,
+    pub payload: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandResponse {
+    pub protocol_version: ProtocolVersion,
+    pub client_command_id: LocalClientCommandId,
+    pub outcome: CommandOutcome,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommandOutcome {
+    Accepted,
+    Rejected(CommandRejectReason),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommandRejectReason {
+    ProtocolVersionMismatch,
+    MalformedRequest,
+    ServerNotReady,
+    UnsupportedCommand,
+    RouterMailboxClosed,
+    InternalFailure,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttachRequest {
+    pub protocol_version: ProtocolVersion,
+    pub client_id: LocalClientId,
+    pub client_command_id: LocalClientCommandId,
+    pub subscription: LocalClientSubscription,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttachAccepted {
+    pub protocol_version: ProtocolVersion,
+    pub client_id: LocalClientId,
+    pub client_command_id: LocalClientCommandId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttachRejected {
+    pub protocol_version: ProtocolVersion,
+    pub client_command_id: LocalClientCommandId,
+    pub reason: CommandRejectReason,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalClientSubscription {
+    pub task_scope: LocalTaskScope,
+    pub detail_level: LocalDetailLevel,
+    pub include_model_call_status: bool,
+    pub include_tool_execution_status: bool,
+    pub include_debug_notices: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalTaskScope {
+    AllTasks,
+    TaskIds(Vec<String>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalDetailLevel {
+    Summary,
+    Verbose,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum LocalClientFrame {
+    Snapshot(LocalClientSnapshotFrame),
+    Event(LocalClientEventFrame),
+    Notice(LocalClientNoticeFrame),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocalClientSnapshotFrame {
+    pub delivery_seq: u64,
+    pub client_command_id: LocalClientCommandId,
+    pub snapshot: LocalClientSnapshot,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocalClientEventFrame {
+    pub delivery_seq: u64,
+    pub event: LocalClientEvent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalClientNoticeFrame {
+    pub delivery_seq: u64,
+    pub client_command_id: LocalClientCommandId,
+    pub notice: LocalNotice,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocalClientSnapshot {
+    pub generated_at: i64,
+    pub tasks: Vec<LocalTaskProjection>,
+    pub task_parent_edges: Vec<LocalTaskParentProjection>,
+    pub history_nodes: Vec<LocalHistoryNodeProjection>,
+    pub task_versions: Vec<LocalSnapshotTaskVersion>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalSnapshotTaskVersion {
+    pub task_id: String,
+    pub state_version: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalTaskProjection {
+    pub task_id: String,
+    pub status: LocalTaskProjectionStatus,
+    pub cursor_node_id: i64,
+    pub model_profile_key: String,
+    pub reasoning_effort: LocalReasoningEffort,
+    pub state_version: u64,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalTaskProjectionStatus {
+    Active,
+    Archived,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalTaskParentProjection {
+    pub parent_task_id: String,
+    pub child_task_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocalHistoryNodeProjection {
+    pub node_id: i64,
+    pub parent_node_id: Option<i64>,
+    pub created_at: i64,
+    pub body: LocalHistoryNodeProjectionBody,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum LocalHistoryNodeProjectionBody {
+    Message {
+        role: LocalMessageRole,
+        text: String,
+    },
+    Reasoning {
+        text: String,
+    },
+    FunctionCall {
+        function_call_id: String,
+        tool_name: String,
+        arguments: Vec<LocalToolCallArgument>,
+    },
+    FunctionOutput {
+        function_call_node_id: i64,
+        function_call_id: String,
+        tool_name: String,
+        output_text: String,
+        is_error: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum LocalClientEvent {
+    TaskChanged(LocalTaskChangedEvent),
+    HistoryAppended(LocalHistoryAppendedEvent),
+    ModelCallStatus(LocalModelCallStatusEvent),
+    ToolExecutionStatus(LocalToolExecutionStatusEvent),
+    DebugNotice(LocalDebugNoticeEvent),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocalTaskChangedEvent {
+    pub task: LocalTaskProjection,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocalHistoryAppendedEvent {
+    pub task_id: String,
+    pub task_state_version: u64,
+    pub appended_nodes: Vec<LocalHistoryNodeProjection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalModelCallStatusEvent {
+    pub task_id: String,
+    pub model_call_id: String,
+    pub phase: LocalModelCallStatusPhase,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalToolExecutionStatusEvent {
+    pub task_id: String,
+    pub tool_execution_run_id: String,
+    pub function_call_node_id: i64,
+    pub tool_name: String,
+    pub phase: LocalToolExecutionStatusPhase,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalDebugNoticeEvent {
+    pub task_id: Option<String>,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalNotice {
+    pub level: LocalNoticeLevel,
+    pub message_text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalNoticeLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalModelCallStatusPhase {
+    Requested,
+    Completed,
+    Failed,
+    Discarded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalToolExecutionStatusPhase {
+    Requested,
+    Completed,
+    Failed,
+    Discarded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalMessageRole {
+    System,
+    Developer,
+    User,
+    Assistant,
+    Tool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalReasoningEffort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocalToolCallArgument {
+    pub name: String,
+    pub value: LocalToolArgumentValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum LocalToolArgumentValue {
+    String(String),
+    Integer(i64),
+    Number(f64),
+    Boolean(bool),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LocalProtocolValidationError {
+    ProtocolVersionMismatch,
+    EmptyClientId,
+    EmptyClientCommandId,
+    EmptyCommandName,
+    EmptyTaskId,
+    DuplicateTaskId,
+    InvalidDeliverySeq,
+    DuplicateSnapshotTaskVersion,
+    InvalidHistoryNodeId,
+    InvalidParentHistoryNodeId,
+    EmptyModelProfileKey,
+    EmptyToolName,
+    EmptyToolArgumentName,
+    EmptyNoticeText,
+}
+
+impl LocalClientId {
+    pub fn new(value: impl Into<String>) -> Result<Self, LocalProtocolValidationError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(LocalProtocolValidationError::EmptyClientId);
+        }
+
+        Ok(Self(value))
+    }
+}
+
+impl LocalClientCommandId {
+    pub fn new(value: impl Into<String>) -> Result<Self, LocalProtocolValidationError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(LocalProtocolValidationError::EmptyClientCommandId);
+        }
+
+        Ok(Self(value))
+    }
+}
+
+pub fn current_protocol_version() -> ProtocolVersion {
+    ProtocolVersion(LOCAL_PROTOCOL_VERSION)
+}
+
+pub fn validate_ready_request(request: &ReadyRequest) -> Result<(), LocalProtocolValidationError> {
+    validate_protocol_version(request.protocol_version)?;
+
+    Ok(())
+}
+
+pub fn validate_command_request(
+    request: &CommandRequest,
+) -> Result<(), LocalProtocolValidationError> {
+    validate_protocol_version(request.protocol_version)?;
+    validate_client_id(&request.client_id)?;
+    validate_client_command_id(&request.client_command_id)?;
+    if request.command_name.trim().is_empty() {
+        return Err(LocalProtocolValidationError::EmptyCommandName);
+    }
+
+    Ok(())
+}
+
+pub fn validate_attach_request(
+    request: &AttachRequest,
+) -> Result<(), LocalProtocolValidationError> {
+    validate_protocol_version(request.protocol_version)?;
+    validate_client_id(&request.client_id)?;
+    validate_client_command_id(&request.client_command_id)?;
+    validate_subscription(&request.subscription)?;
+
+    Ok(())
+}
+
+pub fn validate_subscription(
+    subscription: &LocalClientSubscription,
+) -> Result<(), LocalProtocolValidationError> {
+    if let LocalTaskScope::TaskIds(task_ids) = &subscription.task_scope {
+        let mut seen = BTreeSet::new();
+        for task_id in task_ids {
+            let task_id = task_id.trim();
+            if task_id.is_empty() {
+                return Err(LocalProtocolValidationError::EmptyTaskId);
+            }
+            if !seen.insert(task_id) {
+                return Err(LocalProtocolValidationError::DuplicateTaskId);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_client_frame(frame: &LocalClientFrame) -> Result<(), LocalProtocolValidationError> {
+    match frame {
+        LocalClientFrame::Snapshot(frame) => {
+            validate_delivery_seq(frame.delivery_seq)?;
+            validate_client_command_id(&frame.client_command_id)?;
+            validate_snapshot(&frame.snapshot)?;
+        }
+        LocalClientFrame::Event(frame) => {
+            validate_delivery_seq(frame.delivery_seq)?;
+            validate_client_event(&frame.event)?;
+        }
+        LocalClientFrame::Notice(frame) => {
+            validate_delivery_seq(frame.delivery_seq)?;
+            validate_client_command_id(&frame.client_command_id)?;
+            validate_notice(&frame.notice)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_snapshot(
+    snapshot: &LocalClientSnapshot,
+) -> Result<(), LocalProtocolValidationError> {
+    for task in &snapshot.tasks {
+        validate_task_projection(task)?;
+    }
+
+    for history_node in &snapshot.history_nodes {
+        validate_history_node(history_node)?;
+    }
+
+    let mut seen = BTreeSet::new();
+    for task_version in &snapshot.task_versions {
+        validate_task_id(&task_version.task_id)?;
+        if !seen.insert(task_version.task_id.trim()) {
+            return Err(LocalProtocolValidationError::DuplicateSnapshotTaskVersion);
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_protocol_version(
+    protocol_version: ProtocolVersion,
+) -> Result<(), LocalProtocolValidationError> {
+    if protocol_version != current_protocol_version() {
+        return Err(LocalProtocolValidationError::ProtocolVersionMismatch);
+    }
+
+    Ok(())
+}
+
+fn validate_client_id(client_id: &LocalClientId) -> Result<(), LocalProtocolValidationError> {
+    if client_id.0.trim().is_empty() {
+        return Err(LocalProtocolValidationError::EmptyClientId);
+    }
+
+    Ok(())
+}
+
+fn validate_client_command_id(
+    client_command_id: &LocalClientCommandId,
+) -> Result<(), LocalProtocolValidationError> {
+    if client_command_id.0.trim().is_empty() {
+        return Err(LocalProtocolValidationError::EmptyClientCommandId);
+    }
+
+    Ok(())
+}
+
+fn validate_task_id(task_id: &str) -> Result<(), LocalProtocolValidationError> {
+    if task_id.trim().is_empty() {
+        return Err(LocalProtocolValidationError::EmptyTaskId);
+    }
+
+    Ok(())
+}
+
+fn validate_delivery_seq(delivery_seq: u64) -> Result<(), LocalProtocolValidationError> {
+    if delivery_seq == 0 {
+        return Err(LocalProtocolValidationError::InvalidDeliverySeq);
+    }
+
+    Ok(())
+}
+
+fn validate_task_projection(
+    task: &LocalTaskProjection,
+) -> Result<(), LocalProtocolValidationError> {
+    validate_task_id(&task.task_id)?;
+    if task.cursor_node_id <= 0 {
+        return Err(LocalProtocolValidationError::InvalidHistoryNodeId);
+    }
+    if task.model_profile_key.trim().is_empty() {
+        return Err(LocalProtocolValidationError::EmptyModelProfileKey);
+    }
+
+    Ok(())
+}
+
+fn validate_history_node(
+    history_node: &LocalHistoryNodeProjection,
+) -> Result<(), LocalProtocolValidationError> {
+    if history_node.node_id <= 0 {
+        return Err(LocalProtocolValidationError::InvalidHistoryNodeId);
+    }
+    if history_node
+        .parent_node_id
+        .is_some_and(|node_id| node_id <= 0)
+    {
+        return Err(LocalProtocolValidationError::InvalidParentHistoryNodeId);
+    }
+    validate_history_node_body(&history_node.body)
+}
+
+fn validate_history_node_body(
+    body: &LocalHistoryNodeProjectionBody,
+) -> Result<(), LocalProtocolValidationError> {
+    match body {
+        LocalHistoryNodeProjectionBody::Message { .. }
+        | LocalHistoryNodeProjectionBody::Reasoning { .. } => Ok(()),
+        LocalHistoryNodeProjectionBody::FunctionCall {
+            tool_name,
+            arguments,
+            ..
+        } => {
+            validate_tool_name(tool_name)?;
+            for argument in arguments {
+                if argument.name.trim().is_empty() {
+                    return Err(LocalProtocolValidationError::EmptyToolArgumentName);
+                }
+            }
+            Ok(())
+        }
+        LocalHistoryNodeProjectionBody::FunctionOutput { tool_name, .. } => {
+            validate_tool_name(tool_name)
+        }
+    }
+}
+
+fn validate_tool_name(tool_name: &str) -> Result<(), LocalProtocolValidationError> {
+    if tool_name.trim().is_empty() {
+        return Err(LocalProtocolValidationError::EmptyToolName);
+    }
+
+    Ok(())
+}
+
+fn validate_notice(notice: &LocalNotice) -> Result<(), LocalProtocolValidationError> {
+    if notice.message_text.trim().is_empty() {
+        return Err(LocalProtocolValidationError::EmptyNoticeText);
+    }
+
+    Ok(())
+}
+
+fn validate_client_event(event: &LocalClientEvent) -> Result<(), LocalProtocolValidationError> {
+    match event {
+        LocalClientEvent::TaskChanged(event) => validate_task_projection(&event.task),
+        LocalClientEvent::HistoryAppended(event) => {
+            for node in &event.appended_nodes {
+                validate_history_node(node)?;
+            }
+            Ok(())
+        }
+        LocalClientEvent::ModelCallStatus(_)
+        | LocalClientEvent::ToolExecutionStatus(_)
+        | LocalClientEvent::DebugNotice(_) => Ok(()),
+    }
+}

--- a/crates/local-protocol/src/lib.rs
+++ b/crates/local-protocol/src/lib.rs
@@ -541,7 +541,14 @@ fn validate_history_node_body(
             }
             Ok(())
         }
-        LocalHistoryNodeProjectionBody::FunctionOutput { tool_name, .. } => {
+        LocalHistoryNodeProjectionBody::FunctionOutput {
+            function_call_node_id,
+            tool_name,
+            ..
+        } => {
+            if *function_call_node_id <= 0 {
+                return Err(LocalProtocolValidationError::InvalidHistoryNodeId);
+            }
             validate_tool_name(tool_name)
         }
     }

--- a/crates/local-protocol/src/lib.rs
+++ b/crates/local-protocol/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeSet;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-pub const LOCAL_PROTOCOL_VERSION: u32 = 1;
+pub const LOCAL_PROTOCOL_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProtocolVersion(pub u32);

--- a/crates/local-protocol/src/lib.rs
+++ b/crates/local-protocol/src/lib.rs
@@ -66,6 +66,19 @@ pub enum CommandRejectReason {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AttachRejectReason {
+    ProtocolVersionMismatch,
+    MalformedRequest,
+    ServerNotReady,
+    DuplicateAttach,
+    ClientRegistryFull,
+    RouterMailboxClosed,
+    ClientSyncUnavailable,
+    AttachChannelFailed,
+    InternalFailure,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttachRequest {
     pub protocol_version: ProtocolVersion,
     pub client_id: LocalClientId,
@@ -84,7 +97,7 @@ pub struct AttachAccepted {
 pub struct AttachRejected {
     pub protocol_version: ProtocolVersion,
     pub client_command_id: LocalClientCommandId,
-    pub reason: CommandRejectReason,
+    pub reason: AttachRejectReason,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/local-protocol/tests/local_protocol_contract.rs
+++ b/crates/local-protocol/tests/local_protocol_contract.rs
@@ -1,0 +1,310 @@
+use selvedge_local_protocol::{
+    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
+    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientEvent, LocalClientEventFrame,
+    LocalClientFrame, LocalClientId, LocalClientNoticeFrame, LocalClientSnapshot,
+    LocalClientSnapshotFrame, LocalClientSubscription, LocalDebugNoticeEvent, LocalDetailLevel,
+    LocalHistoryNodeProjection, LocalHistoryNodeProjectionBody, LocalMessageRole,
+    LocalModelCallStatusEvent, LocalModelCallStatusPhase, LocalNotice, LocalNoticeLevel,
+    LocalProtocolValidationError, LocalReasoningEffort, LocalSnapshotTaskVersion,
+    LocalTaskParentProjection, LocalTaskProjection, LocalTaskProjectionStatus, LocalTaskScope,
+    LocalToolArgumentValue, LocalToolCallArgument, LocalToolExecutionStatusEvent,
+    LocalToolExecutionStatusPhase, ProtocolVersion, ReadyRequest, ReadyResponse, ReadyState,
+    current_protocol_version, validate_attach_request, validate_client_frame,
+    validate_command_request, validate_ready_request, validate_snapshot, validate_subscription,
+};
+use serde_json::json;
+
+#[test]
+fn request_validation_enforces_protocol_version_and_required_client_fields() {
+    assert_eq!(current_protocol_version(), ProtocolVersion(1));
+
+    let ready = ReadyRequest {
+        protocol_version: ProtocolVersion(2),
+    };
+    assert_eq!(
+        validate_ready_request(&ready),
+        Err(LocalProtocolValidationError::ProtocolVersionMismatch)
+    );
+
+    assert_eq!(
+        LocalClientId::new(" "),
+        Err(LocalProtocolValidationError::EmptyClientId)
+    );
+    assert_eq!(
+        LocalClientCommandId::new(" "),
+        Err(LocalProtocolValidationError::EmptyClientCommandId)
+    );
+
+    let request = CommandRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_command_id: LocalClientCommandId::new("command-1").expect("valid command id"),
+        command_name: " ".to_owned(),
+        payload: json!({"message": "hello"}),
+    };
+    assert_eq!(
+        validate_command_request(&request),
+        Err(LocalProtocolValidationError::EmptyCommandName)
+    );
+}
+
+#[test]
+fn attach_validation_enforces_valid_subscription_filters() {
+    let valid_subscription = LocalClientSubscription {
+        task_scope: LocalTaskScope::TaskIds(vec!["task-1".to_owned(), "task-2".to_owned()]),
+        detail_level: LocalDetailLevel::Verbose,
+        include_model_call_status: true,
+        include_tool_execution_status: true,
+        include_debug_notices: false,
+    };
+    validate_subscription(&valid_subscription).expect("valid subscription");
+
+    let empty_task = LocalClientSubscription {
+        task_scope: LocalTaskScope::TaskIds(vec!["task-1".to_owned(), " ".to_owned()]),
+        ..valid_subscription.clone()
+    };
+    assert_eq!(
+        validate_subscription(&empty_task),
+        Err(LocalProtocolValidationError::EmptyTaskId)
+    );
+
+    let duplicate_task = LocalClientSubscription {
+        task_scope: LocalTaskScope::TaskIds(vec!["task-1".to_owned(), "task-1".to_owned()]),
+        ..valid_subscription.clone()
+    };
+    assert_eq!(
+        validate_subscription(&duplicate_task),
+        Err(LocalProtocolValidationError::DuplicateTaskId)
+    );
+
+    let attach = AttachRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+        subscription: valid_subscription,
+    };
+    validate_attach_request(&attach).expect("valid attach request");
+}
+
+#[test]
+fn frame_validation_enforces_delivery_sequence_snapshot_and_notice_contracts() {
+    let snapshot = valid_snapshot();
+    validate_snapshot(&snapshot).expect("valid snapshot");
+
+    let frame = LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
+        delivery_seq: 1,
+        client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+        snapshot: snapshot.clone(),
+    });
+    validate_client_frame(&frame).expect("valid snapshot frame");
+
+    let zero_seq = LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
+        delivery_seq: 0,
+        client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+        snapshot: snapshot.clone(),
+    });
+    assert_eq!(
+        validate_client_frame(&zero_seq),
+        Err(LocalProtocolValidationError::InvalidDeliverySeq)
+    );
+
+    let duplicate_version = LocalClientSnapshot {
+        task_versions: vec![
+            LocalSnapshotTaskVersion {
+                task_id: "task-1".to_owned(),
+                state_version: 1,
+            },
+            LocalSnapshotTaskVersion {
+                task_id: "task-1".to_owned(),
+                state_version: 2,
+            },
+        ],
+        ..snapshot.clone()
+    };
+    assert_eq!(
+        validate_snapshot(&duplicate_version),
+        Err(LocalProtocolValidationError::DuplicateSnapshotTaskVersion)
+    );
+
+    let invalid_task = LocalClientSnapshot {
+        tasks: vec![LocalTaskProjection {
+            cursor_node_id: 0,
+            ..valid_task_projection()
+        }],
+        ..snapshot.clone()
+    };
+    assert_eq!(
+        validate_snapshot(&invalid_task),
+        Err(LocalProtocolValidationError::InvalidHistoryNodeId)
+    );
+
+    let invalid_history_parent = LocalClientSnapshot {
+        history_nodes: vec![LocalHistoryNodeProjection {
+            parent_node_id: Some(0),
+            ..valid_history_message()
+        }],
+        ..snapshot.clone()
+    };
+    assert_eq!(
+        validate_snapshot(&invalid_history_parent),
+        Err(LocalProtocolValidationError::InvalidParentHistoryNodeId)
+    );
+
+    let empty_tool_argument = LocalClientSnapshot {
+        history_nodes: vec![LocalHistoryNodeProjection {
+            body: LocalHistoryNodeProjectionBody::FunctionCall {
+                function_call_id: "call-1".to_owned(),
+                tool_name: "tool".to_owned(),
+                arguments: vec![LocalToolCallArgument {
+                    name: " ".to_owned(),
+                    value: LocalToolArgumentValue::Boolean(true),
+                }],
+            },
+            ..valid_history_message()
+        }],
+        ..snapshot
+    };
+    assert_eq!(
+        validate_snapshot(&empty_tool_argument),
+        Err(LocalProtocolValidationError::EmptyToolArgumentName)
+    );
+
+    let empty_notice = LocalClientFrame::Notice(LocalClientNoticeFrame {
+        delivery_seq: 1,
+        client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+        notice: LocalNotice {
+            level: LocalNoticeLevel::Warning,
+            message_text: " ".to_owned(),
+        },
+    });
+    assert_eq!(
+        validate_client_frame(&empty_notice),
+        Err(LocalProtocolValidationError::EmptyNoticeText)
+    );
+}
+
+#[test]
+fn protocol_messages_round_trip_through_json() {
+    let ready = ReadyResponse {
+        protocol_version: current_protocol_version(),
+        state: ReadyState::Ready,
+    };
+    let ready_json = serde_json::to_string(&ready).expect("serialize ready response");
+    assert_eq!(
+        serde_json::from_str::<ReadyResponse>(&ready_json).expect("deserialize ready response"),
+        ready
+    );
+
+    let command = CommandResponse {
+        protocol_version: current_protocol_version(),
+        client_command_id: LocalClientCommandId::new("command-1").expect("valid command id"),
+        outcome: CommandOutcome::Rejected(CommandRejectReason::ServerNotReady),
+    };
+    let command_json = serde_json::to_string(&command).expect("serialize command response");
+    assert_eq!(
+        serde_json::from_str::<CommandResponse>(&command_json)
+            .expect("deserialize command response"),
+        command
+    );
+
+    let accepted = AttachAccepted {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+    };
+    let accepted_json = serde_json::to_string(&accepted).expect("serialize attach accepted");
+    assert_eq!(
+        serde_json::from_str::<AttachAccepted>(&accepted_json).expect("deserialize accepted"),
+        accepted
+    );
+
+    let rejected = AttachRejected {
+        protocol_version: current_protocol_version(),
+        client_command_id: LocalClientCommandId::new("attach-2").expect("valid command id"),
+        reason: CommandRejectReason::ProtocolVersionMismatch,
+    };
+    let rejected_json = serde_json::to_string(&rejected).expect("serialize attach rejected");
+    assert_eq!(
+        serde_json::from_str::<AttachRejected>(&rejected_json).expect("deserialize rejected"),
+        rejected
+    );
+
+    let event_frame = LocalClientFrame::Event(LocalClientEventFrame {
+        delivery_seq: 2,
+        event: LocalClientEvent::ToolExecutionStatus(LocalToolExecutionStatusEvent {
+            task_id: "task-1".to_owned(),
+            tool_execution_run_id: "tool-run-1".to_owned(),
+            function_call_node_id: 3,
+            tool_name: "tool".to_owned(),
+            phase: LocalToolExecutionStatusPhase::Completed,
+        }),
+    });
+    let event_json = serde_json::to_string(&event_frame).expect("serialize event frame");
+    assert_eq!(
+        serde_json::from_str::<LocalClientFrame>(&event_json).expect("deserialize event frame"),
+        event_frame
+    );
+
+    let model_event = LocalClientEvent::ModelCallStatus(LocalModelCallStatusEvent {
+        task_id: "task-1".to_owned(),
+        model_call_id: "model-call-1".to_owned(),
+        phase: LocalModelCallStatusPhase::Requested,
+    });
+    assert!(matches!(
+        model_event,
+        LocalClientEvent::ModelCallStatus(LocalModelCallStatusEvent {
+            phase: LocalModelCallStatusPhase::Requested,
+            ..
+        })
+    ));
+
+    let debug_event = LocalClientEvent::DebugNotice(LocalDebugNoticeEvent {
+        task_id: Some("task-1".to_owned()),
+        message_text: "debug".to_owned(),
+    });
+    assert!(matches!(debug_event, LocalClientEvent::DebugNotice(_)));
+
+    let parent_edge = LocalTaskParentProjection {
+        parent_task_id: "parent".to_owned(),
+        child_task_id: "child".to_owned(),
+    };
+    assert_eq!(parent_edge.child_task_id, "child");
+}
+
+fn valid_snapshot() -> LocalClientSnapshot {
+    LocalClientSnapshot {
+        generated_at: 100,
+        tasks: vec![valid_task_projection()],
+        task_parent_edges: Vec::new(),
+        history_nodes: vec![valid_history_message()],
+        task_versions: vec![LocalSnapshotTaskVersion {
+            task_id: "task-1".to_owned(),
+            state_version: 1,
+        }],
+    }
+}
+
+fn valid_task_projection() -> LocalTaskProjection {
+    LocalTaskProjection {
+        task_id: "task-1".to_owned(),
+        status: LocalTaskProjectionStatus::Active,
+        cursor_node_id: 1,
+        model_profile_key: "default".to_owned(),
+        reasoning_effort: LocalReasoningEffort::Medium,
+        state_version: 1,
+        created_at: 10,
+        updated_at: 20,
+    }
+}
+
+fn valid_history_message() -> LocalHistoryNodeProjection {
+    LocalHistoryNodeProjection {
+        node_id: 1,
+        parent_node_id: None,
+        created_at: 20,
+        body: LocalHistoryNodeProjectionBody::Message {
+            role: LocalMessageRole::User,
+            text: String::new(),
+        },
+    }
+}

--- a/crates/local-protocol/tests/local_protocol_contract.rs
+++ b/crates/local-protocol/tests/local_protocol_contract.rs
@@ -1,9 +1,9 @@
 use selvedge_local_protocol::{
-    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
-    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientEvent, LocalClientEventFrame,
-    LocalClientFrame, LocalClientId, LocalClientNoticeFrame, LocalClientSnapshot,
-    LocalClientSnapshotFrame, LocalClientSubscription, LocalDebugNoticeEvent, LocalDetailLevel,
-    LocalHistoryNodeProjection, LocalHistoryNodeProjectionBody, LocalMessageRole,
+    AttachAccepted, AttachRejectReason, AttachRejected, AttachRequest, CommandOutcome,
+    CommandRejectReason, CommandRequest, CommandResponse, LocalClientCommandId, LocalClientEvent,
+    LocalClientEventFrame, LocalClientFrame, LocalClientId, LocalClientNoticeFrame,
+    LocalClientSnapshot, LocalClientSnapshotFrame, LocalClientSubscription, LocalDebugNoticeEvent,
+    LocalDetailLevel, LocalHistoryNodeProjection, LocalHistoryNodeProjectionBody, LocalMessageRole,
     LocalModelCallStatusEvent, LocalModelCallStatusPhase, LocalNotice, LocalNoticeLevel,
     LocalProtocolValidationError, LocalReasoningEffort, LocalSnapshotTaskVersion,
     LocalTaskParentProjection, LocalTaskProjection, LocalTaskProjectionStatus, LocalTaskScope,
@@ -266,7 +266,7 @@ fn protocol_messages_round_trip_through_json() {
     let rejected = AttachRejected {
         protocol_version: current_protocol_version(),
         client_command_id: LocalClientCommandId::new("attach-2").expect("valid command id"),
-        reason: CommandRejectReason::ProtocolVersionMismatch,
+        reason: AttachRejectReason::ProtocolVersionMismatch,
     };
     let rejected_json = serde_json::to_string(&rejected).expect("serialize attach rejected");
     assert_eq!(

--- a/crates/local-protocol/tests/local_protocol_contract.rs
+++ b/crates/local-protocol/tests/local_protocol_contract.rs
@@ -16,10 +16,10 @@ use serde_json::json;
 
 #[test]
 fn request_validation_enforces_protocol_version_and_required_client_fields() {
-    assert_eq!(current_protocol_version(), ProtocolVersion(1));
+    assert_eq!(current_protocol_version(), ProtocolVersion(2));
 
     let ready = ReadyRequest {
-        protocol_version: ProtocolVersion(2),
+        protocol_version: ProtocolVersion(3),
     };
     assert_eq!(
         validate_ready_request(&ready),

--- a/crates/local-protocol/tests/local_protocol_contract.rs
+++ b/crates/local-protocol/tests/local_protocol_contract.rs
@@ -150,6 +150,18 @@ fn frame_validation_enforces_delivery_sequence_snapshot_and_notice_contracts() {
         Err(LocalProtocolValidationError::InvalidParentHistoryNodeId)
     );
 
+    let empty_parent_edge_task = LocalClientSnapshot {
+        task_parent_edges: vec![LocalTaskParentProjection {
+            parent_task_id: " ".to_owned(),
+            child_task_id: "task-2".to_owned(),
+        }],
+        ..snapshot.clone()
+    };
+    assert_eq!(
+        validate_snapshot(&empty_parent_edge_task),
+        Err(LocalProtocolValidationError::EmptyTaskId)
+    );
+
     let empty_tool_argument = LocalClientSnapshot {
         history_nodes: vec![LocalHistoryNodeProjection {
             body: LocalHistoryNodeProjectionBody::FunctionCall {
@@ -180,6 +192,21 @@ fn frame_validation_enforces_delivery_sequence_snapshot_and_notice_contracts() {
     assert_eq!(
         validate_client_frame(&empty_notice),
         Err(LocalProtocolValidationError::EmptyNoticeText)
+    );
+
+    let invalid_tool_status = LocalClientFrame::Event(LocalClientEventFrame {
+        delivery_seq: 1,
+        event: LocalClientEvent::ToolExecutionStatus(LocalToolExecutionStatusEvent {
+            task_id: "task-1".to_owned(),
+            tool_execution_run_id: "tool-run-1".to_owned(),
+            function_call_node_id: 0,
+            tool_name: "tool".to_owned(),
+            phase: LocalToolExecutionStatusPhase::Failed,
+        }),
+    });
+    assert_eq!(
+        validate_client_frame(&invalid_tool_status),
+        Err(LocalProtocolValidationError::InvalidHistoryNodeId)
     );
 }
 
@@ -269,6 +296,14 @@ fn protocol_messages_round_trip_through_json() {
         child_task_id: "child".to_owned(),
     };
     assert_eq!(parent_edge.child_task_id, "child");
+
+    let error_json = serde_json::to_string(&LocalProtocolValidationError::EmptyTaskId)
+        .expect("serialize validation error");
+    assert_eq!(
+        serde_json::from_str::<LocalProtocolValidationError>(&error_json)
+            .expect("deserialize validation error"),
+        LocalProtocolValidationError::EmptyTaskId
+    );
 }
 
 fn valid_snapshot() -> LocalClientSnapshot {

--- a/crates/local-protocol/tests/local_protocol_contract.rs
+++ b/crates/local-protocol/tests/local_protocol_contract.rs
@@ -174,11 +174,29 @@ fn frame_validation_enforces_delivery_sequence_snapshot_and_notice_contracts() {
             },
             ..valid_history_message()
         }],
-        ..snapshot
+        ..snapshot.clone()
     };
     assert_eq!(
         validate_snapshot(&empty_tool_argument),
         Err(LocalProtocolValidationError::EmptyToolArgumentName)
+    );
+
+    let invalid_function_output_ref = LocalClientSnapshot {
+        history_nodes: vec![LocalHistoryNodeProjection {
+            body: LocalHistoryNodeProjectionBody::FunctionOutput {
+                function_call_node_id: 0,
+                function_call_id: "call-1".to_owned(),
+                tool_name: "tool".to_owned(),
+                output_text: "done".to_owned(),
+                is_error: false,
+            },
+            ..valid_history_message()
+        }],
+        ..snapshot
+    };
+    assert_eq!(
+        validate_snapshot(&invalid_function_output_ref),
+        Err(LocalProtocolValidationError::InvalidHistoryNodeId)
     );
 
     let empty_notice = LocalClientFrame::Notice(LocalClientNoticeFrame {

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -13,6 +13,8 @@ Router ingress is unbounded. The router is the lifecycle coordinator for task ru
 Core output routing is task-id based. A runtime that enqueued core output before a synchronous stop still has that output routed normally; stop controls runtime registry ownership and future task command delivery.
 Core output with an embedded task id must match the envelope task id before the router starts model calls, tool executions, or event publication.
 
+Attach routing is an admission boundary. `RouterCommand::AttachClient` sends `ReserveClientSession` to events and answers the command's admission responder with the reservation result; snapshot hydration starts later through client-sync after server observes the accepted admission.
+
 ## Runtime Ownership Decision
 
 The router's runtime uniqueness invariant is route ownership: for one `TaskId`, at most one `TaskRuntimeSender` in `task_runtime_registry` may receive router task commands at a time. Creation is also single-owned through `pending_effects_by_task`.

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -273,36 +273,47 @@ impl RouterActor {
         admission_tx: selvedge_command_model::RouterAttachAdmissionSender,
     ) -> Result<(), RouterExitStatus> {
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-        match self.events_tx.try_send(EventIngress::Control(
-            EventControlMessage::ReserveClientSession(ReserveClientSession {
-                client_id,
-                client_command_id,
-                result_tx,
-            }),
-        )) {
-            Ok(()) => {}
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                let _ = admission_tx.send(RouterAttachAdmissionResult::EventsMailboxClosed);
-                return Ok(());
-            }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                let _ = admission_tx.send(RouterAttachAdmissionResult::EventsMailboxClosed);
-                return Err(RouterExitStatus::EventsMailboxClosed);
-            }
+        let cleanup_client_id = client_id.clone();
+        let cleanup_client_command_id = client_command_id.clone();
+        if self
+            .events_tx
+            .send(EventIngress::Control(
+                EventControlMessage::ReserveClientSession(ReserveClientSession {
+                    client_id,
+                    client_command_id,
+                    result_tx,
+                }),
+            ))
+            .await
+            .is_err()
+        {
+            let _ = admission_tx.send(RouterAttachAdmissionResult::EventsMailboxClosed);
+            return Err(RouterExitStatus::EventsMailboxClosed);
         }
 
-        let result = match result_rx.await {
-            Ok(EventClientReservationResult::Reserved) => RouterAttachAdmissionResult::Accepted,
+        let (result, reserved) = match result_rx.await {
+            Ok(EventClientReservationResult::Reserved) => {
+                (RouterAttachAdmissionResult::Accepted, true)
+            }
             Ok(EventClientReservationResult::DuplicateAttach) => {
-                RouterAttachAdmissionResult::DuplicateAttach
+                (RouterAttachAdmissionResult::DuplicateAttach, false)
             }
             Ok(EventClientReservationResult::ClientRegistryFull) => {
-                RouterAttachAdmissionResult::ClientRegistryFull
+                (RouterAttachAdmissionResult::ClientRegistryFull, false)
             }
-            Err(_) => RouterAttachAdmissionResult::EventsMailboxClosed,
+            Err(_) => (RouterAttachAdmissionResult::EventsMailboxClosed, false),
         };
 
-        let _ = admission_tx.send(result);
+        if admission_tx.send(result).is_err() && reserved {
+            self.send_event(EventIngress::Control(EventControlMessage::DetachClient(
+                selvedge_command_model::DetachClient {
+                    client_id: cleanup_client_id,
+                    client_command_id: cleanup_client_command_id,
+                    reason: DetachReason::ClientDisconnected,
+                },
+            )))
+            .await?;
+        }
         Ok(())
     }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -6,11 +6,13 @@ use std::sync::Arc;
 use selvedge_api::{ApiExecutorConfig, spawn_model_call_tokio_task};
 use selvedge_command_model::{
     ApiOutputEnvelope, CoreOutputEnvelope, CoreOutputMessage, DebugRawEvent, DetachReason,
-    DomainEvent, DomainEventPublishRequest, EventControlMessage, EventIngress, EventIngressSender,
-    FactoryEffectId, FactoryOutput, FactoryOutputEnvelope, FactoryScanOutput, FactoryTaskFailure,
-    RawEvent, RouterCommand, RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender,
-    RouterIngressWeakSender, TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice,
-    TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult, validate_router_command,
+    DomainEvent, DomainEventPublishRequest, EventClientReservationResult, EventControlMessage,
+    EventIngress, EventIngressSender, FactoryEffectId, FactoryOutput, FactoryOutputEnvelope,
+    FactoryScanOutput, FactoryTaskFailure, RawEvent, ReserveClientSession,
+    RouterAttachAdmissionResult, RouterCommand, RouterCommandEnvelope, RouterIngressMessage,
+    RouterIngressSender, RouterIngressWeakSender, TaskRuntimeCommand, TaskRuntimeControl,
+    TaskRuntimeExitNotice, TaskRuntimeSender, ToolExecutionRequest, ToolExecutionResult,
+    validate_router_command,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::DbPool;
@@ -153,20 +155,11 @@ impl RouterActor {
             RouterCommand::AttachClient {
                 client_id,
                 client_command_id,
-                outbound,
-                subscription,
+                admission_tx,
+                ..
             } => {
-                self.send_event(EventIngress::Control(
-                    EventControlMessage::BeginClientHydration(
-                        selvedge_command_model::BeginClientHydration {
-                            client_id,
-                            client_command_id,
-                            outbound,
-                            subscription,
-                        },
-                    ),
-                ))
-                .await
+                self.reserve_client_session(client_id, client_command_id, admission_tx)
+                    .await
             }
             RouterCommand::DetachClient {
                 client_id,
@@ -271,6 +264,46 @@ impl RouterActor {
                 .await
             }
         }
+    }
+
+    async fn reserve_client_session(
+        &mut self,
+        client_id: selvedge_command_model::ClientId,
+        client_command_id: selvedge_command_model::ClientCommandId,
+        admission_tx: selvedge_command_model::RouterAttachAdmissionSender,
+    ) -> Result<(), RouterExitStatus> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        match self.events_tx.try_send(EventIngress::Control(
+            EventControlMessage::ReserveClientSession(ReserveClientSession {
+                client_id,
+                client_command_id,
+                result_tx,
+            }),
+        )) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                let _ = admission_tx.send(RouterAttachAdmissionResult::EventsMailboxClosed);
+                return Ok(());
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                let _ = admission_tx.send(RouterAttachAdmissionResult::EventsMailboxClosed);
+                return Err(RouterExitStatus::EventsMailboxClosed);
+            }
+        }
+
+        let result = match result_rx.await {
+            Ok(EventClientReservationResult::Reserved) => RouterAttachAdmissionResult::Accepted,
+            Ok(EventClientReservationResult::DuplicateAttach) => {
+                RouterAttachAdmissionResult::DuplicateAttach
+            }
+            Ok(EventClientReservationResult::ClientRegistryFull) => {
+                RouterAttachAdmissionResult::ClientRegistryFull
+            }
+            Err(_) => RouterAttachAdmissionResult::EventsMailboxClosed,
+        };
+
+        let _ = admission_tx.send(result);
+        Ok(())
     }
 
     async fn handle_api_output(

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -5,12 +5,12 @@ use std::time::Duration;
 use selvedge_api::ApiExecutorConfig;
 use selvedge_command_model::{
     ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ClientCommandId, ClientId,
-    ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel, DomainEvent,
-    DomainEventPublishRequest, EventClientReservationResult, EventControlMessage, EventIngress,
-    ModelCallError, ModelCallErrorKind, ModelRunId, RawEvent, RouterAttachAdmissionResult,
-    RouterCommand, RouterCommandEnvelope, RouterIngressMessage, TaskRuntimeCommand,
-    TaskRuntimeControl, TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskScope,
-    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
+    ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetachReason, DetailLevel,
+    DomainEvent, DomainEventPublishRequest, EventClientReservationResult, EventControlMessage,
+    EventIngress, ModelCallError, ModelCallErrorKind, ModelRunId, RawEvent,
+    RouterAttachAdmissionResult, RouterCommand, RouterCommandEnvelope, RouterIngressMessage,
+    TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice, TaskRuntimeExitReason,
+    TaskScope, ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_core::{
     SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
@@ -88,6 +88,75 @@ async fn attach_client_command_is_forwarded_to_events() {
         admission_rx.await.expect("admission result"),
         RouterAttachAdmissionResult::Accepted
     );
+
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::StopRouter)
+        .expect("stop router");
+    assert_eq!(
+        handle.join_handle.await.expect("join router"),
+        RouterExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn cancelled_attach_admission_detaches_reserved_events_session() {
+    let db = open_memory_db();
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(8);
+
+    let handle = spawn_router(RouterStartArgs {
+        db,
+        events_tx,
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolSpawner),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 8,
+            model_profiles: HashMap::new(),
+        }),
+    })
+    .expect("spawn router");
+
+    let (outbound, _outbound_rx) = tokio::sync::mpsc::channel(4);
+    let (admission_tx, admission_rx) = tokio::sync::oneshot::channel();
+    drop(admission_rx);
+    handle
+        .ingress_tx
+        .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+            client_id: Some(ClientId("client-1".to_owned())),
+            client_command_id: Some(ClientCommandId("attach-1".to_owned())),
+            command: RouterCommand::AttachClient {
+                client_id: ClientId("client-1".to_owned()),
+                client_command_id: ClientCommandId("attach-1".to_owned()),
+                outbound,
+                subscription: verbose_subscription(),
+                admission_tx,
+            },
+        }))
+        .expect("send command");
+
+    let EventIngress::Control(EventControlMessage::ReserveClientSession(reservation)) =
+        events_rx.recv().await.expect("reservation")
+    else {
+        panic!("unexpected events ingress");
+    };
+    reservation
+        .result_tx
+        .send(EventClientReservationResult::Reserved)
+        .expect("send reservation result");
+    let EventIngress::Control(EventControlMessage::DetachClient(detach)) =
+        events_rx.recv().await.expect("detach")
+    else {
+        panic!("unexpected events ingress");
+    };
+    assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+    assert_eq!(
+        detach.client_command_id,
+        ClientCommandId("attach-1".to_owned())
+    );
+    assert_eq!(detach.reason, DetachReason::ClientDisconnected);
 
     handle
         .ingress_tx
@@ -1117,6 +1186,16 @@ impl ToolExecutionSpawner for CapturingToolSpawner {
             .map_err(|_| ToolExecutionSpawnError::ToolExecutorUnavailable)?;
         requests.push(request);
         Ok(tokio::spawn(async {}))
+    }
+}
+
+fn verbose_subscription() -> ClientSubscription {
+    ClientSubscription {
+        task_scope: TaskScope::AllTasks,
+        detail_level: DetailLevel::Verbose,
+        include_model_call_status: true,
+        include_tool_execution_status: true,
+        include_debug_notices: true,
     }
 }
 

--- a/crates/router/tests/router_contract.rs
+++ b/crates/router/tests/router_contract.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 
 use selvedge_api::ApiExecutorConfig;
 use selvedge_command_model::{
-    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, BeginClientHydration, ClientCommandId,
-    ClientId, ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel, DomainEvent,
-    DomainEventPublishRequest, EventControlMessage, EventIngress, ModelCallError,
-    ModelCallErrorKind, ModelRunId, RawEvent, RouterCommand, RouterCommandEnvelope,
-    RouterIngressMessage, TaskRuntimeCommand, TaskRuntimeControl, TaskRuntimeExitNotice,
-    TaskRuntimeExitReason, TaskScope, ToolExecutionRequest, ToolExecutionResult,
-    ToolExecutionRunId,
+    ApiCallCorrelation, ApiEffectId, ApiOutputEnvelope, ClientCommandId, ClientId,
+    ClientSubscription, CoreOutputEnvelope, CoreOutputMessage, DetailLevel, DomainEvent,
+    DomainEventPublishRequest, EventClientReservationResult, EventControlMessage, EventIngress,
+    ModelCallError, ModelCallErrorKind, ModelRunId, RawEvent, RouterAttachAdmissionResult,
+    RouterCommand, RouterCommandEnvelope, RouterIngressMessage, TaskRuntimeCommand,
+    TaskRuntimeControl, TaskRuntimeExitNotice, TaskRuntimeExitReason, TaskScope,
+    ToolExecutionRequest, ToolExecutionResult, ToolExecutionRunId,
 };
 use selvedge_core::{
     SpawnTaskRuntimeArgs, SpawnTaskRuntimeError, SpawnedTaskRuntime, TaskRuntimeConfig,
@@ -47,6 +47,7 @@ async fn attach_client_command_is_forwarded_to_events() {
     .expect("spawn router");
 
     let (outbound, _outbound_rx) = tokio::sync::mpsc::channel(4);
+    let (admission_tx, admission_rx) = tokio::sync::oneshot::channel();
     let subscription = ClientSubscription {
         task_scope: TaskScope::AllTasks,
         detail_level: DetailLevel::Verbose,
@@ -64,23 +65,29 @@ async fn attach_client_command_is_forwarded_to_events() {
                 client_command_id: ClientCommandId("attach-1".to_owned()),
                 outbound,
                 subscription: subscription.clone(),
+                admission_tx,
             },
         }))
         .expect("send command");
 
     let event = events_rx.recv().await.expect("events ingress");
-    let EventIngress::Control(EventControlMessage::BeginClientHydration(BeginClientHydration {
-        client_id,
-        client_command_id,
-        subscription: received_subscription,
-        ..
-    })) = event
+    let EventIngress::Control(EventControlMessage::ReserveClientSession(reservation)) = event
     else {
         panic!("unexpected events ingress");
     };
-    assert_eq!(client_id, ClientId("client-1".to_owned()));
-    assert_eq!(client_command_id, ClientCommandId("attach-1".to_owned()));
-    assert_eq!(received_subscription, subscription);
+    assert_eq!(reservation.client_id, ClientId("client-1".to_owned()));
+    assert_eq!(
+        reservation.client_command_id,
+        ClientCommandId("attach-1".to_owned())
+    );
+    reservation
+        .result_tx
+        .send(EventClientReservationResult::Reserved)
+        .expect("send reservation result");
+    assert_eq!(
+        admission_rx.await.expect("admission result"),
+        RouterAttachAdmissionResult::Accepted
+    );
 
     handle
         .ingress_tx

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "selvedge-server"
+edition = "2024"
+publish = false
+
+[dependencies]
+futures-core = "0.3.31"
+selvedge-api = { path = "../api" }
+selvedge-client-sync = { path = "../client-sync" }
+selvedge-command-model = { path = "../command-model" }
+selvedge-config = { path = "../config" }
+selvedge-core = { path = "../core" }
+selvedge-db = { path = "../db" }
+selvedge-domain-model = { path = "../domain-model" }
+selvedge-events = { path = "../events" }
+selvedge-local-protocol = { path = "../local-protocol" }
+selvedge-logging = { path = "../logging" }
+selvedge-router = { path = "../router" }
+selvedge-web = { path = "../web" }
+tokio = { version = "1.42.0", features = ["fs", "macros", "rt", "sync"] }
+
+[dev-dependencies]
+futures-util = "0.3.31"
+serde_json = "1.0.145"
+tempfile = "3.14.0"
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
+fs2 = "0.4.3"
 futures-core = "0.3.31"
 selvedge-api = { path = "../api" }
 selvedge-client-sync = { path = "../client-sync" }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -8,6 +8,6 @@ Use it to start the server runtime, hold the singleton lock, initialize config a
 
 The singleton lock is `<selvedge_home>/server.lock`. The lock file is removed during normal shutdown and startup-failure cleanup.
 
-This crate exposes the in-process control surface, validates localhost bind targets, and accepts attach requests by sending hydration starts into `selvedge-client-sync`.
+This crate exposes the in-process control surface, validates localhost bind targets, and accepts attach requests after router-mediated events reservation succeeds.
 
-`ServerControl::attach_client` creates an internal client frame channel, sends `StartHydration` to client-sync, and returns a local-protocol frame stream. Frames from `selvedge-events` are converted from command-model client frames into local-protocol frames without reordering.
+`ServerControl::attach_client` creates an internal client frame channel, sends router attach admission, sends `StartHydration` to client-sync after admission succeeds, and returns a local-protocol frame stream. Frames from `selvedge-events` are converted from command-model client frames into local-protocol frames without reordering.

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -9,3 +9,5 @@ Use it to start the server runtime, hold the singleton lock, initialize config a
 The singleton lock is `<selvedge_home>/server.lock`. The lock file is removed during normal shutdown and startup-failure cleanup.
 
 This crate currently exposes the in-process control surface and validates localhost bind targets. Wire protocol routes and framing are owned by the local-client package stage.
+
+`ServerControl::attach_client` validates attach requests and returns an explicit rejection while the client-sync package still lacks hydration delivery. Returning `Accepted` requires the initial snapshot and event stream to be backed by client-sync.

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -1,0 +1,11 @@
+# server
+
+This crate owns the process-local Selvedge server lifecycle.
+
+Use it to start the server runtime, hold the singleton lock, initialize config and logging, open the SQLite database at `<selvedge_home>/selvedge.sqlite`, start events, client-sync, router, and optional web surface tasks, and expose the in-process `ServerControl` used by local clients and UI surfaces.
+
+`ServerStartArgs` uses the current `selvedge-api` boundary: server passes `ApiExecutorConfig` into the router, and provider selection remains inside each model-call request. This crate does not own a provider registry.
+
+The singleton lock is `<selvedge_home>/server.lock`. The lock file is removed during normal shutdown and startup-failure cleanup.
+
+This crate currently exposes the in-process control surface and validates localhost bind targets. Wire protocol routes and framing are owned by the local-client package stage.

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -8,6 +8,6 @@ Use it to start the server runtime, hold the singleton lock, initialize config a
 
 The singleton lock is `<selvedge_home>/server.lock`. The lock file is removed during normal shutdown and startup-failure cleanup.
 
-This crate currently exposes the in-process control surface and validates localhost bind targets. Wire protocol routes and framing are owned by the local-client package stage.
+This crate exposes the in-process control surface, validates localhost bind targets, and accepts attach requests by sending hydration starts into `selvedge-client-sync`.
 
-`ServerControl::attach_client` validates attach requests and returns an explicit rejection while the client-sync package still lacks hydration delivery. Returning `Accepted` requires the initial snapshot and event stream to be backed by client-sync.
+`ServerControl::attach_client` creates an internal client frame channel, sends `StartHydration` to client-sync, and returns a local-protocol frame stream. Frames from `selvedge-events` are converted from command-model client frames into local-protocol frames without reordering.

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -837,7 +837,23 @@ fn init_config(explicit_home: Option<&PathBuf>) -> Result<(), ServerStartupError
 
     match result {
         Ok(()) => Ok(()),
-        Err(error) if error.to_string().contains("already") => Ok(()),
+        Err(error) if error.to_string().contains("already") => {
+            if let Some(home) = explicit_home {
+                let selected_home = selvedge_config::selvedge_home()
+                    .map_err(|error| ServerStartupError::ConfigInitFailed(error.to_string()))?;
+                let requested_home = std::fs::canonicalize(home)
+                    .map_err(|error| ServerStartupError::ConfigInitFailed(error.to_string()))?;
+                if selected_home != requested_home {
+                    return Err(ServerStartupError::ConfigInitFailed(format!(
+                        "config service is initialized for {}, requested {}",
+                        selected_home.display(),
+                        requested_home.display()
+                    )));
+                }
+            }
+
+            Ok(())
+        }
         Err(error) => Err(ServerStartupError::ConfigInitFailed(error.to_string())),
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -18,13 +18,13 @@ use selvedge_client_sync::{
     ClientSyncStartArgs, SpawnClientSyncError, spawn_client_sync,
 };
 use selvedge_command_model::{
-    BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
-    ClientNoticeLevel, ClientSnapshot, ClientSubscription, DeliverySeq, DetachClient, DetachReason,
-    DetailLevel, EventControlMessage, EventIngress, EventIngressSender, HistoryNodeProjection,
-    HistoryNodeProjectionBody, ModelCallStatusPhase, RouterAttachAdmissionResult, RouterCommand,
-    RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender, SnapshotTaskVersion,
-    TaskParentProjection, TaskProjection, TaskProjectionStatus, TaskScope,
-    ToolExecutionStatusPhase,
+    BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientFrameSender, ClientId,
+    ClientNotice, ClientNoticeLevel, ClientSnapshot, ClientSubscription, DeliverySeq, DetachClient,
+    DetachReason, DetailLevel, EventControlMessage, EventIngress, EventIngressSender,
+    HistoryNodeProjection, HistoryNodeProjectionBody, ModelCallStatusPhase,
+    RouterAttachAdmissionResult, RouterCommand, RouterCommandEnvelope, RouterIngressMessage,
+    RouterIngressSender, SnapshotTaskVersion, TaskParentProjection, TaskProjection,
+    TaskProjectionStatus, TaskScope, ToolExecutionStatusPhase,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::{OpenDbOptions, open_db};
@@ -61,6 +61,24 @@ const DEFAULT_HYDRATION_BUFFER_CAPACITY: usize = 256;
 const DEFAULT_CLIENT_SYNC_INGRESS_CAPACITY: usize = 64;
 
 type ActiveAttachRegistry = Arc<StdMutex<HashMap<ClientId, ClientCommandId>>>;
+
+trait AttachFrameChannelFactory: Send + Sync {
+    fn create(
+        &self,
+        capacity: usize,
+    ) -> Result<(ClientFrameSender, mpsc::Receiver<ClientFrame>), AttachRejectReason>;
+}
+
+struct TokioAttachFrameChannelFactory;
+
+impl AttachFrameChannelFactory for TokioAttachFrameChannelFactory {
+    fn create(
+        &self,
+        capacity: usize,
+    ) -> Result<(ClientFrameSender, mpsc::Receiver<ClientFrame>), AttachRejectReason> {
+        Ok(mpsc::channel(capacity))
+    }
+}
 
 pub struct ServerStartArgs {
     pub explicit_home: Option<PathBuf>,
@@ -275,7 +293,14 @@ impl ServerControl {
             Some(events_tx.clone()),
         );
 
-        let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
+        let (outbound_tx, outbound_rx) = match self
+            .inner
+            .frame_channel_factory
+            .create(DEFAULT_HYDRATION_BUFFER_CAPACITY)
+        {
+            Ok(channel) => channel,
+            Err(reason) => return reject(reason),
+        };
         let subscription = local_subscription_to_command(request.subscription);
         let (admission_tx, admission_rx) = tokio::sync::oneshot::channel();
         if self
@@ -458,6 +483,7 @@ struct ServerInner {
     events_tx: Mutex<Option<EventIngressSender>>,
     client_sync_tx: Mutex<selvedge_client_sync::ClientSyncSender>,
     active_attaches: ActiveAttachRegistry,
+    frame_channel_factory: Arc<dyn AttachFrameChannelFactory>,
     command_mapper: Arc<dyn LocalCommandMapper>,
     web_control: Mutex<Option<selvedge_web::WebControl>>,
 }
@@ -637,6 +663,7 @@ fn start_server_after_lock(
         events_tx: Mutex::new(Some(events.ingress_tx.clone())),
         client_sync_tx: Mutex::new(client_sync.ingress_tx.clone()),
         active_attaches: Arc::new(StdMutex::new(HashMap::new())),
+        frame_channel_factory: Arc::new(TokioAttachFrameChannelFactory),
         command_mapper: args.command_mapper,
         web_control: Mutex::new(web.as_ref().map(|handle| handle.control.clone())),
     });
@@ -1324,6 +1351,31 @@ mod tests {
         }
     }
 
+    struct FailOnceAttachFrameChannelFactory {
+        failed: AtomicBool,
+    }
+
+    impl FailOnceAttachFrameChannelFactory {
+        fn new() -> Self {
+            Self {
+                failed: AtomicBool::new(false),
+            }
+        }
+    }
+
+    impl AttachFrameChannelFactory for FailOnceAttachFrameChannelFactory {
+        fn create(
+            &self,
+            capacity: usize,
+        ) -> Result<(ClientFrameSender, mpsc::Receiver<ClientFrame>), AttachRejectReason> {
+            if !self.failed.swap(true, Ordering::SeqCst) {
+                return Err(AttachRejectReason::AttachChannelFailed);
+            }
+
+            Ok(mpsc::channel(capacity))
+        }
+    }
+
     #[tokio::test]
     async fn attach_closed_router_shutdown_path_returns_rejection() {
         let (router_tx, router_rx) = mpsc::unbounded_channel();
@@ -1460,6 +1512,39 @@ mod tests {
             client_sync_rx.try_recv(),
             Err(tokio::sync::mpsc::error::TryRecvError::Empty)
         ));
+    }
+
+    #[tokio::test]
+    async fn frame_channel_creation_failure_rejects_and_restores_attach_slot() {
+        let router_tx = accepting_router_sender();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
+        let (events_tx, _events_rx) = mpsc::channel(4);
+        let control = test_control_with_frame_channel_factory(
+            router_tx,
+            client_sync_tx,
+            events_tx,
+            Arc::new(FailOnceAttachFrameChannelFactory::new()),
+        );
+
+        let rejected = match control.attach_client(test_attach_request()).await {
+            Ok(_) => panic!("frame channel failure should reject"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason, AttachRejectReason::AttachChannelFailed);
+        assert!(matches!(
+            client_sync_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+
+        let (_accepted, _stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("retry attach accepted after failed channel creation");
+        let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("retry start hydration arrives")
+            .expect("retry start hydration");
     }
 
     #[tokio::test]
@@ -1763,6 +1848,20 @@ mod tests {
         client_sync_tx: selvedge_client_sync::ClientSyncSender,
         events_tx: EventIngressSender,
     ) -> ServerControl {
+        test_control_with_frame_channel_factory(
+            router_tx,
+            client_sync_tx,
+            events_tx,
+            Arc::new(TokioAttachFrameChannelFactory),
+        )
+    }
+
+    fn test_control_with_frame_channel_factory(
+        router_tx: RouterIngressSender,
+        client_sync_tx: selvedge_client_sync::ClientSyncSender,
+        events_tx: EventIngressSender,
+        frame_channel_factory: Arc<dyn AttachFrameChannelFactory>,
+    ) -> ServerControl {
         ServerControl {
             inner: Arc::new(ServerInner {
                 state: RwLock::new(ServerRuntimeState::Ready),
@@ -1775,6 +1874,7 @@ mod tests {
                 events_tx: Mutex::new(Some(events_tx)),
                 client_sync_tx: Mutex::new(client_sync_tx),
                 active_attaches: Arc::new(StdMutex::new(HashMap::new())),
+                frame_channel_factory,
                 command_mapper: Arc::new(UnusedMapper),
                 web_control: Mutex::new(None),
             }),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -13,15 +13,16 @@ use fs2::FileExt;
 use futures_core::Stream;
 use selvedge_api::ApiExecutorConfig;
 use selvedge_client_sync::{
-    CancelHydration, ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress,
-    ClientSyncStartArgs, SpawnClientSyncError, spawn_client_sync,
+    ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress, ClientSyncStartArgs,
+    SpawnClientSyncError, spawn_client_sync,
 };
 use selvedge_command_model::{
     BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
-    ClientNoticeLevel, ClientSnapshot, ClientSubscription, DeliverySeq, DetailLevel,
-    HistoryNodeProjection, HistoryNodeProjectionBody, ModelCallStatusPhase, RouterCommandEnvelope,
-    RouterIngressMessage, RouterIngressSender, SnapshotTaskVersion, TaskParentProjection,
-    TaskProjection, TaskProjectionStatus, TaskScope, ToolExecutionStatusPhase,
+    ClientNoticeLevel, ClientSnapshot, ClientSubscription, DeliverySeq, DetachClient, DetachReason,
+    DetailLevel, EventControlMessage, EventIngress, EventIngressSender, HistoryNodeProjection,
+    HistoryNodeProjectionBody, ModelCallStatusPhase, RouterCommandEnvelope, RouterIngressMessage,
+    RouterIngressSender, SnapshotTaskVersion, TaskParentProjection, TaskProjection,
+    TaskProjectionStatus, TaskScope, ToolExecutionStatusPhase,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::{OpenDbOptions, open_db};
@@ -222,6 +223,7 @@ impl ServerControl {
         &self,
         request: AttachRequest,
     ) -> Result<(AttachAccepted, ServerFrameStream), AttachRejected> {
+        let _request_guard = self.inner.request_gate.lock().await;
         let protocol_version = current_protocol_version();
         let client_command_id = request.client_command_id.clone();
 
@@ -258,6 +260,9 @@ impl ServerControl {
             outbound: outbound_tx,
             subscription: local_subscription_to_command(request.subscription),
         };
+        let Some(events_tx) = self.inner.events_tx.lock().await.as_ref().cloned() else {
+            return reject(CommandRejectReason::InternalFailure);
+        };
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
 
         if client_sync_tx
@@ -277,10 +282,9 @@ impl ServerControl {
             },
             Box::pin(ServerAttachFrameStream {
                 inner: outbound_rx,
-                client_sync_tx,
                 client_id,
                 client_command_id,
-                cancel_sent: false,
+                events_tx: events_tx.downgrade(),
                 closed_reported: false,
             }),
         ))
@@ -356,6 +360,7 @@ impl ServerControl {
         if let Some(web_control) = self.inner.web_control.lock().await.as_ref() {
             web_control.stop().await;
         }
+        let _ = self.inner.events_tx.lock().await.take();
         self.inner.stop_notify.notify_waiters();
     }
 }
@@ -373,6 +378,7 @@ struct ServerInner {
     lock_path: PathBuf,
     _singleton_lock: File,
     router_tx: RouterIngressSender,
+    events_tx: Mutex<Option<EventIngressSender>>,
     client_sync_tx: Mutex<selvedge_client_sync::ClientSyncSender>,
     command_mapper: Arc<dyn LocalCommandMapper>,
     web_control: Mutex<Option<selvedge_web::WebControl>>,
@@ -462,6 +468,7 @@ fn start_server_after_lock(
         lock_path: lock_path_for_home(&home),
         _singleton_lock: singleton_lock,
         router_tx: router.ingress_tx.clone(),
+        events_tx: Mutex::new(Some(events.ingress_tx.clone())),
         client_sync_tx: Mutex::new(client_sync.ingress_tx.clone()),
         command_mapper: args.command_mapper,
         web_control: Mutex::new(web.as_ref().map(|handle| handle.control.clone())),
@@ -508,10 +515,11 @@ fn spawn_server_join_task(
 
 struct ServerAttachFrameStream {
     inner: mpsc::Receiver<ClientFrame>,
-    client_sync_tx: selvedge_client_sync::ClientSyncSender,
     client_id: ClientId,
     client_command_id: ClientCommandId,
-    cancel_sent: bool,
+    // NOTE: Weak sender lets server shutdown close events while callers still hold frame streams;
+    // Drop upgrades it only to report client detach.
+    events_tx: mpsc::WeakSender<EventIngress>,
     closed_reported: bool,
 }
 
@@ -536,16 +544,28 @@ impl futures_core::Stream for ServerAttachFrameStream {
 
 impl Drop for ServerAttachFrameStream {
     fn drop(&mut self) {
-        if self.cancel_sent {
+        let Some(events_tx) = self.events_tx.upgrade() else {
             return;
+        };
+        let retry_events_tx = events_tx.clone();
+        let client_id = self.client_id.clone();
+        let client_command_id = self.client_command_id.clone();
+        let detach = EventIngress::Control(EventControlMessage::DetachClient(DetachClient {
+            client_id,
+            client_command_id,
+            reason: DetachReason::ClientRequested,
+        }));
+
+        match events_tx.try_send(detach) {
+            Ok(()) => {}
+            Err(error) => {
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    handle.spawn(async move {
+                        let _ = retry_events_tx.send(error.into_inner()).await;
+                    });
+                }
+            }
         }
-        self.cancel_sent = true;
-        let _ = self
-            .client_sync_tx
-            .try_send(ClientSyncIngress::CancelHydration(CancelHydration {
-                client_id: self.client_id.clone(),
-                client_command_id: self.client_command_id.clone(),
-            }));
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -263,6 +263,12 @@ impl ServerControl {
             Ok(previous_attach) => previous_attach,
             Err(reason) => return reject(reason),
         };
+        let mut reservation = ActiveAttachReservation::new(
+            Arc::clone(&self.inner.active_attaches),
+            client_id.clone(),
+            client_command_id.clone(),
+            previous_attach,
+        );
 
         let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
         let begin = BeginClientHydration {
@@ -272,8 +278,6 @@ impl ServerControl {
             subscription: local_subscription_to_command(request.subscription),
         };
         let Some(events_tx) = self.inner.events_tx.lock().await.as_ref().cloned() else {
-            self.inner
-                .restore_active_attach(&client_id, &client_command_id, previous_attach);
             return reject(AttachRejectReason::InternalFailure);
         };
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
@@ -283,29 +287,25 @@ impl ServerControl {
             .await
             .is_err()
         {
-            self.inner
-                .restore_active_attach(&client_id, &client_command_id, previous_attach);
             self.begin_shutdown_locked().await;
             return reject(AttachRejectReason::ClientSyncUnavailable);
         }
 
-        if let Some(previous_command_id) = previous_attach {
-            let _ = client_sync_tx
-                .send(ClientSyncIngress::CancelHydration(CancelHydration {
-                    client_id: client_id.clone(),
-                    client_command_id: previous_command_id.clone(),
-                }))
-                .await;
-            let _ = events_tx
-                .send(EventIngress::Control(EventControlMessage::DetachClient(
-                    DetachClient {
-                        client_id: client_id.clone(),
-                        client_command_id: previous_command_id,
-                        reason: DetachReason::ReplacedByNewHydration,
-                    },
-                )))
-                .await;
+        if let Some(previous_command_id) = reservation.previous_attach() {
+            send_cancel_hydration(
+                &client_sync_tx,
+                client_id.clone(),
+                previous_command_id.clone(),
+            );
+            send_detach_client(
+                &events_tx,
+                client_id.clone(),
+                previous_command_id,
+                DetachReason::ReplacedByNewHydration,
+            );
         }
+
+        reservation.commit();
 
         Ok((
             AttachAccepted {
@@ -441,25 +441,50 @@ impl ServerInner {
 
         Ok(active.insert(client_id.clone(), client_command_id.clone()))
     }
+}
 
-    fn restore_active_attach(
-        &self,
-        client_id: &ClientId,
-        client_command_id: &ClientCommandId,
+struct ActiveAttachReservation {
+    active_attaches: ActiveAttachRegistry,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+    previous_attach: Option<ClientCommandId>,
+    active: bool,
+}
+
+impl ActiveAttachReservation {
+    fn new(
+        active_attaches: ActiveAttachRegistry,
+        client_id: ClientId,
+        client_command_id: ClientCommandId,
         previous_attach: Option<ClientCommandId>,
-    ) {
-        let mut active = self
-            .active_attaches
-            .lock()
-            .expect("server active attach registry lock");
-        if active.get(client_id) != Some(client_command_id) {
-            return;
+    ) -> Self {
+        Self {
+            active_attaches,
+            client_id,
+            client_command_id,
+            previous_attach,
+            active: true,
         }
+    }
 
-        if let Some(previous_command_id) = previous_attach {
-            active.insert(client_id.clone(), previous_command_id);
-        } else {
-            active.remove(client_id);
+    fn previous_attach(&self) -> Option<ClientCommandId> {
+        self.previous_attach.clone()
+    }
+
+    fn commit(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for ActiveAttachReservation {
+    fn drop(&mut self) {
+        if self.active {
+            restore_active_attach(
+                &self.active_attaches,
+                &self.client_id,
+                &self.client_command_id,
+                self.previous_attach.clone(),
+            );
         }
     }
 }
@@ -638,46 +663,72 @@ impl Drop for ServerAttachFrameStream {
         clear_active_attach(&self.active_attaches, &client_id, &client_command_id);
 
         if let Some(client_sync_tx) = self.client_sync_tx.upgrade() {
-            let retry_client_sync_tx = client_sync_tx.clone();
-            let cancel = ClientSyncIngress::CancelHydration(CancelHydration {
-                client_id: client_id.clone(),
-                client_command_id: client_command_id.clone(),
-            });
-
-            match client_sync_tx.try_send(cancel) {
-                Ok(()) => {}
-                Err(tokio::sync::mpsc::error::TrySendError::Full(cancel)) => {
-                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                        handle.spawn(async move {
-                            let _ = retry_client_sync_tx.send(cancel).await;
-                        });
-                    }
-                }
-                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
-            }
+            send_cancel_hydration(
+                &client_sync_tx,
+                client_id.clone(),
+                client_command_id.clone(),
+            );
         }
 
         let Some(events_tx) = self.events_tx.upgrade() else {
             return;
         };
-        let retry_events_tx = events_tx.clone();
-        let detach = EventIngress::Control(EventControlMessage::DetachClient(DetachClient {
+        send_detach_client(
+            &events_tx,
             client_id,
             client_command_id,
-            reason: DetachReason::ClientDisconnected,
-        }));
+            DetachReason::ClientDisconnected,
+        );
+    }
+}
 
-        match events_tx.try_send(detach) {
-            Ok(()) => {}
-            Err(tokio::sync::mpsc::error::TrySendError::Full(detach)) => {
-                if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                    handle.spawn(async move {
-                        let _ = retry_events_tx.send(detach).await;
-                    });
-                }
+fn send_cancel_hydration(
+    client_sync_tx: &selvedge_client_sync::ClientSyncSender,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+) {
+    let retry_client_sync_tx = client_sync_tx.clone();
+    let cancel = ClientSyncIngress::CancelHydration(CancelHydration {
+        client_id,
+        client_command_id,
+    });
+
+    match client_sync_tx.try_send(cancel) {
+        Ok(()) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Full(cancel)) => {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = retry_client_sync_tx.send(cancel).await;
+                });
             }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
         }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+    }
+}
+
+fn send_detach_client(
+    events_tx: &EventIngressSender,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+    reason: DetachReason,
+) {
+    let retry_events_tx = events_tx.clone();
+    let detach = EventIngress::Control(EventControlMessage::DetachClient(DetachClient {
+        client_id,
+        client_command_id,
+        reason,
+    }));
+
+    match events_tx.try_send(detach) {
+        Ok(()) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Full(detach)) => {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = retry_events_tx.send(detach).await;
+                });
+            }
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
     }
 }
 
@@ -690,6 +741,26 @@ fn clear_active_attach(
         .lock()
         .expect("server active attach registry lock");
     if active.get(client_id) == Some(client_command_id) {
+        active.remove(client_id);
+    }
+}
+
+fn restore_active_attach(
+    active_attaches: &ActiveAttachRegistry,
+    client_id: &ClientId,
+    client_command_id: &ClientCommandId,
+    previous_attach: Option<ClientCommandId>,
+) {
+    let mut active = active_attaches
+        .lock()
+        .expect("server active attach registry lock");
+    if active.get(client_id) != Some(client_command_id) {
+        return;
+    }
+
+    if let Some(previous_command_id) = previous_attach {
+        active.insert(client_id.clone(), previous_command_id);
+    } else {
         active.remove(client_id);
     }
 }
@@ -1342,6 +1413,46 @@ mod tests {
             .attach_client(test_attach_request())
             .await
             .expect("retry attach accepted after channel close");
+    }
+
+    #[tokio::test]
+    async fn cancelled_attach_future_restores_reserved_attach_slot() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(1);
+        client_sync_tx
+            .send(ClientSyncIngress::Shutdown)
+            .await
+            .expect("fill client-sync mailbox");
+        let (events_tx, _events_rx) = mpsc::channel(4);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+        let task_control = control.clone();
+        let attach_task =
+            tokio::spawn(async move { task_control.attach_client(test_attach_request()).await });
+
+        timeout(Duration::from_millis(100), async {
+            loop {
+                if !control
+                    .inner
+                    .active_attaches
+                    .lock()
+                    .expect("active attach registry")
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("attach reservation appears");
+        attach_task.abort();
+        let _ = attach_task.await;
+        let _ = client_sync_rx.recv().await.expect("drain filled mailbox");
+
+        let (_accepted, _stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("attach accepted after cancelled future");
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,8 +5,8 @@ use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::task::{Context, Poll};
 
 use futures_core::Stream;
@@ -326,7 +326,13 @@ impl ServerControl {
         let _ = self.inner.router_tx.send(RouterIngressMessage::StopRouter);
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
         let _ = client_sync_tx.send(ClientSyncIngress::Shutdown).await;
-        if let Some(web_control) = self.inner.web_control.lock().await.as_ref() {
+        let web_control = self
+            .inner
+            .web_control
+            .lock()
+            .expect("web control lock")
+            .clone();
+        if let Some(web_control) = web_control {
             web_control.stop().await;
         }
         self.inner.stop_notify.notify_waiters();
@@ -347,7 +353,7 @@ struct ServerInner {
     router_tx: RouterIngressSender,
     client_sync_tx: Mutex<selvedge_client_sync::ClientSyncSender>,
     command_mapper: Arc<dyn LocalCommandMapper>,
-    web_control: Mutex<Option<selvedge_web::WebControl>>,
+    web_control: StdMutex<Option<selvedge_web::WebControl>>,
 }
 
 impl ServerContext {
@@ -394,8 +400,6 @@ fn start_server_after_lock(
     })
     .map_err(map_router_start_error)?;
 
-    let web = start_web(args.web_binding, &args.command_mapper)?;
-
     let inner = Arc::new(ServerInner {
         state: RwLock::new(ServerRuntimeState::Ready),
         closing: AtomicBool::new(false),
@@ -405,8 +409,15 @@ fn start_server_after_lock(
         router_tx: router.ingress_tx.clone(),
         client_sync_tx: Mutex::new(client_sync.ingress_tx.clone()),
         command_mapper: args.command_mapper,
-        web_control: Mutex::new(web.as_ref().map(|handle| handle.control.clone())),
+        web_control: StdMutex::new(None),
     });
+    let control = ServerControl {
+        inner: inner.clone(),
+    };
+    let web = start_web(args.web_binding, control)?;
+    if let Some(web_handle) = &web {
+        *inner.web_control.lock().expect("web control lock") = Some(web_handle.control.clone());
+    }
     let join_handle = spawn_server_join_task(inner.clone(), router, events, client_sync, web);
 
     Ok(ServerContext { inner, join_handle })
@@ -445,56 +456,88 @@ fn spawn_server_join_task(
 
 fn start_web(
     web_binding: Option<WebBindingConfig>,
-    bridge: &Arc<dyn LocalCommandMapper>,
+    control: ServerControl,
 ) -> Result<Option<WebHandle>, ServerStartupError> {
     let Some(web_binding) = web_binding else {
         return Ok(None);
     };
 
     let bind = local_bind_to_web_bind(web_binding.bind_target)?;
-    let bridge = Arc::new(ServerWebBridge {
-        _command_mapper: Arc::clone(bridge),
-    });
+    let bridge = Arc::new(ServerWebBridge { control });
     spawn_web_surface(WebStartArgs { bind, bridge })
         .map(Some)
         .map_err(map_web_start_error)
 }
 
 struct ServerWebBridge {
-    _command_mapper: Arc<dyn LocalCommandMapper>,
+    control: ServerControl,
 }
 
 impl WebBridge for ServerWebBridge {
-    fn ready(&self, _request: ReadyRequest) -> selvedge_web::WebBridgeFuture<ReadyResponse> {
-        Box::pin(async {
-            Ok(ReadyResponse {
-                protocol_version: current_protocol_version(),
-                state: ReadyState::Ready,
-            })
-        })
+    fn ready(&self, request: ReadyRequest) -> selvedge_web::WebBridgeFuture<ReadyResponse> {
+        let control = self.control.clone();
+        Box::pin(async move { Ok(control.ready(request).await) })
     }
 
     fn submit_command(
         &self,
         request: CommandRequest,
     ) -> selvedge_web::WebBridgeFuture<CommandResponse> {
-        Box::pin(async move {
-            Ok(CommandResponse {
-                protocol_version: current_protocol_version(),
-                client_command_id: request.client_command_id,
-                outcome: CommandOutcome::Rejected(CommandRejectReason::InternalFailure),
-            })
-        })
+        let control = self.control.clone();
+        Box::pin(async move { Ok(control.submit_command(request).await) })
     }
 
-    fn attach(&self, _request: AttachRequest) -> selvedge_web::WebAttachFuture {
-        Box::pin(async {
-            Err(selvedge_web::AttachRejectedOrBridgeError::Bridge(
-                selvedge_web::WebBridgeError::InternalFailure(
-                    "server web bridge is owned by the server runtime".to_owned(),
-                ),
-            ))
+    fn attach(&self, request: AttachRequest) -> selvedge_web::WebAttachFuture {
+        let control = self.control.clone();
+        Box::pin(async move {
+            match control.attach_client(request).await {
+                Ok((accepted, stream)) => Ok((
+                    accepted,
+                    Box::pin(WebServerFrameStream { inner: stream })
+                        as selvedge_web::WebFrameStream,
+                )),
+                Err(rejected) => Err(selvedge_web::AttachRejectedOrBridgeError::Rejected(
+                    rejected,
+                )),
+            }
         })
+    }
+}
+
+struct WebServerFrameStream {
+    inner: ServerFrameStream,
+}
+
+impl Stream for WebServerFrameStream {
+    type Item = Result<LocalClientFrame, selvedge_web::WebBridgeError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+            Poll::Ready(Some(Err(error))) => {
+                Poll::Ready(Some(Err(server_request_error_to_web_bridge(error))))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn server_request_error_to_web_bridge(error: ServerRequestError) -> selvedge_web::WebBridgeError {
+    match error {
+        ServerRequestError::NotReady => selvedge_web::WebBridgeError::ServerNotReady,
+        ServerRequestError::ProtocolValidationFailed => {
+            selvedge_web::WebBridgeError::ProtocolValidationFailed
+        }
+        ServerRequestError::UnsupportedCommand => {
+            selvedge_web::WebBridgeError::CommandRejected("unsupported command".to_owned())
+        }
+        ServerRequestError::RouterMailboxClosed => selvedge_web::WebBridgeError::StreamClosed,
+        ServerRequestError::AttachChannelFailed => selvedge_web::WebBridgeError::StreamClosed,
+        ServerRequestError::InternalFailure(message) => {
+            selvedge_web::WebBridgeError::InternalFailure(message)
+        }
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -255,6 +255,9 @@ impl ServerControl {
             return reject(AttachRejectReason::RouterMailboxClosed);
         }
 
+        let Some(events_tx) = self.inner.events_tx.lock().await.as_ref().cloned() else {
+            return reject(AttachRejectReason::InternalFailure);
+        };
         let client_id = ClientId(request.client_id.0.clone());
         let client_command_id = ClientCommandId(request.client_command_id.0.clone());
         let previous_attach = match self
@@ -269,6 +272,7 @@ impl ServerControl {
             client_id.clone(),
             client_command_id.clone(),
             previous_attach,
+            Some(events_tx.clone()),
         );
 
         let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
@@ -295,7 +299,9 @@ impl ServerControl {
         }
 
         match admission_rx.await {
-            Ok(RouterAttachAdmissionResult::Accepted) => {}
+            Ok(RouterAttachAdmissionResult::Accepted) => {
+                reservation.mark_events_reserved();
+            }
             Ok(RouterAttachAdmissionResult::DuplicateAttach) => {
                 return reject(AttachRejectReason::DuplicateAttach);
             }
@@ -313,29 +319,14 @@ impl ServerControl {
             outbound: outbound_tx,
             subscription,
         };
-        let Some(events_tx) = self.inner.events_tx.lock().await.as_ref().cloned() else {
-            return reject(AttachRejectReason::InternalFailure);
-        };
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
 
         match client_sync_tx.try_send(ClientSyncIngress::StartHydration(begin)) {
             Ok(()) => {}
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                send_detach_client(
-                    &events_tx,
-                    client_id.clone(),
-                    client_command_id.clone(),
-                    DetachReason::ClientDisconnected,
-                );
                 return reject(AttachRejectReason::ClientSyncUnavailable);
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                send_detach_client(
-                    &events_tx,
-                    client_id.clone(),
-                    client_command_id.clone(),
-                    DetachReason::ClientDisconnected,
-                );
                 self.begin_shutdown_locked().await;
                 return reject(AttachRejectReason::ClientSyncUnavailable);
             }
@@ -498,6 +489,8 @@ struct ActiveAttachReservation {
     client_id: ClientId,
     client_command_id: ClientCommandId,
     previous_attach: Option<ClientCommandId>,
+    events_tx: Option<EventIngressSender>,
+    events_reserved: bool,
     active: bool,
 }
 
@@ -507,12 +500,15 @@ impl ActiveAttachReservation {
         client_id: ClientId,
         client_command_id: ClientCommandId,
         previous_attach: Option<ClientCommandId>,
+        events_tx: Option<EventIngressSender>,
     ) -> Self {
         Self {
             active_attaches,
             client_id,
             client_command_id,
             previous_attach,
+            events_tx,
+            events_reserved: false,
             active: true,
         }
     }
@@ -524,11 +520,25 @@ impl ActiveAttachReservation {
     fn commit(&mut self) {
         self.active = false;
     }
+
+    fn mark_events_reserved(&mut self) {
+        self.events_reserved = true;
+    }
 }
 
 impl Drop for ActiveAttachReservation {
     fn drop(&mut self) {
         if self.active {
+            if self.events_reserved
+                && let Some(events_tx) = &self.events_tx
+            {
+                send_detach_client(
+                    events_tx,
+                    self.client_id.clone(),
+                    self.client_command_id.clone(),
+                    DetachReason::ClientDisconnected,
+                );
+            }
             restore_active_attach(
                 &self.active_attaches,
                 &self.client_id,
@@ -1522,7 +1532,7 @@ mod tests {
             .send(ClientSyncIngress::Shutdown)
             .await
             .expect("fill client-sync mailbox");
-        let (events_tx, _events_rx) = mpsc::channel(4);
+        let (events_tx, mut events_rx) = mpsc::channel(4);
         let control = test_control(router_tx, client_sync_tx, events_tx);
 
         let rejected = match control.attach_client(test_attach_request()).await {
@@ -1530,6 +1540,21 @@ mod tests {
             Err(rejected) => rejected,
         };
         assert_eq!(rejected.reason, AttachRejectReason::ClientSyncUnavailable);
+        match timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("reservation cleanup detach arrives")
+            .expect("reservation cleanup detach")
+        {
+            EventIngress::Control(EventControlMessage::DetachClient(detach)) => {
+                assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    detach.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+                assert_eq!(detach.reason, DetachReason::ClientDisconnected);
+            }
+            _ => panic!("unexpected events ingress"),
+        }
         let _ = client_sync_rx.recv().await.expect("drain filled mailbox");
 
         let (_accepted, _stream) = control

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -322,6 +322,7 @@ impl ServerControl {
             self.begin_shutdown_locked().await;
             return reject(AttachRejectReason::RouterMailboxClosed);
         }
+        reservation.mark_router_attach_sent();
 
         match admission_rx.await {
             Ok(RouterAttachAdmissionResult::Accepted) => {
@@ -520,6 +521,7 @@ struct ActiveAttachReservation {
     previous_attach: Option<ClientCommandId>,
     events_tx: Option<EventIngressSender>,
     events_reserved: bool,
+    router_attach_sent: bool,
     active: bool,
 }
 
@@ -538,6 +540,7 @@ impl ActiveAttachReservation {
             previous_attach,
             events_tx,
             events_reserved: false,
+            router_attach_sent: false,
             active: true,
         }
     }
@@ -552,6 +555,10 @@ impl ActiveAttachReservation {
 
     fn mark_events_reserved(&mut self) {
         self.events_reserved = true;
+    }
+
+    fn mark_router_attach_sent(&mut self) {
+        self.router_attach_sent = true;
     }
 
     async fn cleanup_events_reservation_before_reject(&mut self) {
@@ -579,7 +586,7 @@ impl ActiveAttachReservation {
 impl Drop for ActiveAttachReservation {
     fn drop(&mut self) {
         if self.active {
-            if self.events_reserved
+            if (self.events_reserved || self.router_attach_sent)
                 && let Some(events_tx) = &self.events_tx
             {
                 send_detach_client_and_restore_active(
@@ -1816,6 +1823,65 @@ mod tests {
             .attach_client(test_attach_request())
             .await
             .expect("attach accepted after queued cleanup");
+    }
+
+    #[tokio::test]
+    async fn cancelled_attach_after_router_send_detaches_possible_reservation() {
+        let (router_tx, mut router_rx) = mpsc::unbounded_channel();
+        let (router_seen_tx, router_seen_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let mut router_seen_tx = Some(router_seen_tx);
+            while let Some(message) = router_rx.recv().await {
+                match message {
+                    RouterIngressMessage::Command(RouterCommandEnvelope {
+                        command: RouterCommand::AttachClient { admission_tx, .. },
+                        ..
+                    }) => {
+                        if let Some(router_seen_tx) = router_seen_tx.take() {
+                            let _ = router_seen_tx.send(());
+                        }
+                        let _admission_tx = admission_tx;
+                        std::future::pending::<()>().await;
+                    }
+                    RouterIngressMessage::StopRouter => break,
+                    _ => {}
+                }
+            }
+        });
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
+        let (events_tx, mut events_rx) = mpsc::channel(4);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+        let attach_task = tokio::spawn({
+            let control = control.clone();
+            async move { control.attach_client(test_attach_request()).await }
+        });
+
+        router_seen_rx.await.expect("router attach command arrives");
+        attach_task.abort();
+        match attach_task.await {
+            Ok(_) => panic!("attach task should abort"),
+            Err(error) => assert!(error.is_cancelled()),
+        }
+
+        match timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("cancelled attach detach arrives")
+            .expect("cancelled attach detach")
+        {
+            EventIngress::Control(EventControlMessage::DetachClient(detach)) => {
+                assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    detach.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+                assert_eq!(detach.reason, DetachReason::ClientDisconnected);
+            }
+            _ => panic!("unexpected events ingress"),
+        }
+        assert!(matches!(
+            client_sync_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -309,6 +309,7 @@ impl ServerControl {
                 return reject(AttachRejectReason::ClientRegistryFull);
             }
             Ok(RouterAttachAdmissionResult::EventsMailboxClosed) | Err(_) => {
+                self.begin_shutdown_locked().await;
                 return reject(AttachRejectReason::InternalFailure);
             }
         }
@@ -1370,6 +1371,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn attach_closed_events_admission_starts_shutdown() {
+        let router_tx = events_closed_router_sender();
+        let (client_sync_tx, _client_sync_rx) = mpsc::channel(1);
+        let (events_tx, _events_rx) = mpsc::channel(1);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let rejected = match timeout(
+            Duration::from_millis(100),
+            control.attach_client(test_attach_request()),
+        )
+        .await
+        .expect("attach returns")
+        {
+            Ok(_) => panic!("attach should reject after events admission closes"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason, AttachRejectReason::InternalFailure);
+        assert_eq!(control.state().await, ServerRuntimeState::Closing);
+    }
+
+    #[tokio::test]
     async fn duplicate_active_attach_rejects_without_second_start() {
         let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
@@ -1707,6 +1730,25 @@ mod tests {
                         ..
                     }) => {
                         let _ = admission_tx.send(RouterAttachAdmissionResult::Accepted);
+                    }
+                    RouterIngressMessage::StopRouter => break,
+                    _ => {}
+                }
+            }
+        });
+        router_tx
+    }
+
+    fn events_closed_router_sender() -> RouterIngressSender {
+        let (router_tx, mut router_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(message) = router_rx.recv().await {
+                match message {
+                    RouterIngressMessage::Command(RouterCommandEnvelope {
+                        command: RouterCommand::AttachClient { admission_tx, .. },
+                        ..
+                    }) => {
+                        let _ = admission_tx.send(RouterAttachAdmissionResult::EventsMailboxClosed);
                     }
                     RouterIngressMessage::StopRouter => break,
                     _ => {}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -707,6 +707,10 @@ impl futures_core::Stream for ServerAttachFrameStream {
 
 impl Drop for ServerAttachFrameStream {
     fn drop(&mut self) {
+        if self.closed_reported {
+            return;
+        }
+
         let client_id = self.client_id.clone();
         let client_command_id = self.client_command_id.clone();
 
@@ -1499,6 +1503,15 @@ mod tests {
             .attach_client(test_attach_request())
             .await
             .expect("retry attach accepted after channel close");
+        let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("retry start hydration arrives")
+            .expect("retry start hydration");
+        drop(stream);
+        assert!(matches!(
+            client_sync_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -21,9 +21,10 @@ use selvedge_command_model::{
     BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
     ClientNoticeLevel, ClientSnapshot, ClientSubscription, DeliverySeq, DetachClient, DetachReason,
     DetailLevel, EventControlMessage, EventIngress, EventIngressSender, HistoryNodeProjection,
-    HistoryNodeProjectionBody, ModelCallStatusPhase, RouterCommandEnvelope, RouterIngressMessage,
-    RouterIngressSender, SnapshotTaskVersion, TaskParentProjection, TaskProjection,
-    TaskProjectionStatus, TaskScope, ToolExecutionStatusPhase,
+    HistoryNodeProjectionBody, ModelCallStatusPhase, RouterAttachAdmissionResult, RouterCommand,
+    RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender, SnapshotTaskVersion,
+    TaskParentProjection, TaskProjection, TaskProjectionStatus, TaskScope,
+    ToolExecutionStatusPhase,
 };
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::{OpenDbOptions, open_db};
@@ -271,11 +272,46 @@ impl ServerControl {
         );
 
         let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
+        let subscription = local_subscription_to_command(request.subscription);
+        let (admission_tx, admission_rx) = tokio::sync::oneshot::channel();
+        if self
+            .inner
+            .router_tx
+            .send(RouterIngressMessage::Command(RouterCommandEnvelope {
+                client_id: Some(client_id.clone()),
+                client_command_id: Some(client_command_id.clone()),
+                command: RouterCommand::AttachClient {
+                    client_id: client_id.clone(),
+                    client_command_id: client_command_id.clone(),
+                    outbound: outbound_tx.clone(),
+                    subscription: subscription.clone(),
+                    admission_tx,
+                },
+            }))
+            .is_err()
+        {
+            self.begin_shutdown_locked().await;
+            return reject(AttachRejectReason::RouterMailboxClosed);
+        }
+
+        match admission_rx.await {
+            Ok(RouterAttachAdmissionResult::Accepted) => {}
+            Ok(RouterAttachAdmissionResult::DuplicateAttach) => {
+                return reject(AttachRejectReason::DuplicateAttach);
+            }
+            Ok(RouterAttachAdmissionResult::ClientRegistryFull) => {
+                return reject(AttachRejectReason::ClientRegistryFull);
+            }
+            Ok(RouterAttachAdmissionResult::EventsMailboxClosed) | Err(_) => {
+                return reject(AttachRejectReason::InternalFailure);
+            }
+        }
+
         let begin = BeginClientHydration {
             client_id: client_id.clone(),
             client_command_id: client_command_id.clone(),
             outbound: outbound_tx,
-            subscription: local_subscription_to_command(request.subscription),
+            subscription,
         };
         let Some(events_tx) = self.inner.events_tx.lock().await.as_ref().cloned() else {
             return reject(AttachRejectReason::InternalFailure);
@@ -285,9 +321,21 @@ impl ServerControl {
         match client_sync_tx.try_send(ClientSyncIngress::StartHydration(begin)) {
             Ok(()) => {}
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                send_detach_client(
+                    &events_tx,
+                    client_id.clone(),
+                    client_command_id.clone(),
+                    DetachReason::ClientDisconnected,
+                );
                 return reject(AttachRejectReason::ClientSyncUnavailable);
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                send_detach_client(
+                    &events_tx,
+                    client_id.clone(),
+                    client_command_id.clone(),
+                    DetachReason::ClientDisconnected,
+                );
                 self.begin_shutdown_locked().await;
                 return reject(AttachRejectReason::ClientSyncUnavailable);
             }
@@ -1286,7 +1334,7 @@ mod tests {
 
     #[tokio::test]
     async fn attach_closed_client_sync_shutdown_path_returns_rejection() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, client_sync_rx) = mpsc::channel(1);
         drop(client_sync_rx);
         let (events_tx, _events_rx) = mpsc::channel(1);
@@ -1309,7 +1357,7 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_active_attach_rejects_without_second_start() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
         let (events_tx, _events_rx) = mpsc::channel(4);
         let control = test_control(router_tx, client_sync_tx, events_tx);
@@ -1337,7 +1385,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_client_attach_rejects_when_registry_capacity_is_reserved() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) =
             mpsc::channel(DEFAULT_CLIENT_REGISTRY_CAPACITY + 1);
         let (events_tx, _events_rx) = mpsc::channel(4);
@@ -1379,7 +1427,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_stream_drop_after_replacement_preserves_new_active_attach() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(8);
         let (events_tx, mut events_rx) = mpsc::channel(8);
         let control = test_control(router_tx, client_sync_tx, events_tx);
@@ -1425,7 +1473,7 @@ mod tests {
 
     #[tokio::test]
     async fn closed_frame_channel_clears_active_attach_before_stream_drop() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
         let (events_tx, _events_rx) = mpsc::channel(4);
         let control = test_control(router_tx, client_sync_tx, events_tx);
@@ -1455,7 +1503,7 @@ mod tests {
 
     #[tokio::test]
     async fn backpressured_client_sync_rejects_and_restores_attach_slot() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(1);
         client_sync_tx
             .send(ClientSyncIngress::Shutdown)
@@ -1479,7 +1527,7 @@ mod tests {
 
     #[tokio::test]
     async fn dropped_attach_stream_sends_cancel_and_client_disconnect_detach() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
         let (events_tx, mut events_rx) = mpsc::channel(4);
         let control = test_control(router_tx, client_sync_tx, events_tx);
@@ -1539,7 +1587,7 @@ mod tests {
 
     #[tokio::test]
     async fn full_events_mailbox_delays_active_attach_release_until_detach_is_queued() {
-        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
         let (events_tx, mut events_rx) = mpsc::channel(1);
         events_tx
@@ -1609,6 +1657,25 @@ mod tests {
             .attach_client(test_attach_request())
             .await
             .expect("attach accepted after detach queued");
+    }
+
+    fn accepting_router_sender() -> RouterIngressSender {
+        let (router_tx, mut router_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(message) = router_rx.recv().await {
+                match message {
+                    RouterIngressMessage::Command(RouterCommandEnvelope {
+                        command: RouterCommand::AttachClient { admission_tx, .. },
+                        ..
+                    }) => {
+                        let _ = admission_tx.send(RouterAttachAdmissionResult::Accepted);
+                    }
+                    RouterIngressMessage::StopRouter => break,
+                    _ => {}
+                }
+            }
+        });
+        router_tx
     }
 
     fn test_control(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -702,6 +702,8 @@ fn send_cancel_hydration(
                 handle.spawn(async move {
                     let _ = retry_client_sync_tx.send(cancel).await;
                 });
+            } else {
+                let _ = retry_client_sync_tx.blocking_send(cancel);
             }
         }
         Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
@@ -728,6 +730,8 @@ fn send_detach_client(
                 handle.spawn(async move {
                     let _ = retry_events_tx.send(detach).await;
                 });
+            } else {
+                let _ = retry_events_tx.blocking_send(detach);
             }
         }
         Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
@@ -758,6 +762,9 @@ fn send_detach_client_and_clear_active(
                     let _ = retry_events_tx.send(detach).await;
                     clear_active_attach(&active_attaches, &client_id, &client_command_id);
                 });
+            } else {
+                let _ = retry_events_tx.blocking_send(detach);
+                clear_active_attach(&active_attaches, &client_id, &client_command_id);
             }
         }
     }
@@ -1554,7 +1561,8 @@ mod tests {
             .await
             .expect("start hydration arrives")
             .expect("start hydration");
-        drop(stream);
+        let drop_thread = std::thread::spawn(move || drop(stream));
+        tokio::time::sleep(Duration::from_millis(10)).await;
 
         let rejected = match control.attach_client(test_attach_request()).await {
             Ok(_) => panic!("attach should remain active until detach is queued"),
@@ -1563,6 +1571,7 @@ mod tests {
         assert_eq!(rejected.reason, AttachRejectReason::DuplicateAttach);
 
         let _ = events_rx.recv().await.expect("drain occupied events slot");
+        drop_thread.join().expect("drop thread completes");
         match timeout(Duration::from_millis(100), events_rx.recv())
             .await
             .expect("client detach arrives")

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -350,9 +350,11 @@ impl ServerControl {
         match client_sync_tx.try_send(ClientSyncIngress::StartHydration(begin)) {
             Ok(()) => {}
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                reservation.cleanup_events_reservation_before_reject().await;
                 return reject(AttachRejectReason::ClientSyncUnavailable);
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                reservation.cleanup_events_reservation_before_reject().await;
                 self.begin_shutdown_locked().await;
                 return reject(AttachRejectReason::ClientSyncUnavailable);
             }
@@ -551,6 +553,27 @@ impl ActiveAttachReservation {
     fn mark_events_reserved(&mut self) {
         self.events_reserved = true;
     }
+
+    async fn cleanup_events_reservation_before_reject(&mut self) {
+        if self.events_reserved
+            && let Some(events_tx) = &self.events_tx
+        {
+            send_detach_client_await(
+                events_tx,
+                self.client_id.clone(),
+                self.client_command_id.clone(),
+                DetachReason::ClientDisconnected,
+            )
+            .await;
+        }
+        restore_active_attach(
+            &self.active_attaches,
+            &self.client_id,
+            &self.client_command_id,
+            self.previous_attach.clone(),
+        );
+        self.active = false;
+    }
 }
 
 impl Drop for ActiveAttachReservation {
@@ -559,19 +582,22 @@ impl Drop for ActiveAttachReservation {
             if self.events_reserved
                 && let Some(events_tx) = &self.events_tx
             {
-                send_detach_client(
+                send_detach_client_and_restore_active(
                     events_tx,
                     self.client_id.clone(),
                     self.client_command_id.clone(),
                     DetachReason::ClientDisconnected,
+                    Arc::clone(&self.active_attaches),
+                    self.previous_attach.clone(),
+                );
+            } else {
+                restore_active_attach(
+                    &self.active_attaches,
+                    &self.client_id,
+                    &self.client_command_id,
+                    self.previous_attach.clone(),
                 );
             }
-            restore_active_attach(
-                &self.active_attaches,
-                &self.client_id,
-                &self.client_command_id,
-                self.previous_attach.clone(),
-            );
         }
     }
 }
@@ -825,6 +851,68 @@ fn send_detach_client(
             }
         }
         Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+    }
+}
+
+async fn send_detach_client_await(
+    events_tx: &EventIngressSender,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+    reason: DetachReason,
+) {
+    let detach = EventIngress::Control(EventControlMessage::DetachClient(DetachClient {
+        client_id,
+        client_command_id,
+        reason,
+    }));
+    let _ = events_tx.send(detach).await;
+}
+
+fn send_detach_client_and_restore_active(
+    events_tx: &EventIngressSender,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+    reason: DetachReason,
+    active_attaches: ActiveAttachRegistry,
+    previous_attach: Option<ClientCommandId>,
+) {
+    let retry_events_tx = events_tx.clone();
+    let detach = EventIngress::Control(EventControlMessage::DetachClient(DetachClient {
+        client_id: client_id.clone(),
+        client_command_id: client_command_id.clone(),
+        reason,
+    }));
+
+    match events_tx.try_send(detach) {
+        Ok(()) | Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            restore_active_attach(
+                &active_attaches,
+                &client_id,
+                &client_command_id,
+                previous_attach,
+            );
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Full(detach)) => {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = retry_events_tx.send(detach).await;
+                    restore_active_attach(
+                        &active_attaches,
+                        &client_id,
+                        &client_command_id,
+                        previous_attach,
+                    );
+                });
+            } else {
+                let _ = retry_events_tx.blocking_send(detach);
+                restore_active_attach(
+                    &active_attaches,
+                    &client_id,
+                    &client_command_id,
+                    previous_attach,
+                );
+            }
+        }
     }
 }
 
@@ -1669,6 +1757,65 @@ mod tests {
             .attach_client(test_attach_request())
             .await
             .expect("attach accepted after cancelled future");
+    }
+
+    #[tokio::test]
+    async fn rejected_attach_waits_for_full_events_cleanup_before_returning() {
+        let router_tx = accepting_router_sender();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(1);
+        client_sync_tx
+            .send(ClientSyncIngress::Shutdown)
+            .await
+            .expect("fill client-sync mailbox");
+        let (events_tx, mut events_rx) = mpsc::channel(1);
+        events_tx
+            .try_send(EventIngress::Control(EventControlMessage::DetachClient(
+                DetachClient {
+                    client_id: ClientId("occupied-client".to_owned()),
+                    client_command_id: ClientCommandId("occupied-attach".to_owned()),
+                    reason: DetachReason::ClientRequested,
+                },
+            )))
+            .expect("fill events mailbox");
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let mut attach_task = tokio::spawn({
+            let control = control.clone();
+            async move { control.attach_client(test_attach_request()).await }
+        });
+        assert!(
+            timeout(Duration::from_millis(10), &mut attach_task)
+                .await
+                .is_err()
+        );
+
+        let _ = events_rx.recv().await.expect("drain occupied events slot");
+        match timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("reservation cleanup detach arrives")
+            .expect("reservation cleanup detach")
+        {
+            EventIngress::Control(EventControlMessage::DetachClient(detach)) => {
+                assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    detach.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+                assert_eq!(detach.reason, DetachReason::ClientDisconnected);
+            }
+            _ => panic!("unexpected events ingress"),
+        }
+        let rejected = match attach_task.await.expect("attach task joins") {
+            Ok(_) => panic!("backpressured client-sync should reject"),
+            Err(rejected) => rejected,
+        };
+        assert_eq!(rejected.reason, AttachRejectReason::ClientSyncUnavailable);
+
+        let _ = client_sync_rx.recv().await.expect("drain filled mailbox");
+        let (_accepted, _stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("attach accepted after queued cleanup");
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -617,6 +617,11 @@ impl futures_core::Stream for ServerAttachFrameStream {
         match this.inner.poll_recv(context) {
             Poll::Ready(Some(frame)) => Poll::Ready(Some(Ok(client_frame_to_local(frame)))),
             Poll::Ready(None) => {
+                clear_active_attach(
+                    &this.active_attaches,
+                    &this.client_id,
+                    &this.client_command_id,
+                );
                 this.closed_reported = true;
                 Poll::Ready(Some(Err(ServerRequestError::AttachChannelFailed)))
             }
@@ -1132,6 +1137,7 @@ fn map_web_start_error(error: WebStartError) -> ServerStartupError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
     use std::time::Duration;
     use tokio::time::timeout;
 
@@ -1306,6 +1312,36 @@ mod tests {
         };
 
         assert_eq!(rejected.reason, AttachRejectReason::DuplicateAttach);
+    }
+
+    #[tokio::test]
+    async fn closed_frame_channel_clears_active_attach_before_stream_drop() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
+        let (events_tx, _events_rx) = mpsc::channel(4);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let (_accepted, mut stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("attach accepted");
+        let start = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("start hydration arrives")
+            .expect("start hydration");
+        drop(start);
+
+        let error = timeout(Duration::from_millis(100), stream.next())
+            .await
+            .expect("stream terminal item arrives")
+            .expect("stream terminal item")
+            .expect_err("closed frame channel reports error");
+        assert_eq!(error, ServerRequestError::AttachChannelFailed);
+
+        let (_accepted, _retry_stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("retry attach accepted after channel close");
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -149,11 +149,17 @@ pub fn spawn_server(args: ServerStartArgs) -> Result<ServerHandle, ServerStartup
     if let Some(web_binding) = &args.web_binding {
         validate_web_bind_target(&web_binding.bind_target)?;
     }
-    let web_bind = reserve_web_binding(args.web_binding.as_ref())?;
 
     init_config(args.explicit_home.as_ref())?;
     let home = resolve_home()?;
     let singleton_lock = acquire_singleton_lock(&home)?;
+    let web_bind = match reserve_web_binding(args.web_binding.as_ref()) {
+        Ok(web_bind) => web_bind,
+        Err(error) => {
+            cleanup_startup_lock(&home);
+            return Err(error);
+        }
+    };
 
     let startup_result = start_server_after_lock(args, home, singleton_lock, web_bind);
     if let Err(error) = &startup_result {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,12 +1,13 @@
 #![doc = include_str!("../README.md")]
 
+use std::collections::HashMap;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::task::{Context, Poll};
 
 use fs2::FileExt;
@@ -57,6 +58,8 @@ const DEFAULT_EVENTS_INGRESS_CAPACITY: usize = 64;
 const DEFAULT_CLIENT_REGISTRY_CAPACITY: usize = 64;
 const DEFAULT_HYDRATION_BUFFER_CAPACITY: usize = 256;
 const DEFAULT_CLIENT_SYNC_INGRESS_CAPACITY: usize = 64;
+
+type ActiveAttachRegistry = Arc<StdMutex<HashMap<ClientId, ClientCommandId>>>;
 
 pub struct ServerStartArgs {
     pub explicit_home: Option<PathBuf>,
@@ -251,9 +254,17 @@ impl ServerControl {
             return reject(AttachRejectReason::RouterMailboxClosed);
         }
 
-        let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
         let client_id = ClientId(request.client_id.0.clone());
         let client_command_id = ClientCommandId(request.client_command_id.0.clone());
+        let previous_attach = match self
+            .inner
+            .reserve_active_attach(&client_id, &client_command_id)
+        {
+            Ok(previous_attach) => previous_attach,
+            Err(reason) => return reject(reason),
+        };
+
+        let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
         let begin = BeginClientHydration {
             client_id: client_id.clone(),
             client_command_id: client_command_id.clone(),
@@ -261,6 +272,8 @@ impl ServerControl {
             subscription: local_subscription_to_command(request.subscription),
         };
         let Some(events_tx) = self.inner.events_tx.lock().await.as_ref().cloned() else {
+            self.inner
+                .restore_active_attach(&client_id, &client_command_id, previous_attach);
             return reject(AttachRejectReason::InternalFailure);
         };
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
@@ -270,8 +283,28 @@ impl ServerControl {
             .await
             .is_err()
         {
+            self.inner
+                .restore_active_attach(&client_id, &client_command_id, previous_attach);
             self.begin_shutdown_locked().await;
             return reject(AttachRejectReason::ClientSyncUnavailable);
+        }
+
+        if let Some(previous_command_id) = previous_attach {
+            let _ = client_sync_tx
+                .send(ClientSyncIngress::CancelHydration(CancelHydration {
+                    client_id: client_id.clone(),
+                    client_command_id: previous_command_id.clone(),
+                }))
+                .await;
+            let _ = events_tx
+                .send(EventIngress::Control(EventControlMessage::DetachClient(
+                    DetachClient {
+                        client_id: client_id.clone(),
+                        client_command_id: previous_command_id,
+                        reason: DetachReason::ReplacedByNewHydration,
+                    },
+                )))
+                .await;
         }
 
         Ok((
@@ -286,6 +319,7 @@ impl ServerControl {
                 client_command_id,
                 events_tx: events_tx.downgrade(),
                 client_sync_tx: client_sync_tx.downgrade(),
+                active_attaches: Arc::clone(&self.inner.active_attaches),
                 closed_reported: false,
             }),
         ))
@@ -381,8 +415,53 @@ struct ServerInner {
     router_tx: RouterIngressSender,
     events_tx: Mutex<Option<EventIngressSender>>,
     client_sync_tx: Mutex<selvedge_client_sync::ClientSyncSender>,
+    active_attaches: ActiveAttachRegistry,
     command_mapper: Arc<dyn LocalCommandMapper>,
     web_control: Mutex<Option<selvedge_web::WebControl>>,
+}
+
+impl ServerInner {
+    fn reserve_active_attach(
+        &self,
+        client_id: &ClientId,
+        client_command_id: &ClientCommandId,
+    ) -> Result<Option<ClientCommandId>, AttachRejectReason> {
+        let mut active = self
+            .active_attaches
+            .lock()
+            .expect("server active attach registry lock");
+
+        if active.get(client_id) == Some(client_command_id) {
+            return Err(AttachRejectReason::DuplicateAttach);
+        }
+
+        if !active.contains_key(client_id) && active.len() >= DEFAULT_CLIENT_REGISTRY_CAPACITY {
+            return Err(AttachRejectReason::ClientRegistryFull);
+        }
+
+        Ok(active.insert(client_id.clone(), client_command_id.clone()))
+    }
+
+    fn restore_active_attach(
+        &self,
+        client_id: &ClientId,
+        client_command_id: &ClientCommandId,
+        previous_attach: Option<ClientCommandId>,
+    ) {
+        let mut active = self
+            .active_attaches
+            .lock()
+            .expect("server active attach registry lock");
+        if active.get(client_id) != Some(client_command_id) {
+            return;
+        }
+
+        if let Some(previous_command_id) = previous_attach {
+            active.insert(client_id.clone(), previous_command_id);
+        } else {
+            active.remove(client_id);
+        }
+    }
 }
 
 impl ServerContext {
@@ -471,6 +550,7 @@ fn start_server_after_lock(
         router_tx: router.ingress_tx.clone(),
         events_tx: Mutex::new(Some(events.ingress_tx.clone())),
         client_sync_tx: Mutex::new(client_sync.ingress_tx.clone()),
+        active_attaches: Arc::new(StdMutex::new(HashMap::new())),
         command_mapper: args.command_mapper,
         web_control: Mutex::new(web.as_ref().map(|handle| handle.control.clone())),
     });
@@ -522,6 +602,7 @@ struct ServerAttachFrameStream {
     // Drop upgrades it only to report client detach.
     events_tx: mpsc::WeakSender<EventIngress>,
     client_sync_tx: mpsc::WeakSender<ClientSyncIngress>,
+    active_attaches: ActiveAttachRegistry,
     closed_reported: bool,
 }
 
@@ -548,6 +629,8 @@ impl Drop for ServerAttachFrameStream {
     fn drop(&mut self) {
         let client_id = self.client_id.clone();
         let client_command_id = self.client_command_id.clone();
+
+        clear_active_attach(&self.active_attaches, &client_id, &client_command_id);
 
         if let Some(client_sync_tx) = self.client_sync_tx.upgrade() {
             let retry_client_sync_tx = client_sync_tx.clone();
@@ -590,6 +673,19 @@ impl Drop for ServerAttachFrameStream {
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
         }
+    }
+}
+
+fn clear_active_attach(
+    active_attaches: &ActiveAttachRegistry,
+    client_id: &ClientId,
+    client_command_id: &ClientCommandId,
+) {
+    let mut active = active_attaches
+        .lock()
+        .expect("server active attach registry lock");
+    if active.get(client_id) == Some(client_command_id) {
+        active.remove(client_id);
     }
 }
 
@@ -1097,6 +1193,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn duplicate_active_attach_rejects_without_second_start() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
+        let (events_tx, _events_rx) = mpsc::channel(4);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let (_accepted, _stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("attach accepted");
+        let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("start hydration arrives")
+            .expect("start hydration");
+
+        let rejected = match control.attach_client(test_attach_request()).await {
+            Ok(_) => panic!("duplicate attach should reject"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason, AttachRejectReason::DuplicateAttach);
+        assert!(matches!(
+            client_sync_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn new_client_attach_rejects_when_registry_capacity_is_reserved() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, mut client_sync_rx) =
+            mpsc::channel(DEFAULT_CLIENT_REGISTRY_CAPACITY + 1);
+        let (events_tx, _events_rx) = mpsc::channel(4);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+        let mut streams = Vec::new();
+
+        for index in 0..DEFAULT_CLIENT_REGISTRY_CAPACITY {
+            let (_accepted, stream) = control
+                .attach_client(test_attach_request_for(
+                    &format!("client-{index}"),
+                    &format!("attach-{index}"),
+                ))
+                .await
+                .expect("attach accepted");
+            streams.push(stream);
+            let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+                .await
+                .expect("start hydration arrives")
+                .expect("start hydration");
+        }
+
+        let rejected = match control
+            .attach_client(test_attach_request_for(
+                "client-overflow",
+                "attach-overflow",
+            ))
+            .await
+        {
+            Ok(_) => panic!("full registry should reject"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason, AttachRejectReason::ClientRegistryFull);
+        assert!(matches!(
+            client_sync_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn stale_stream_drop_after_replacement_preserves_new_active_attach() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(8);
+        let (events_tx, mut events_rx) = mpsc::channel(8);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let (_accepted, old_stream) = control
+            .attach_client(test_attach_request_for("client-1", "attach-1"))
+            .await
+            .expect("first attach accepted");
+        let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("first start hydration arrives")
+            .expect("first start hydration");
+
+        let (_accepted, _new_stream) = control
+            .attach_client(test_attach_request_for("client-1", "attach-2"))
+            .await
+            .expect("replacement attach accepted");
+        let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("replacement start hydration arrives")
+            .expect("replacement start hydration");
+        let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("old cancel hydration arrives")
+            .expect("old cancel hydration");
+        let _ = timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("old detach arrives")
+            .expect("old detach");
+
+        drop(old_stream);
+
+        let rejected = match control
+            .attach_client(test_attach_request_for("client-1", "attach-2"))
+            .await
+        {
+            Ok(_) => panic!("new attach should remain active"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason, AttachRejectReason::DuplicateAttach);
+    }
+
+    #[tokio::test]
     async fn dropped_attach_stream_sends_cancel_and_client_disconnect_detach() {
         let (router_tx, _router_rx) = mpsc::unbounded_channel();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
@@ -1172,6 +1384,7 @@ mod tests {
                 router_tx,
                 events_tx: Mutex::new(Some(events_tx)),
                 client_sync_tx: Mutex::new(client_sync_tx),
+                active_attaches: Arc::new(StdMutex::new(HashMap::new())),
                 command_mapper: Arc::new(UnusedMapper),
                 web_control: Mutex::new(None),
             }),
@@ -1179,11 +1392,16 @@ mod tests {
     }
 
     fn test_attach_request() -> AttachRequest {
+        test_attach_request_for("client-1", "attach-1")
+    }
+
+    fn test_attach_request_for(client_id: &str, client_command_id: &str) -> AttachRequest {
         AttachRequest {
             protocol_version: current_protocol_version(),
-            client_id: selvedge_local_protocol::LocalClientId::new("client-1")
+            client_id: selvedge_local_protocol::LocalClientId::new(client_id)
                 .expect("valid client id"),
-            client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+            client_command_id: LocalClientCommandId::new(client_command_id)
+                .expect("valid command id"),
             subscription: selvedge_local_protocol::LocalClientSubscription {
                 task_scope: LocalTaskScope::AllTasks,
                 detail_level: LocalDetailLevel::Summary,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::{Context, Poll};
 
 use fs2::FileExt;
 use futures_core::Stream;
@@ -16,24 +15,14 @@ use selvedge_client_sync::{
     ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress, ClientSyncStartArgs,
     SpawnClientSyncError, spawn_client_sync,
 };
-use selvedge_command_model::{
-    BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
-    ClientNoticeLevel, ClientSnapshot, ClientSubscription, DetailLevel, RouterCommandEnvelope,
-    RouterIngressMessage, RouterIngressSender, TaskScope,
-};
+use selvedge_command_model::{RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender};
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::{OpenDbOptions, open_db};
 use selvedge_events::{EventsHandle, EventsStartArgs, SpawnEventsError, spawn_events_task};
 use selvedge_local_protocol::{
     AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
-    CommandRequest, CommandResponse, LocalClientEvent, LocalClientFrame, LocalClientNoticeFrame,
-    LocalClientSnapshot, LocalClientSnapshotFrame, LocalDetailLevel, LocalHistoryNodeProjection,
-    LocalHistoryNodeProjectionBody, LocalMessageRole, LocalModelCallStatusEvent,
-    LocalModelCallStatusPhase, LocalNotice, LocalNoticeLevel, LocalReasoningEffort,
-    LocalSnapshotTaskVersion, LocalTaskParentProjection, LocalTaskProjection,
-    LocalTaskProjectionStatus, LocalTaskScope, LocalToolArgumentValue, LocalToolCallArgument,
-    LocalToolExecutionStatusEvent, LocalToolExecutionStatusPhase, ReadyRequest, ReadyResponse,
-    ReadyState, current_protocol_version, validate_attach_request, validate_command_request,
+    CommandRequest, CommandResponse, LocalClientFrame, ReadyRequest, ReadyResponse, ReadyState,
+    current_protocol_version, validate_attach_request, validate_command_request,
     validate_ready_request,
 };
 use selvedge_router::{RouterHandle, RouterStartArgs, SpawnRouterError, ToolExecutionSpawner};
@@ -41,7 +30,7 @@ use selvedge_web::{
     WebBridge, WebHandle, WebLocalhostBind, WebLocalhostHost, WebStartArgs, WebStartError,
     spawn_web_surface,
 };
-use tokio::sync::{Mutex, Notify, RwLock, mpsc};
+use tokio::sync::{Mutex, Notify, RwLock};
 use tokio::task::JoinHandle;
 
 const SQLITE_FILE_NAME: &str = "selvedge.sqlite";
@@ -50,7 +39,6 @@ const DEFAULT_EVENTS_INGRESS_CAPACITY: usize = 64;
 const DEFAULT_CLIENT_REGISTRY_CAPACITY: usize = 64;
 const DEFAULT_HYDRATION_BUFFER_CAPACITY: usize = 256;
 const DEFAULT_CLIENT_SYNC_INGRESS_CAPACITY: usize = 64;
-const DEFAULT_ATTACH_FRAME_CAPACITY: usize = 64;
 
 pub struct ServerStartArgs {
     pub explicit_home: Option<PathBuf>,
@@ -213,7 +201,6 @@ impl ServerControl {
         request: AttachRequest,
     ) -> Result<(AttachAccepted, ServerFrameStream), AttachRejected> {
         let protocol_version = current_protocol_version();
-        let client_id = request.client_id.clone();
         let client_command_id = request.client_command_id.clone();
 
         let reject = |reason| {
@@ -240,30 +227,11 @@ impl ServerControl {
             return reject(CommandRejectReason::RouterMailboxClosed);
         }
 
-        let (outbound, inbound) = mpsc::channel(DEFAULT_ATTACH_FRAME_CAPACITY);
-        let hydration = BeginClientHydration {
-            client_id: ClientId(client_id.0.clone()),
-            client_command_id: ClientCommandId(client_command_id.0.clone()),
-            outbound,
-            subscription: local_subscription_to_command(&request.subscription),
-        };
-
-        let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
-        if client_sync_tx
-            .send(ClientSyncIngress::StartHydration(hydration))
-            .await
-            .is_err()
-        {
-            return reject(CommandRejectReason::InternalFailure);
-        }
-
-        let accepted = AttachAccepted {
-            protocol_version,
-            client_id,
-            client_command_id,
-        };
-        let stream = Box::pin(ServerMpscFrameStream { inbound });
-        Ok((accepted, stream))
+        // NOTE: Accepted attach streams require client-sync hydration to deliver
+        // the initial snapshot and event stream. The server stage only owns the
+        // lifecycle/control boundary, so a valid attach request is deferred with
+        // an explicit rejection until the client-sync package supplies hydration.
+        reject(CommandRejectReason::ServerNotReady)
     }
 
     pub async fn stop(&self) {
@@ -495,306 +463,6 @@ impl WebBridge for ServerWebBridge {
                 ),
             ))
         })
-    }
-}
-
-struct ServerMpscFrameStream {
-    inbound: mpsc::Receiver<ClientFrame>,
-}
-
-impl Stream for ServerMpscFrameStream {
-    type Item = Result<LocalClientFrame, ServerRequestError>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        match this.inbound.poll_recv(cx) {
-            Poll::Ready(Some(frame)) => Poll::Ready(Some(command_frame_to_local(frame))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-fn command_frame_to_local(frame: ClientFrame) -> Result<LocalClientFrame, ServerRequestError> {
-    match frame {
-        ClientFrame::Snapshot(frame) => Ok(LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
-            delivery_seq: frame.delivery_seq.0,
-            client_command_id: selvedge_local_protocol::LocalClientCommandId(
-                frame.client_command_id.0,
-            ),
-            snapshot: client_snapshot_to_local(frame.snapshot),
-        })),
-        ClientFrame::Event(frame) => Ok(LocalClientFrame::Event(
-            selvedge_local_protocol::LocalClientEventFrame {
-                delivery_seq: frame.delivery_seq.0,
-                event: client_event_to_local(frame.event),
-            },
-        )),
-        ClientFrame::Notice(frame) => Ok(LocalClientFrame::Notice(LocalClientNoticeFrame {
-            delivery_seq: frame.delivery_seq.0,
-            client_command_id: selvedge_local_protocol::LocalClientCommandId(
-                frame.client_command_id.0,
-            ),
-            notice: client_notice_to_local(frame.notice),
-        })),
-    }
-}
-
-fn client_snapshot_to_local(snapshot: ClientSnapshot) -> LocalClientSnapshot {
-    LocalClientSnapshot {
-        generated_at: snapshot.generated_at.0,
-        tasks: snapshot
-            .tasks
-            .into_iter()
-            .map(|task| LocalTaskProjection {
-                task_id: task.task_id.0,
-                status: match task.status {
-                    selvedge_command_model::TaskProjectionStatus::Active => {
-                        LocalTaskProjectionStatus::Active
-                    }
-                    selvedge_command_model::TaskProjectionStatus::Archived => {
-                        LocalTaskProjectionStatus::Archived
-                    }
-                },
-                cursor_node_id: task.cursor_node_id.0,
-                model_profile_key: task.model_profile_key.0,
-                reasoning_effort: reasoning_effort_to_local(task.reasoning_effort),
-                state_version: task.state_version,
-                created_at: task.created_at.0,
-                updated_at: task.updated_at.0,
-            })
-            .collect(),
-        task_parent_edges: snapshot
-            .task_parent_edges
-            .into_iter()
-            .map(|edge| LocalTaskParentProjection {
-                parent_task_id: edge.parent_task_id.0,
-                child_task_id: edge.child_task_id.0,
-            })
-            .collect(),
-        history_nodes: snapshot
-            .history_nodes
-            .into_iter()
-            .map(history_node_to_local)
-            .collect(),
-        task_versions: snapshot
-            .task_versions
-            .into_iter()
-            .map(|version| LocalSnapshotTaskVersion {
-                task_id: version.task_id.0,
-                state_version: version.state_version,
-            })
-            .collect(),
-    }
-}
-
-fn history_node_to_local(
-    node: selvedge_command_model::HistoryNodeProjection,
-) -> LocalHistoryNodeProjection {
-    LocalHistoryNodeProjection {
-        node_id: node.node_id.0,
-        parent_node_id: node.parent_node_id.map(|id| id.0),
-        created_at: node.created_at.0,
-        body: match node.body {
-            selvedge_command_model::HistoryNodeProjectionBody::Message { role, text } => {
-                LocalHistoryNodeProjectionBody::Message {
-                    role: message_role_to_local(role),
-                    text,
-                }
-            }
-            selvedge_command_model::HistoryNodeProjectionBody::Reasoning { text } => {
-                LocalHistoryNodeProjectionBody::Reasoning { text }
-            }
-            selvedge_command_model::HistoryNodeProjectionBody::FunctionCall {
-                function_call_id,
-                tool_name,
-                arguments,
-            } => LocalHistoryNodeProjectionBody::FunctionCall {
-                function_call_id: function_call_id.0,
-                tool_name: tool_name.0,
-                arguments: arguments
-                    .into_iter()
-                    .map(|argument| LocalToolCallArgument {
-                        name: argument.name.0,
-                        value: tool_argument_value_to_local(argument.value),
-                    })
-                    .collect(),
-            },
-            selvedge_command_model::HistoryNodeProjectionBody::FunctionOutput {
-                function_call_node_id,
-                function_call_id,
-                tool_name,
-                output_text,
-                is_error,
-            } => LocalHistoryNodeProjectionBody::FunctionOutput {
-                function_call_node_id: function_call_node_id.0,
-                function_call_id: function_call_id.0,
-                tool_name: tool_name.0,
-                output_text,
-                is_error,
-            },
-        },
-    }
-}
-
-fn client_event_to_local(event: ClientEvent) -> LocalClientEvent {
-    match event {
-        ClientEvent::TaskChanged(event) => {
-            LocalClientEvent::TaskChanged(selvedge_local_protocol::LocalTaskChangedEvent {
-                task: client_snapshot_to_local(ClientSnapshot {
-                    generated_at: selvedge_domain_model::UnixTs(0),
-                    tasks: vec![event.task],
-                    task_parent_edges: Vec::new(),
-                    history_nodes: Vec::new(),
-                    task_versions: Vec::new(),
-                })
-                .tasks
-                .remove(0),
-            })
-        }
-        ClientEvent::HistoryAppended(event) => {
-            LocalClientEvent::HistoryAppended(selvedge_local_protocol::LocalHistoryAppendedEvent {
-                task_id: event.task_id.0,
-                task_state_version: event.task_state_version,
-                appended_nodes: event
-                    .appended_nodes
-                    .into_iter()
-                    .map(history_node_to_local)
-                    .collect(),
-            })
-        }
-        ClientEvent::ModelCallStatus(event) => {
-            LocalClientEvent::ModelCallStatus(LocalModelCallStatusEvent {
-                task_id: event.task_id.0,
-                model_call_id: event.model_call_id.0,
-                phase: model_phase_to_local(event.phase),
-            })
-        }
-        ClientEvent::ToolExecutionStatus(event) => {
-            LocalClientEvent::ToolExecutionStatus(LocalToolExecutionStatusEvent {
-                task_id: event.task_id.0,
-                tool_execution_run_id: event.tool_execution_run_id.0,
-                function_call_node_id: event.function_call_node_id.0,
-                tool_name: event.tool_name.0,
-                phase: tool_phase_to_local(event.phase),
-            })
-        }
-        ClientEvent::DebugNotice(event) => {
-            LocalClientEvent::DebugNotice(selvedge_local_protocol::LocalDebugNoticeEvent {
-                task_id: event.task_id.map(|id| id.0),
-                message_text: event.message_text,
-            })
-        }
-    }
-}
-
-fn local_subscription_to_command(
-    subscription: &selvedge_local_protocol::LocalClientSubscription,
-) -> ClientSubscription {
-    ClientSubscription {
-        task_scope: match &subscription.task_scope {
-            LocalTaskScope::AllTasks => TaskScope::AllTasks,
-            LocalTaskScope::TaskIds(task_ids) => TaskScope::TaskIds(
-                task_ids
-                    .iter()
-                    .map(|task_id| selvedge_command_model::TaskId(task_id.clone()))
-                    .collect(),
-            ),
-        },
-        detail_level: match subscription.detail_level {
-            LocalDetailLevel::Summary => DetailLevel::Summary,
-            LocalDetailLevel::Verbose => DetailLevel::Verbose,
-        },
-        include_model_call_status: subscription.include_model_call_status,
-        include_tool_execution_status: subscription.include_tool_execution_status,
-        include_debug_notices: subscription.include_debug_notices,
-    }
-}
-
-fn client_notice_to_local(notice: ClientNotice) -> LocalNotice {
-    LocalNotice {
-        level: match notice.level {
-            ClientNoticeLevel::Info => LocalNoticeLevel::Info,
-            ClientNoticeLevel::Warning => LocalNoticeLevel::Warning,
-            ClientNoticeLevel::Error => LocalNoticeLevel::Error,
-        },
-        message_text: notice.message_text,
-    }
-}
-
-fn reasoning_effort_to_local(
-    effort: selvedge_domain_model::ReasoningEffort,
-) -> LocalReasoningEffort {
-    match effort {
-        selvedge_domain_model::ReasoningEffort::Minimal => LocalReasoningEffort::Minimal,
-        selvedge_domain_model::ReasoningEffort::Low => LocalReasoningEffort::Low,
-        selvedge_domain_model::ReasoningEffort::Medium => LocalReasoningEffort::Medium,
-        selvedge_domain_model::ReasoningEffort::High => LocalReasoningEffort::High,
-    }
-}
-
-fn message_role_to_local(role: selvedge_domain_model::MessageRole) -> LocalMessageRole {
-    match role {
-        selvedge_domain_model::MessageRole::System => LocalMessageRole::System,
-        selvedge_domain_model::MessageRole::Developer => LocalMessageRole::Developer,
-        selvedge_domain_model::MessageRole::User => LocalMessageRole::User,
-        selvedge_domain_model::MessageRole::Assistant => LocalMessageRole::Assistant,
-        selvedge_domain_model::MessageRole::Tool => LocalMessageRole::Tool,
-    }
-}
-
-fn tool_argument_value_to_local(
-    value: selvedge_domain_model::ToolArgumentValue,
-) -> LocalToolArgumentValue {
-    match value {
-        selvedge_domain_model::ToolArgumentValue::String(value) => {
-            LocalToolArgumentValue::String(value)
-        }
-        selvedge_domain_model::ToolArgumentValue::Integer(value) => {
-            LocalToolArgumentValue::Integer(value)
-        }
-        selvedge_domain_model::ToolArgumentValue::Number(value) => {
-            LocalToolArgumentValue::Number(value)
-        }
-        selvedge_domain_model::ToolArgumentValue::Boolean(value) => {
-            LocalToolArgumentValue::Boolean(value)
-        }
-    }
-}
-
-fn model_phase_to_local(
-    phase: selvedge_command_model::ModelCallStatusPhase,
-) -> LocalModelCallStatusPhase {
-    match phase {
-        selvedge_command_model::ModelCallStatusPhase::Requested => {
-            LocalModelCallStatusPhase::Requested
-        }
-        selvedge_command_model::ModelCallStatusPhase::Completed => {
-            LocalModelCallStatusPhase::Completed
-        }
-        selvedge_command_model::ModelCallStatusPhase::Failed => LocalModelCallStatusPhase::Failed,
-        selvedge_command_model::ModelCallStatusPhase::Discarded => {
-            LocalModelCallStatusPhase::Discarded
-        }
-    }
-}
-
-fn tool_phase_to_local(
-    phase: selvedge_command_model::ToolExecutionStatusPhase,
-) -> LocalToolExecutionStatusPhase {
-    match phase {
-        selvedge_command_model::ToolExecutionStatusPhase::Requested => {
-            LocalToolExecutionStatusPhase::Requested
-        }
-        selvedge_command_model::ToolExecutionStatusPhase::Completed => {
-            LocalToolExecutionStatusPhase::Completed
-        }
-        selvedge_command_model::ToolExecutionStatusPhase::Failed => {
-            LocalToolExecutionStatusPhase::Failed
-        }
-        selvedge_command_model::ToolExecutionStatusPhase::Discarded => {
-            LocalToolExecutionStatusPhase::Discarded
-        }
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,8 +5,8 @@ use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
 use std::task::{Context, Poll};
 
 use fs2::FileExt;
@@ -326,13 +326,7 @@ impl ServerControl {
         let _ = self.inner.router_tx.send(RouterIngressMessage::StopRouter);
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
         let _ = client_sync_tx.send(ClientSyncIngress::Shutdown).await;
-        let web_control = self
-            .inner
-            .web_control
-            .lock()
-            .expect("web control lock")
-            .clone();
-        if let Some(web_control) = web_control {
+        if let Some(web_control) = self.inner.web_control.lock().await.as_ref() {
             web_control.stop().await;
         }
         self.inner.stop_notify.notify_waiters();
@@ -353,7 +347,7 @@ struct ServerInner {
     router_tx: RouterIngressSender,
     client_sync_tx: Mutex<selvedge_client_sync::ClientSyncSender>,
     command_mapper: Arc<dyn LocalCommandMapper>,
-    web_control: StdMutex<Option<selvedge_web::WebControl>>,
+    web_control: Mutex<Option<selvedge_web::WebControl>>,
 }
 
 impl ServerContext {
@@ -400,6 +394,8 @@ fn start_server_after_lock(
     })
     .map_err(map_router_start_error)?;
 
+    let web = start_web(args.web_binding, &args.command_mapper)?;
+
     let inner = Arc::new(ServerInner {
         state: RwLock::new(ServerRuntimeState::Ready),
         closing: AtomicBool::new(false),
@@ -409,15 +405,8 @@ fn start_server_after_lock(
         router_tx: router.ingress_tx.clone(),
         client_sync_tx: Mutex::new(client_sync.ingress_tx.clone()),
         command_mapper: args.command_mapper,
-        web_control: StdMutex::new(None),
+        web_control: Mutex::new(web.as_ref().map(|handle| handle.control.clone())),
     });
-    let control = ServerControl {
-        inner: inner.clone(),
-    };
-    let web = start_web(args.web_binding, control)?;
-    if let Some(web_handle) = &web {
-        *inner.web_control.lock().expect("web control lock") = Some(web_handle.control.clone());
-    }
     let join_handle = spawn_server_join_task(inner.clone(), router, events, client_sync, web);
 
     Ok(ServerContext { inner, join_handle })
@@ -456,88 +445,56 @@ fn spawn_server_join_task(
 
 fn start_web(
     web_binding: Option<WebBindingConfig>,
-    control: ServerControl,
+    bridge: &Arc<dyn LocalCommandMapper>,
 ) -> Result<Option<WebHandle>, ServerStartupError> {
     let Some(web_binding) = web_binding else {
         return Ok(None);
     };
 
     let bind = local_bind_to_web_bind(web_binding.bind_target)?;
-    let bridge = Arc::new(ServerWebBridge { control });
+    let bridge = Arc::new(ServerWebBridge {
+        _command_mapper: Arc::clone(bridge),
+    });
     spawn_web_surface(WebStartArgs { bind, bridge })
         .map(Some)
         .map_err(map_web_start_error)
 }
 
 struct ServerWebBridge {
-    control: ServerControl,
+    _command_mapper: Arc<dyn LocalCommandMapper>,
 }
 
 impl WebBridge for ServerWebBridge {
-    fn ready(&self, request: ReadyRequest) -> selvedge_web::WebBridgeFuture<ReadyResponse> {
-        let control = self.control.clone();
-        Box::pin(async move { Ok(control.ready(request).await) })
+    fn ready(&self, _request: ReadyRequest) -> selvedge_web::WebBridgeFuture<ReadyResponse> {
+        Box::pin(async {
+            Ok(ReadyResponse {
+                protocol_version: current_protocol_version(),
+                state: ReadyState::Ready,
+            })
+        })
     }
 
     fn submit_command(
         &self,
         request: CommandRequest,
     ) -> selvedge_web::WebBridgeFuture<CommandResponse> {
-        let control = self.control.clone();
-        Box::pin(async move { Ok(control.submit_command(request).await) })
-    }
-
-    fn attach(&self, request: AttachRequest) -> selvedge_web::WebAttachFuture {
-        let control = self.control.clone();
         Box::pin(async move {
-            match control.attach_client(request).await {
-                Ok((accepted, stream)) => Ok((
-                    accepted,
-                    Box::pin(WebServerFrameStream { inner: stream })
-                        as selvedge_web::WebFrameStream,
-                )),
-                Err(rejected) => Err(selvedge_web::AttachRejectedOrBridgeError::Rejected(
-                    rejected,
-                )),
-            }
+            Ok(CommandResponse {
+                protocol_version: current_protocol_version(),
+                client_command_id: request.client_command_id,
+                outcome: CommandOutcome::Rejected(CommandRejectReason::InternalFailure),
+            })
         })
     }
-}
 
-struct WebServerFrameStream {
-    inner: ServerFrameStream,
-}
-
-impl Stream for WebServerFrameStream {
-    type Item = Result<LocalClientFrame, selvedge_web::WebBridgeError>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        match this.inner.as_mut().poll_next(cx) {
-            Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
-            Poll::Ready(Some(Err(error))) => {
-                Poll::Ready(Some(Err(server_request_error_to_web_bridge(error))))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-fn server_request_error_to_web_bridge(error: ServerRequestError) -> selvedge_web::WebBridgeError {
-    match error {
-        ServerRequestError::NotReady => selvedge_web::WebBridgeError::ServerNotReady,
-        ServerRequestError::ProtocolValidationFailed => {
-            selvedge_web::WebBridgeError::ProtocolValidationFailed
-        }
-        ServerRequestError::UnsupportedCommand => {
-            selvedge_web::WebBridgeError::CommandRejected("unsupported command".to_owned())
-        }
-        ServerRequestError::RouterMailboxClosed => selvedge_web::WebBridgeError::StreamClosed,
-        ServerRequestError::AttachChannelFailed => selvedge_web::WebBridgeError::StreamClosed,
-        ServerRequestError::InternalFailure(message) => {
-            selvedge_web::WebBridgeError::InternalFailure(message)
-        }
+    fn attach(&self, _request: AttachRequest) -> selvedge_web::WebAttachFuture {
+        Box::pin(async {
+            Err(selvedge_web::AttachRejectedOrBridgeError::Bridge(
+                selvedge_web::WebBridgeError::InternalFailure(
+                    "server web bridge is owned by the server runtime".to_owned(),
+                ),
+            ))
+        })
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -161,6 +161,7 @@ pub fn spawn_server(args: ServerStartArgs) -> Result<ServerHandle, ServerStartup
         validate_bind_target(&web_binding.bind_target)?;
     }
 
+    init_config(args.explicit_home.as_ref())?;
     let home = resolve_home(args.explicit_home.clone())?;
     let singleton_lock = acquire_singleton_lock(&home)?;
 
@@ -228,6 +229,9 @@ impl ServerControl {
         }
 
         if validate_attach_request(&request).is_err() {
+            if request.protocol_version != current_protocol_version() {
+                return reject(CommandRejectReason::ProtocolVersionMismatch);
+            }
             return reject(CommandRejectReason::MalformedRequest);
         }
 
@@ -360,7 +364,6 @@ fn start_server_after_lock(
     home: PathBuf,
     singleton_lock: File,
 ) -> Result<ServerContext, ServerStartupError> {
-    init_config(args.explicit_home.as_ref())?;
     init_logging()?;
 
     let db = open_db(OpenDbOptions {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::task::{Context, Poll};
 
+use fs2::FileExt;
 use futures_core::Stream;
 use selvedge_api::ApiExecutorConfig;
 use selvedge_client_sync::{
@@ -915,14 +916,19 @@ fn acquire_singleton_lock(home: &Path) -> Result<File, ServerStartupError> {
     })?;
 
     match OpenOptions::new()
-        .create_new(true)
+        .create(true)
+        .truncate(false)
         .write(true)
+        .read(true)
         .open(lock_path_for_home(home))
     {
-        Ok(file) => Ok(file),
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            Err(ServerStartupError::SingletonAlreadyRunning)
-        }
+        Ok(file) => match file.try_lock_exclusive() {
+            Ok(()) => Ok(file),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                Err(ServerStartupError::SingletonAlreadyRunning)
+            }
+            Err(error) => Err(ServerStartupError::ConfigInitFailed(error.to_string())),
+        },
         Err(error) => Err(ServerStartupError::ConfigInitFailed(error.to_string())),
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -282,13 +282,15 @@ impl ServerControl {
         };
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
 
-        if client_sync_tx
-            .send(ClientSyncIngress::StartHydration(begin))
-            .await
-            .is_err()
-        {
-            self.begin_shutdown_locked().await;
-            return reject(AttachRejectReason::ClientSyncUnavailable);
+        match client_sync_tx.try_send(ClientSyncIngress::StartHydration(begin)) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                return reject(AttachRejectReason::ClientSyncUnavailable);
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                self.begin_shutdown_locked().await;
+                return reject(AttachRejectReason::ClientSyncUnavailable);
+            }
         }
 
         if let Some(previous_command_id) = reservation.previous_attach() {
@@ -660,8 +662,6 @@ impl Drop for ServerAttachFrameStream {
         let client_id = self.client_id.clone();
         let client_command_id = self.client_command_id.clone();
 
-        clear_active_attach(&self.active_attaches, &client_id, &client_command_id);
-
         if let Some(client_sync_tx) = self.client_sync_tx.upgrade() {
             send_cancel_hydration(
                 &client_sync_tx,
@@ -671,13 +671,15 @@ impl Drop for ServerAttachFrameStream {
         }
 
         let Some(events_tx) = self.events_tx.upgrade() else {
+            clear_active_attach(&self.active_attaches, &client_id, &client_command_id);
             return;
         };
-        send_detach_client(
+        send_detach_client_and_clear_active(
             &events_tx,
             client_id,
             client_command_id,
             DetachReason::ClientDisconnected,
+            Arc::clone(&self.active_attaches),
         );
     }
 }
@@ -729,6 +731,35 @@ fn send_detach_client(
             }
         }
         Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+    }
+}
+
+fn send_detach_client_and_clear_active(
+    events_tx: &EventIngressSender,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+    reason: DetachReason,
+    active_attaches: ActiveAttachRegistry,
+) {
+    let retry_events_tx = events_tx.clone();
+    let detach = EventIngress::Control(EventControlMessage::DetachClient(DetachClient {
+        client_id: client_id.clone(),
+        client_command_id: client_command_id.clone(),
+        reason,
+    }));
+
+    match events_tx.try_send(detach) {
+        Ok(()) | Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            clear_active_attach(&active_attaches, &client_id, &client_command_id);
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Full(detach)) => {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = retry_events_tx.send(detach).await;
+                    clear_active_attach(&active_attaches, &client_id, &client_command_id);
+                });
+            }
+        }
     }
 }
 
@@ -1416,7 +1447,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancelled_attach_future_restores_reserved_attach_slot() {
+    async fn backpressured_client_sync_rejects_and_restores_attach_slot() {
         let (router_tx, _router_rx) = mpsc::unbounded_channel();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(1);
         client_sync_tx
@@ -1425,28 +1456,12 @@ mod tests {
             .expect("fill client-sync mailbox");
         let (events_tx, _events_rx) = mpsc::channel(4);
         let control = test_control(router_tx, client_sync_tx, events_tx);
-        let task_control = control.clone();
-        let attach_task =
-            tokio::spawn(async move { task_control.attach_client(test_attach_request()).await });
 
-        timeout(Duration::from_millis(100), async {
-            loop {
-                if !control
-                    .inner
-                    .active_attaches
-                    .lock()
-                    .expect("active attach registry")
-                    .is_empty()
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("attach reservation appears");
-        attach_task.abort();
-        let _ = attach_task.await;
+        let rejected = match control.attach_client(test_attach_request()).await {
+            Ok(_) => panic!("backpressured client-sync should reject"),
+            Err(rejected) => rejected,
+        };
+        assert_eq!(rejected.reason, AttachRejectReason::ClientSyncUnavailable);
         let _ = client_sync_rx.recv().await.expect("drain filled mailbox");
 
         let (_accepted, _stream) = control
@@ -1513,6 +1528,78 @@ mod tests {
             }
             _ => panic!("unexpected events ingress"),
         }
+    }
+
+    #[tokio::test]
+    async fn full_events_mailbox_delays_active_attach_release_until_detach_is_queued() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
+        let (events_tx, mut events_rx) = mpsc::channel(1);
+        events_tx
+            .try_send(EventIngress::Control(EventControlMessage::DetachClient(
+                DetachClient {
+                    client_id: ClientId("occupied-client".to_owned()),
+                    client_command_id: ClientCommandId("occupied-attach".to_owned()),
+                    reason: DetachReason::ClientRequested,
+                },
+            )))
+            .expect("fill events mailbox");
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let (_accepted, stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("attach accepted");
+        let _ = timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("start hydration arrives")
+            .expect("start hydration");
+        drop(stream);
+
+        let rejected = match control.attach_client(test_attach_request()).await {
+            Ok(_) => panic!("attach should remain active until detach is queued"),
+            Err(rejected) => rejected,
+        };
+        assert_eq!(rejected.reason, AttachRejectReason::DuplicateAttach);
+
+        let _ = events_rx.recv().await.expect("drain occupied events slot");
+        match timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("client detach arrives")
+            .expect("client detach")
+        {
+            EventIngress::Control(EventControlMessage::DetachClient(detach)) => {
+                assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    detach.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+                assert_eq!(detach.reason, DetachReason::ClientDisconnected);
+            }
+            _ => panic!("unexpected events ingress"),
+        }
+
+        timeout(Duration::from_millis(100), async {
+            loop {
+                if control
+                    .inner
+                    .active_attaches
+                    .lock()
+                    .expect("active attach registry")
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("active attach clears after detach is queued");
+
+        let (_accepted, _stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("attach accepted after detach queued");
     }
 
     fn test_control(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -13,8 +13,8 @@ use fs2::FileExt;
 use futures_core::Stream;
 use selvedge_api::ApiExecutorConfig;
 use selvedge_client_sync::{
-    ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress, ClientSyncStartArgs,
-    SpawnClientSyncError, spawn_client_sync,
+    CancelHydration, ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress,
+    ClientSyncStartArgs, SpawnClientSyncError, spawn_client_sync,
 };
 use selvedge_command_model::{
     BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
@@ -31,10 +31,10 @@ use selvedge_domain_model::{
 };
 use selvedge_events::{EventsHandle, EventsStartArgs, SpawnEventsError, spawn_events_task};
 use selvedge_local_protocol::{
-    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
-    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientEvent, LocalClientEventFrame,
-    LocalClientFrame, LocalClientSnapshot, LocalClientSnapshotFrame, LocalDebugNoticeEvent,
-    LocalDetailLevel, LocalHistoryAppendedEvent, LocalHistoryNodeProjection,
+    AttachAccepted, AttachRejectReason, AttachRejected, AttachRequest, CommandOutcome,
+    CommandRejectReason, CommandRequest, CommandResponse, LocalClientCommandId, LocalClientEvent,
+    LocalClientEventFrame, LocalClientFrame, LocalClientSnapshot, LocalClientSnapshotFrame,
+    LocalDebugNoticeEvent, LocalDetailLevel, LocalHistoryAppendedEvent, LocalHistoryNodeProjection,
     LocalHistoryNodeProjectionBody, LocalMessageRole, LocalModelCallStatusEvent,
     LocalModelCallStatusPhase, LocalNotice, LocalNoticeLevel, LocalReasoningEffort,
     LocalSnapshotTaskVersion, LocalTaskChangedEvent, LocalTaskParentProjection,
@@ -236,19 +236,19 @@ impl ServerControl {
         };
 
         if *self.inner.state.read().await != ServerRuntimeState::Ready {
-            return reject(CommandRejectReason::ServerNotReady);
+            return reject(AttachRejectReason::ServerNotReady);
         }
 
         if validate_attach_request(&request).is_err() {
             if request.protocol_version != current_protocol_version() {
-                return reject(CommandRejectReason::ProtocolVersionMismatch);
+                return reject(AttachRejectReason::ProtocolVersionMismatch);
             }
-            return reject(CommandRejectReason::MalformedRequest);
+            return reject(AttachRejectReason::MalformedRequest);
         }
 
         if self.inner.router_tx.is_closed() {
             self.begin_shutdown_locked().await;
-            return reject(CommandRejectReason::RouterMailboxClosed);
+            return reject(AttachRejectReason::RouterMailboxClosed);
         }
 
         let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
@@ -261,7 +261,7 @@ impl ServerControl {
             subscription: local_subscription_to_command(request.subscription),
         };
         let Some(events_tx) = self.inner.events_tx.lock().await.as_ref().cloned() else {
-            return reject(CommandRejectReason::InternalFailure);
+            return reject(AttachRejectReason::InternalFailure);
         };
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
 
@@ -271,7 +271,7 @@ impl ServerControl {
             .is_err()
         {
             self.begin_shutdown_locked().await;
-            return reject(CommandRejectReason::InternalFailure);
+            return reject(AttachRejectReason::ClientSyncUnavailable);
         }
 
         Ok((
@@ -285,6 +285,7 @@ impl ServerControl {
                 client_id,
                 client_command_id,
                 events_tx: events_tx.downgrade(),
+                client_sync_tx: client_sync_tx.downgrade(),
                 closed_reported: false,
             }),
         ))
@@ -520,6 +521,7 @@ struct ServerAttachFrameStream {
     // NOTE: Weak sender lets server shutdown close events while callers still hold frame streams;
     // Drop upgrades it only to report client detach.
     events_tx: mpsc::WeakSender<EventIngress>,
+    client_sync_tx: mpsc::WeakSender<ClientSyncIngress>,
     closed_reported: bool,
 }
 
@@ -544,27 +546,49 @@ impl futures_core::Stream for ServerAttachFrameStream {
 
 impl Drop for ServerAttachFrameStream {
     fn drop(&mut self) {
+        let client_id = self.client_id.clone();
+        let client_command_id = self.client_command_id.clone();
+
+        if let Some(client_sync_tx) = self.client_sync_tx.upgrade() {
+            let retry_client_sync_tx = client_sync_tx.clone();
+            let cancel = ClientSyncIngress::CancelHydration(CancelHydration {
+                client_id: client_id.clone(),
+                client_command_id: client_command_id.clone(),
+            });
+
+            match client_sync_tx.try_send(cancel) {
+                Ok(()) => {}
+                Err(tokio::sync::mpsc::error::TrySendError::Full(cancel)) => {
+                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                        handle.spawn(async move {
+                            let _ = retry_client_sync_tx.send(cancel).await;
+                        });
+                    }
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+            }
+        }
+
         let Some(events_tx) = self.events_tx.upgrade() else {
             return;
         };
         let retry_events_tx = events_tx.clone();
-        let client_id = self.client_id.clone();
-        let client_command_id = self.client_command_id.clone();
         let detach = EventIngress::Control(EventControlMessage::DetachClient(DetachClient {
             client_id,
             client_command_id,
-            reason: DetachReason::ClientRequested,
+            reason: DetachReason::ClientDisconnected,
         }));
 
         match events_tx.try_send(detach) {
             Ok(()) => {}
-            Err(error) => {
+            Err(tokio::sync::mpsc::error::TrySendError::Full(detach)) => {
                 if let Ok(handle) = tokio::runtime::Handle::try_current() {
                     handle.spawn(async move {
-                        let _ = retry_events_tx.send(error.into_inner()).await;
+                        let _ = retry_events_tx.send(detach).await;
                     });
                 }
             }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
         }
     }
 }
@@ -1045,7 +1069,7 @@ mod tests {
             Err(rejected) => rejected,
         };
 
-        assert_eq!(rejected.reason, CommandRejectReason::RouterMailboxClosed);
+        assert_eq!(rejected.reason, AttachRejectReason::RouterMailboxClosed);
         assert_eq!(control.state().await, ServerRuntimeState::Closing);
     }
 
@@ -1068,8 +1092,68 @@ mod tests {
             Err(rejected) => rejected,
         };
 
-        assert_eq!(rejected.reason, CommandRejectReason::InternalFailure);
+        assert_eq!(rejected.reason, AttachRejectReason::ClientSyncUnavailable);
         assert_eq!(control.state().await, ServerRuntimeState::Closing);
+    }
+
+    #[tokio::test]
+    async fn dropped_attach_stream_sends_cancel_and_client_disconnect_detach() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
+        let (events_tx, mut events_rx) = mpsc::channel(4);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let (_accepted, stream) = control
+            .attach_client(test_attach_request())
+            .await
+            .expect("attach accepted");
+        match timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("start hydration arrives")
+            .expect("start hydration")
+        {
+            ClientSyncIngress::StartHydration(begin) => {
+                assert_eq!(begin.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    begin.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+            }
+            _ => panic!("unexpected client-sync ingress"),
+        }
+
+        drop(stream);
+
+        match timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("cancel hydration arrives")
+            .expect("cancel hydration")
+        {
+            ClientSyncIngress::CancelHydration(cancel) => {
+                assert_eq!(cancel.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    cancel.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+            }
+            _ => panic!("unexpected client-sync ingress"),
+        }
+
+        match timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("detach arrives")
+            .expect("detach")
+        {
+            EventIngress::Control(EventControlMessage::DetachClient(detach)) => {
+                assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    detach.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+                assert_eq!(detach.reason, DetachReason::ClientDisconnected);
+            }
+            _ => panic!("unexpected events ingress"),
+        }
     }
 
     fn test_control(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -14,8 +14,8 @@ use fs2::FileExt;
 use futures_core::Stream;
 use selvedge_api::ApiExecutorConfig;
 use selvedge_client_sync::{
-    CancelHydration, ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress,
-    ClientSyncStartArgs, SpawnClientSyncError, spawn_client_sync,
+    CancelHydration, ClientSnapshotBuilder, ClientSyncExitStatus, ClientSyncHandle,
+    ClientSyncIngress, ClientSyncStartArgs, SpawnClientSyncError, spawn_client_sync,
 };
 use selvedge_command_model::{
     BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientFrameSender, ClientId,
@@ -45,13 +45,15 @@ use selvedge_local_protocol::{
     ReadyRequest, ReadyResponse, ReadyState, current_protocol_version, validate_attach_request,
     validate_command_request, validate_ready_request,
 };
-use selvedge_router::{RouterHandle, RouterStartArgs, SpawnRouterError, ToolExecutionSpawner};
+use selvedge_router::{
+    RouterExitStatus, RouterHandle, RouterStartArgs, SpawnRouterError, ToolExecutionSpawner,
+};
 use selvedge_web::{
     ReservedWebStartArgs, WebBindReservation, WebBridge, WebHandle, WebLocalhostBind,
     WebLocalhostHost, WebStartError, reserve_web_bind, spawn_reserved_web_surface,
 };
 use tokio::sync::{Mutex, Notify, RwLock, mpsc};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinError, JoinHandle};
 
 const SQLITE_FILE_NAME: &str = "selvedge.sqlite";
 const LOCK_FILE_NAME: &str = "server.lock";
@@ -462,7 +464,13 @@ impl ServerControl {
         let _ = self.inner.router_tx.send(RouterIngressMessage::StopRouter);
         let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
         let _ = client_sync_tx.send(ClientSyncIngress::Shutdown).await;
-        if let Some(web_control) = self.inner.web_control.lock().await.as_ref() {
+        let web_control = self
+            .inner
+            .web_control
+            .lock()
+            .expect("server web control lock")
+            .clone();
+        if let Some(web_control) = web_control {
             web_control.stop().await;
         }
         let _ = self.inner.events_tx.lock().await.take();
@@ -488,7 +496,7 @@ struct ServerInner {
     active_attaches: ActiveAttachRegistry,
     frame_channel_factory: Arc<dyn AttachFrameChannelFactory>,
     command_mapper: Arc<dyn LocalCommandMapper>,
-    web_control: Mutex<Option<selvedge_web::WebControl>>,
+    web_control: StdMutex<Option<selvedge_web::WebControl>>,
 }
 
 impl ServerInner {
@@ -677,14 +685,6 @@ fn start_server_after_lock(
         }
     };
 
-    let web = match start_web(web_bind, &args.command_mapper) {
-        Ok(web) => web,
-        Err(error) => {
-            cleanup_startup_lock(&home);
-            return Err(error);
-        }
-    };
-
     let inner = Arc::new(ServerInner {
         state: RwLock::new(ServerRuntimeState::Ready),
         closing: AtomicBool::new(false),
@@ -698,8 +698,22 @@ fn start_server_after_lock(
         active_attaches: Arc::new(StdMutex::new(HashMap::new())),
         frame_channel_factory: Arc::new(TokioAttachFrameChannelFactory),
         command_mapper: args.command_mapper,
-        web_control: Mutex::new(web.as_ref().map(|handle| handle.control.clone())),
+        web_control: StdMutex::new(None),
     });
+    let web = match start_web(
+        web_bind,
+        ServerControl {
+            inner: inner.clone(),
+        },
+    ) {
+        Ok(web) => web,
+        Err(error) => {
+            cleanup_startup_lock(&home);
+            return Err(error);
+        }
+    };
+    *inner.web_control.lock().expect("server web control lock") =
+        web.as_ref().map(|handle| handle.control.clone());
     let join_handle = spawn_server_join_task(inner.clone(), router, events, client_sync, web);
 
     Ok(ServerContext { inner, join_handle })
@@ -717,27 +731,227 @@ fn spawn_server_join_task(
     web: Option<WebHandle>,
 ) -> JoinHandle<ServerExitStatus> {
     tokio::spawn(async move {
-        loop {
-            if inner.closing.load(Ordering::SeqCst) {
-                break;
-            }
-            let notified = inner.stop_notify.notified();
-            if inner.closing.load(Ordering::SeqCst) {
-                break;
-            }
-            notified.await;
+        let router_tx = router.ingress_tx;
+        let mut router_join = Some(router.join_handle);
+        let mut events_join = Some(events.join_handle);
+        let mut client_sync_join = Some(client_sync.join_handle);
+        let client_sync_tx = client_sync.ingress_tx;
+        let (web_control, mut web_join) = web
+            .map(|handle| (Some(handle.control), Some(handle.join_handle)))
+            .unwrap_or((None, None));
+
+        let first_worker_exit = tokio::select! {
+            _ = wait_for_server_stop(inner.clone()) => None,
+            result = wait_for_join(&mut router_join) => {
+                router_join = None;
+                Some(ServerWorkerExit::Router(result))
+            },
+            result = wait_for_join(&mut events_join) => {
+                events_join = None;
+                Some(ServerWorkerExit::Events(result))
+            },
+            result = wait_for_join(&mut client_sync_join) => {
+                client_sync_join = None;
+                Some(ServerWorkerExit::ClientSync(result))
+            },
+            result = wait_for_join(&mut web_join) => {
+                web_join = None;
+                Some(ServerWorkerExit::Web(result))
+            },
+        };
+
+        let first_worker_expected_shutdown = inner.closing.load(Ordering::SeqCst);
+        if first_worker_exit.is_some() && !first_worker_expected_shutdown {
+            begin_supervised_shutdown(&inner, &router_tx, &client_sync_tx, web_control.as_ref())
+                .await;
         }
-        let _ = router.join_handle.await;
-        drop(events.ingress_tx);
-        let _ = events.join_handle.await;
-        let _ = client_sync.join_handle.await;
-        if let Some(web) = web {
-            let _ = web.join_handle.await;
-        }
+
+        let status = collect_server_exit_status(
+            first_worker_exit,
+            first_worker_expected_shutdown,
+            router_join,
+            events_join,
+            client_sync_join,
+            web_join,
+            events.ingress_tx,
+        )
+        .await;
+
         let _ = std::fs::remove_file(&inner.lock_path);
-        *inner.state.write().await = ServerRuntimeState::Stopped;
-        ServerExitStatus::Stopped
+        *inner.state.write().await = match status {
+            ServerExitStatus::Stopped => ServerRuntimeState::Stopped,
+            ServerExitStatus::StartupFailed(_)
+            | ServerExitStatus::RouterStopped
+            | ServerExitStatus::Fatal(_) => ServerRuntimeState::Failed,
+        };
+        status
     })
+}
+
+enum ServerWorkerExit {
+    Router(Result<RouterExitStatus, JoinError>),
+    Events(Result<(), JoinError>),
+    ClientSync(Result<ClientSyncExitStatus, JoinError>),
+    Web(Result<selvedge_web::WebExitStatus, JoinError>),
+}
+
+async fn wait_for_server_stop(inner: Arc<ServerInner>) {
+    loop {
+        if inner.closing.load(Ordering::SeqCst) {
+            break;
+        }
+        let notified = inner.stop_notify.notified();
+        if inner.closing.load(Ordering::SeqCst) {
+            break;
+        }
+        notified.await;
+    }
+}
+
+async fn wait_for_join<T>(join_handle: &mut Option<JoinHandle<T>>) -> Result<T, JoinError> {
+    match join_handle.as_mut() {
+        Some(join_handle) => join_handle.await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn begin_supervised_shutdown(
+    inner: &ServerInner,
+    router_tx: &RouterIngressSender,
+    client_sync_tx: &selvedge_client_sync::ClientSyncSender,
+    web_control: Option<&selvedge_web::WebControl>,
+) {
+    if inner.closing.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    *inner.state.write().await = ServerRuntimeState::Closing;
+    let _ = router_tx.send(RouterIngressMessage::StopRouter);
+    let _ = client_sync_tx.send(ClientSyncIngress::Shutdown).await;
+    if let Some(web_control) = web_control {
+        web_control.stop().await;
+    }
+    let _ = inner.events_tx.lock().await.take();
+    inner.stop_notify.notify_waiters();
+}
+
+async fn collect_server_exit_status(
+    first_worker_exit: Option<ServerWorkerExit>,
+    first_worker_expected_shutdown: bool,
+    router_join: Option<JoinHandle<RouterExitStatus>>,
+    events_join: Option<JoinHandle<()>>,
+    client_sync_join: Option<JoinHandle<ClientSyncExitStatus>>,
+    web_join: Option<JoinHandle<selvedge_web::WebExitStatus>>,
+    events_tx: EventIngressSender,
+) -> ServerExitStatus {
+    let mut status = first_worker_exit
+        .map(|exit| server_worker_exit_status(exit, first_worker_expected_shutdown))
+        .unwrap_or(ServerExitStatus::Stopped);
+
+    let router_status = match router_join {
+        Some(join_handle) => router_join_status(join_handle.await, true),
+        None => ServerExitStatus::Stopped,
+    };
+    status = merge_server_exit_status(status, router_status);
+
+    drop(events_tx);
+
+    let events_status = match events_join {
+        Some(join_handle) => events_join_status(join_handle.await, true),
+        None => ServerExitStatus::Stopped,
+    };
+    status = merge_server_exit_status(status, events_status);
+
+    let client_sync_status = match client_sync_join {
+        Some(join_handle) => client_sync_join_status(join_handle.await, true),
+        None => ServerExitStatus::Stopped,
+    };
+    status = merge_server_exit_status(status, client_sync_status);
+
+    let web_status = match web_join {
+        Some(join_handle) => web_join_status(join_handle.await, true),
+        None => ServerExitStatus::Stopped,
+    };
+    merge_server_exit_status(status, web_status)
+}
+
+fn server_worker_exit_status(exit: ServerWorkerExit, expected_shutdown: bool) -> ServerExitStatus {
+    match exit {
+        ServerWorkerExit::Router(result) => router_join_status(result, expected_shutdown),
+        ServerWorkerExit::Events(result) => events_join_status(result, expected_shutdown),
+        ServerWorkerExit::ClientSync(result) => client_sync_join_status(result, expected_shutdown),
+        ServerWorkerExit::Web(result) => web_join_status(result, expected_shutdown),
+    }
+}
+
+fn router_join_status(
+    result: Result<RouterExitStatus, JoinError>,
+    expected_shutdown: bool,
+) -> ServerExitStatus {
+    match result {
+        Ok(RouterExitStatus::Stopped) if expected_shutdown => ServerExitStatus::Stopped,
+        Ok(RouterExitStatus::Stopped | RouterExitStatus::RouterMailboxClosed) => {
+            ServerExitStatus::RouterStopped
+        }
+        Ok(RouterExitStatus::EventsMailboxClosed) => {
+            ServerExitStatus::Fatal("router events mailbox closed".to_owned())
+        }
+        Ok(RouterExitStatus::FatalError(message)) => ServerExitStatus::Fatal(message),
+        Err(error) => ServerExitStatus::Fatal(format!("router task join failed: {error}")),
+    }
+}
+
+fn events_join_status(result: Result<(), JoinError>, expected_shutdown: bool) -> ServerExitStatus {
+    match result {
+        Ok(()) if expected_shutdown => ServerExitStatus::Stopped,
+        Ok(()) => ServerExitStatus::Fatal("events task exited unexpectedly".to_owned()),
+        Err(error) => ServerExitStatus::Fatal(format!("events task join failed: {error}")),
+    }
+}
+
+fn client_sync_join_status(
+    result: Result<ClientSyncExitStatus, JoinError>,
+    expected_shutdown: bool,
+) -> ServerExitStatus {
+    match result {
+        Ok(ClientSyncExitStatus::Stopped) if expected_shutdown => ServerExitStatus::Stopped,
+        Ok(ClientSyncExitStatus::Stopped) => {
+            ServerExitStatus::Fatal("client-sync task exited unexpectedly".to_owned())
+        }
+        Ok(ClientSyncExitStatus::IngressClosed) => {
+            ServerExitStatus::Fatal("client-sync ingress closed".to_owned())
+        }
+        Ok(ClientSyncExitStatus::Fatal(message)) => ServerExitStatus::Fatal(message),
+        Err(error) => ServerExitStatus::Fatal(format!("client-sync task join failed: {error}")),
+    }
+}
+
+fn web_join_status(
+    result: Result<selvedge_web::WebExitStatus, JoinError>,
+    expected_shutdown: bool,
+) -> ServerExitStatus {
+    match result {
+        Ok(selvedge_web::WebExitStatus::Stopped) if expected_shutdown => ServerExitStatus::Stopped,
+        Ok(selvedge_web::WebExitStatus::Stopped) => {
+            ServerExitStatus::Fatal("web task exited unexpectedly".to_owned())
+        }
+        Ok(selvedge_web::WebExitStatus::Fatal(message)) => ServerExitStatus::Fatal(message),
+        Err(error) => ServerExitStatus::Fatal(format!("web task join failed: {error}")),
+    }
+}
+
+fn merge_server_exit_status(current: ServerExitStatus, next: ServerExitStatus) -> ServerExitStatus {
+    match (current, next) {
+        (ServerExitStatus::Fatal(message), _) | (_, ServerExitStatus::Fatal(message)) => {
+            ServerExitStatus::Fatal(message)
+        }
+        (ServerExitStatus::RouterStopped, _) | (_, ServerExitStatus::RouterStopped) => {
+            ServerExitStatus::RouterStopped
+        }
+        (ServerExitStatus::StartupFailed(error), _)
+        | (_, ServerExitStatus::StartupFailed(error)) => ServerExitStatus::StartupFailed(error),
+        (ServerExitStatus::Stopped, ServerExitStatus::Stopped) => ServerExitStatus::Stopped,
+    }
 }
 
 struct ServerAttachFrameStream {
@@ -1252,15 +1466,13 @@ fn tool_argument_value_to_local(value: ToolArgumentValue) -> LocalToolArgumentVa
 
 fn start_web(
     web_bind: Option<WebBindReservation>,
-    bridge: &Arc<dyn LocalCommandMapper>,
+    control: ServerControl,
 ) -> Result<Option<WebHandle>, ServerStartupError> {
     let Some(bind) = web_bind else {
         return Ok(None);
     };
 
-    let bridge = Arc::new(ServerWebBridge {
-        _command_mapper: Arc::clone(bridge),
-    });
+    let bridge = Arc::new(ServerWebBridge { control });
     spawn_reserved_web_surface(ReservedWebStartArgs { bind, bridge })
         .map(Some)
         .map_err(map_web_start_error)
@@ -1280,40 +1492,75 @@ fn reserve_web_binding(
 }
 
 struct ServerWebBridge {
-    _command_mapper: Arc<dyn LocalCommandMapper>,
+    control: ServerControl,
 }
 
 impl WebBridge for ServerWebBridge {
-    fn ready(&self, _request: ReadyRequest) -> selvedge_web::WebBridgeFuture<ReadyResponse> {
-        Box::pin(async {
-            Ok(ReadyResponse {
-                protocol_version: current_protocol_version(),
-                state: ReadyState::Ready,
-            })
-        })
+    fn ready(&self, request: ReadyRequest) -> selvedge_web::WebBridgeFuture<ReadyResponse> {
+        let control = self.control.clone();
+        Box::pin(async move { Ok(control.ready(request).await) })
     }
 
     fn submit_command(
         &self,
         request: CommandRequest,
     ) -> selvedge_web::WebBridgeFuture<CommandResponse> {
-        Box::pin(async move {
-            Ok(CommandResponse {
-                protocol_version: current_protocol_version(),
-                client_command_id: request.client_command_id,
-                outcome: CommandOutcome::Rejected(CommandRejectReason::InternalFailure),
-            })
-        })
+        let control = self.control.clone();
+        Box::pin(async move { Ok(control.submit_command(request).await) })
     }
 
-    fn attach(&self, _request: AttachRequest) -> selvedge_web::WebAttachFuture {
-        Box::pin(async {
-            Err(selvedge_web::AttachRejectedOrBridgeError::Bridge(
-                selvedge_web::WebBridgeError::InternalFailure(
-                    "server web bridge is owned by the server runtime".to_owned(),
-                ),
-            ))
+    fn attach(&self, request: AttachRequest) -> selvedge_web::WebAttachFuture {
+        let control = self.control.clone();
+        Box::pin(async move {
+            control
+                .attach_client(request)
+                .await
+                .map(|(accepted, stream)| {
+                    (
+                        accepted,
+                        Box::pin(ServerWebFrameStream { inner: stream })
+                            as selvedge_web::WebFrameStream,
+                    )
+                })
+                .map_err(selvedge_web::AttachRejectedOrBridgeError::Rejected)
         })
+    }
+}
+
+struct ServerWebFrameStream {
+    inner: ServerFrameStream,
+}
+
+impl Stream for ServerWebFrameStream {
+    type Item = Result<LocalClientFrame, selvedge_web::WebBridgeError>;
+
+    fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        this.inner
+            .as_mut()
+            .poll_next(context)
+            .map(|item| item.map(|frame| frame.map_err(server_request_error_to_web_bridge_error)))
+    }
+}
+
+fn server_request_error_to_web_bridge_error(
+    error: ServerRequestError,
+) -> selvedge_web::WebBridgeError {
+    match error {
+        ServerRequestError::NotReady => selvedge_web::WebBridgeError::ServerNotReady,
+        ServerRequestError::ProtocolValidationFailed => {
+            selvedge_web::WebBridgeError::ProtocolValidationFailed
+        }
+        ServerRequestError::UnsupportedCommand => {
+            selvedge_web::WebBridgeError::CommandRejected("unsupported command".to_owned())
+        }
+        ServerRequestError::RouterMailboxClosed => selvedge_web::WebBridgeError::ServerNotReady,
+        ServerRequestError::AttachChannelFailed => {
+            selvedge_web::WebBridgeError::AttachRejected("attach channel failed".to_owned())
+        }
+        ServerRequestError::InternalFailure(message) => {
+            selvedge_web::WebBridgeError::InternalFailure(message)
+        }
     }
 }
 
@@ -1448,6 +1695,7 @@ mod tests {
     use super::*;
     use futures_util::StreamExt;
     use std::time::Duration;
+    use tokio::sync::oneshot;
     use tokio::time::timeout;
 
     struct UnusedMapper;
@@ -1458,6 +1706,21 @@ mod tests {
             _request: CommandRequest,
         ) -> Result<RouterCommandEnvelope, ServerRequestError> {
             unreachable!("attach shutdown-path tests never submit commands")
+        }
+    }
+
+    struct AcceptingMapper;
+
+    impl LocalCommandMapper for AcceptingMapper {
+        fn map_command(
+            &self,
+            request: CommandRequest,
+        ) -> Result<RouterCommandEnvelope, ServerRequestError> {
+            Ok(RouterCommandEnvelope {
+                client_id: Some(ClientId(request.client_id.0)),
+                client_command_id: Some(ClientCommandId(request.client_command_id.0)),
+                command: RouterCommand::EnsureMissingTaskRuntimes,
+            })
         }
     }
 
@@ -1507,6 +1770,133 @@ mod tests {
 
         assert_eq!(rejected.reason, AttachRejectReason::RouterMailboxClosed);
         assert_eq!(control.state().await, ServerRuntimeState::Closing);
+    }
+
+    #[tokio::test]
+    async fn server_web_bridge_forwards_commands_to_server_control() {
+        let router_tx = accepting_router_sender();
+        let (client_sync_tx, _client_sync_rx) = mpsc::channel(1);
+        let (events_tx, _events_rx) = mpsc::channel(1);
+        let control = test_control_with_mapper(
+            router_tx,
+            client_sync_tx,
+            events_tx,
+            Arc::new(AcceptingMapper),
+        );
+        let bridge = ServerWebBridge { control };
+
+        let response = bridge
+            .submit_command(test_command_request())
+            .await
+            .expect("web command forwards");
+
+        assert_eq!(response.outcome, CommandOutcome::Accepted);
+    }
+
+    #[tokio::test]
+    async fn server_web_bridge_forwards_attach_to_server_control() {
+        let router_tx = accepting_router_sender();
+        let (client_sync_tx, mut client_sync_rx) = mpsc::channel(1);
+        let (events_tx, _events_rx) = mpsc::channel(1);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+        let bridge = ServerWebBridge { control };
+
+        let (accepted, _stream) = bridge
+            .attach(test_attach_request())
+            .await
+            .expect("web attach forwards");
+
+        assert_eq!(
+            accepted.client_command_id,
+            test_attach_request().client_command_id
+        );
+        match client_sync_rx.recv().await.expect("start hydration") {
+            ClientSyncIngress::StartHydration(begin) => {
+                assert_eq!(begin.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    begin.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+            }
+            ClientSyncIngress::CancelHydration(_) | ClientSyncIngress::Shutdown => {
+                panic!("expected start hydration")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn server_join_task_reports_unexpected_router_failure() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (events_tx, events_rx) = mpsc::channel(1);
+        let (client_sync_tx, client_sync_rx) = mpsc::channel(1);
+        let control = test_control(router_tx.clone(), client_sync_tx.clone(), events_tx.clone());
+        let join_handle = spawn_server_join_task(
+            control.inner.clone(),
+            RouterHandle {
+                ingress_tx: router_tx,
+                join_handle: tokio::spawn(async {
+                    RouterExitStatus::FatalError("router failed".to_owned())
+                }),
+            },
+            EventsHandle {
+                ingress_tx: events_tx,
+                join_handle: events_join_for_test(events_rx),
+            },
+            ClientSyncHandle {
+                ingress_tx: client_sync_tx,
+                join_handle: client_sync_join_for_test(client_sync_rx),
+            },
+            None,
+        );
+
+        let status = timeout(Duration::from_millis(100), join_handle)
+            .await
+            .expect("server join returns")
+            .expect("server join succeeds");
+
+        assert_eq!(status, ServerExitStatus::Fatal("router failed".to_owned()));
+        assert_eq!(control.state().await, ServerRuntimeState::Failed);
+    }
+
+    #[tokio::test]
+    async fn server_join_task_preserves_router_failure_during_shutdown() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (events_tx, events_rx) = mpsc::channel(1);
+        let (client_sync_tx, client_sync_rx) = mpsc::channel(1);
+        let (release_router_tx, release_router_rx) = oneshot::channel();
+        let control = test_control(router_tx.clone(), client_sync_tx.clone(), events_tx.clone());
+        let join_handle = spawn_server_join_task(
+            control.inner.clone(),
+            RouterHandle {
+                ingress_tx: router_tx,
+                join_handle: tokio::spawn(async {
+                    release_router_rx.await.expect("release router");
+                    RouterExitStatus::EventsMailboxClosed
+                }),
+            },
+            EventsHandle {
+                ingress_tx: events_tx,
+                join_handle: events_join_for_test(events_rx),
+            },
+            ClientSyncHandle {
+                ingress_tx: client_sync_tx,
+                join_handle: client_sync_join_for_test(client_sync_rx),
+            },
+            None,
+        );
+
+        control.stop().await;
+        release_router_tx.send(()).expect("release router");
+        let status = timeout(Duration::from_millis(100), join_handle)
+            .await
+            .expect("server join returns")
+            .expect("server join succeeds");
+
+        assert_eq!(
+            status,
+            ServerExitStatus::Fatal("router events mailbox closed".to_owned())
+        );
+        assert_eq!(control.state().await, ServerRuntimeState::Failed);
     }
 
     #[tokio::test]
@@ -2119,6 +2509,37 @@ mod tests {
         events_tx: EventIngressSender,
         frame_channel_factory: Arc<dyn AttachFrameChannelFactory>,
     ) -> ServerControl {
+        test_control_with_frame_channel_factory_and_mapper(
+            router_tx,
+            client_sync_tx,
+            events_tx,
+            frame_channel_factory,
+            Arc::new(UnusedMapper),
+        )
+    }
+
+    fn test_control_with_mapper(
+        router_tx: RouterIngressSender,
+        client_sync_tx: selvedge_client_sync::ClientSyncSender,
+        events_tx: EventIngressSender,
+        command_mapper: Arc<dyn LocalCommandMapper>,
+    ) -> ServerControl {
+        test_control_with_frame_channel_factory_and_mapper(
+            router_tx,
+            client_sync_tx,
+            events_tx,
+            Arc::new(TokioAttachFrameChannelFactory),
+            command_mapper,
+        )
+    }
+
+    fn test_control_with_frame_channel_factory_and_mapper(
+        router_tx: RouterIngressSender,
+        client_sync_tx: selvedge_client_sync::ClientSyncSender,
+        events_tx: EventIngressSender,
+        frame_channel_factory: Arc<dyn AttachFrameChannelFactory>,
+        command_mapper: Arc<dyn LocalCommandMapper>,
+    ) -> ServerControl {
         ServerControl {
             inner: Arc::new(ServerInner {
                 state: RwLock::new(ServerRuntimeState::Ready),
@@ -2132,9 +2553,37 @@ mod tests {
                 client_sync_tx: Mutex::new(client_sync_tx),
                 active_attaches: Arc::new(StdMutex::new(HashMap::new())),
                 frame_channel_factory,
-                command_mapper: Arc::new(UnusedMapper),
-                web_control: Mutex::new(None),
+                command_mapper,
+                web_control: StdMutex::new(None),
             }),
+        }
+    }
+
+    fn events_join_for_test(mut events_rx: mpsc::Receiver<EventIngress>) -> JoinHandle<()> {
+        tokio::spawn(async move { while events_rx.recv().await.is_some() {} })
+    }
+
+    fn client_sync_join_for_test(
+        mut client_sync_rx: mpsc::Receiver<ClientSyncIngress>,
+    ) -> JoinHandle<ClientSyncExitStatus> {
+        tokio::spawn(async move {
+            while let Some(message) = client_sync_rx.recv().await {
+                if matches!(message, ClientSyncIngress::Shutdown) {
+                    return ClientSyncExitStatus::Stopped;
+                }
+            }
+            ClientSyncExitStatus::IngressClosed
+        })
+    }
+
+    fn test_command_request() -> CommandRequest {
+        CommandRequest {
+            protocol_version: current_protocol_version(),
+            client_id: selvedge_local_protocol::LocalClientId::new("client-1")
+                .expect("valid client id"),
+            client_command_id: LocalClientCommandId::new("command-1").expect("valid command id"),
+            command_name: "send-user-input".to_owned(),
+            payload: serde_json::json!({"message": "hello"}),
         }
     }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -247,7 +247,7 @@ impl ServerControl {
         }
 
         if self.inner.router_tx.is_closed() {
-            self.begin_shutdown().await;
+            self.begin_shutdown_locked().await;
             return reject(CommandRejectReason::RouterMailboxClosed);
         }
 
@@ -270,7 +270,7 @@ impl ServerControl {
             .await
             .is_err()
         {
-            self.begin_shutdown().await;
+            self.begin_shutdown_locked().await;
             return reject(CommandRejectReason::InternalFailure);
         }
 
@@ -1005,6 +1005,108 @@ fn map_web_start_error(error: WebStartError) -> ServerStartupError {
         WebStartError::BindFailed(message) => ServerStartupError::LocalhostBindFailed(message),
         WebStartError::TokioSpawnFailed => {
             ServerStartupError::LocalhostBindFailed("tokio spawn failed".to_owned())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    struct UnusedMapper;
+
+    impl LocalCommandMapper for UnusedMapper {
+        fn map_command(
+            &self,
+            _request: CommandRequest,
+        ) -> Result<RouterCommandEnvelope, ServerRequestError> {
+            unreachable!("attach shutdown-path tests never submit commands")
+        }
+    }
+
+    #[tokio::test]
+    async fn attach_closed_router_shutdown_path_returns_rejection() {
+        let (router_tx, router_rx) = mpsc::unbounded_channel();
+        drop(router_rx);
+        let (client_sync_tx, _client_sync_rx) = mpsc::channel(1);
+        let (events_tx, _events_rx) = mpsc::channel(1);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let rejected = match timeout(
+            Duration::from_millis(100),
+            control.attach_client(test_attach_request()),
+        )
+        .await
+        .expect("attach returns")
+        {
+            Ok(_) => panic!("attach should reject after router mailbox closes"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason, CommandRejectReason::RouterMailboxClosed);
+        assert_eq!(control.state().await, ServerRuntimeState::Closing);
+    }
+
+    #[tokio::test]
+    async fn attach_closed_client_sync_shutdown_path_returns_rejection() {
+        let (router_tx, _router_rx) = mpsc::unbounded_channel();
+        let (client_sync_tx, client_sync_rx) = mpsc::channel(1);
+        drop(client_sync_rx);
+        let (events_tx, _events_rx) = mpsc::channel(1);
+        let control = test_control(router_tx, client_sync_tx, events_tx);
+
+        let rejected = match timeout(
+            Duration::from_millis(100),
+            control.attach_client(test_attach_request()),
+        )
+        .await
+        .expect("attach returns")
+        {
+            Ok(_) => panic!("attach should reject after client-sync mailbox closes"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason, CommandRejectReason::InternalFailure);
+        assert_eq!(control.state().await, ServerRuntimeState::Closing);
+    }
+
+    fn test_control(
+        router_tx: RouterIngressSender,
+        client_sync_tx: selvedge_client_sync::ClientSyncSender,
+        events_tx: EventIngressSender,
+    ) -> ServerControl {
+        ServerControl {
+            inner: Arc::new(ServerInner {
+                state: RwLock::new(ServerRuntimeState::Ready),
+                closing: AtomicBool::new(false),
+                request_gate: Mutex::new(()),
+                stop_notify: Notify::new(),
+                lock_path: std::env::temp_dir().join("selvedge-server-unit-test.lock"),
+                _singleton_lock: tempfile::tempfile().expect("temp singleton lock"),
+                router_tx,
+                events_tx: Mutex::new(Some(events_tx)),
+                client_sync_tx: Mutex::new(client_sync_tx),
+                command_mapper: Arc::new(UnusedMapper),
+                web_control: Mutex::new(None),
+            }),
+        }
+    }
+
+    fn test_attach_request() -> AttachRequest {
+        AttachRequest {
+            protocol_version: current_protocol_version(),
+            client_id: selvedge_local_protocol::LocalClientId::new("client-1")
+                .expect("valid client id"),
+            client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+            subscription: selvedge_local_protocol::LocalClientSubscription {
+                task_scope: LocalTaskScope::AllTasks,
+                detail_level: LocalDetailLevel::Summary,
+                include_model_call_status: false,
+                include_tool_execution_status: false,
+                include_debug_notices: false,
+            },
         }
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -182,7 +182,6 @@ impl ServerControl {
     }
 
     pub async fn ready(&self, request: ReadyRequest) -> ReadyResponse {
-        let protocol_version = request.protocol_version;
         let state = if validate_ready_request(&request).is_ok()
             && *self.inner.state.read().await == ServerRuntimeState::Ready
         {
@@ -192,7 +191,7 @@ impl ServerControl {
         };
 
         ReadyResponse {
-            protocol_version,
+            protocol_version: current_protocol_version(),
             state,
         }
     }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,30 +7,47 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
 
 use fs2::FileExt;
 use futures_core::Stream;
 use selvedge_api::ApiExecutorConfig;
 use selvedge_client_sync::{
-    ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress, ClientSyncStartArgs,
-    SpawnClientSyncError, spawn_client_sync,
+    CancelHydration, ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress,
+    ClientSyncStartArgs, SpawnClientSyncError, spawn_client_sync,
 };
-use selvedge_command_model::{RouterCommandEnvelope, RouterIngressMessage, RouterIngressSender};
+use selvedge_command_model::{
+    BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
+    ClientNoticeLevel, ClientSnapshot, ClientSubscription, DeliverySeq, DetailLevel,
+    HistoryNodeProjection, HistoryNodeProjectionBody, ModelCallStatusPhase, RouterCommandEnvelope,
+    RouterIngressMessage, RouterIngressSender, SnapshotTaskVersion, TaskParentProjection,
+    TaskProjection, TaskProjectionStatus, TaskScope, ToolExecutionStatusPhase,
+};
 use selvedge_core::TaskRuntimeSpawnDeps;
 use selvedge_db::{OpenDbOptions, open_db};
+use selvedge_domain_model::{
+    MessageRole, ReasoningEffort, TaskId, ToolArgumentValue, ToolCallArgument,
+};
 use selvedge_events::{EventsHandle, EventsStartArgs, SpawnEventsError, spawn_events_task};
 use selvedge_local_protocol::{
     AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
-    CommandRequest, CommandResponse, LocalClientFrame, ReadyRequest, ReadyResponse, ReadyState,
-    current_protocol_version, validate_attach_request, validate_command_request,
-    validate_ready_request,
+    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientEvent, LocalClientEventFrame,
+    LocalClientFrame, LocalClientSnapshot, LocalClientSnapshotFrame, LocalDebugNoticeEvent,
+    LocalDetailLevel, LocalHistoryAppendedEvent, LocalHistoryNodeProjection,
+    LocalHistoryNodeProjectionBody, LocalMessageRole, LocalModelCallStatusEvent,
+    LocalModelCallStatusPhase, LocalNotice, LocalNoticeLevel, LocalReasoningEffort,
+    LocalSnapshotTaskVersion, LocalTaskChangedEvent, LocalTaskParentProjection,
+    LocalTaskProjection, LocalTaskProjectionStatus, LocalTaskScope, LocalToolArgumentValue,
+    LocalToolCallArgument, LocalToolExecutionStatusEvent, LocalToolExecutionStatusPhase,
+    ReadyRequest, ReadyResponse, ReadyState, current_protocol_version, validate_attach_request,
+    validate_command_request, validate_ready_request,
 };
 use selvedge_router::{RouterHandle, RouterStartArgs, SpawnRouterError, ToolExecutionSpawner};
 use selvedge_web::{
     ReservedWebStartArgs, WebBindReservation, WebBridge, WebHandle, WebLocalhostBind,
     WebLocalhostHost, WebStartError, reserve_web_bind, spawn_reserved_web_surface,
 };
-use tokio::sync::{Mutex, Notify, RwLock};
+use tokio::sync::{Mutex, Notify, RwLock, mpsc};
 use tokio::task::JoinHandle;
 
 const SQLITE_FILE_NAME: &str = "selvedge.sqlite";
@@ -232,11 +249,41 @@ impl ServerControl {
             return reject(CommandRejectReason::RouterMailboxClosed);
         }
 
-        // NOTE: Accepted attach streams require client-sync hydration to deliver
-        // the initial snapshot and event stream. The server stage only owns the
-        // lifecycle/control boundary, so a valid attach request is deferred with
-        // an explicit rejection until the client-sync package supplies hydration.
-        reject(CommandRejectReason::ServerNotReady)
+        let (outbound_tx, outbound_rx) = mpsc::channel(DEFAULT_HYDRATION_BUFFER_CAPACITY);
+        let client_id = ClientId(request.client_id.0.clone());
+        let client_command_id = ClientCommandId(request.client_command_id.0.clone());
+        let begin = BeginClientHydration {
+            client_id: client_id.clone(),
+            client_command_id: client_command_id.clone(),
+            outbound: outbound_tx,
+            subscription: local_subscription_to_command(request.subscription),
+        };
+        let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
+
+        if client_sync_tx
+            .send(ClientSyncIngress::StartHydration(begin))
+            .await
+            .is_err()
+        {
+            self.begin_shutdown().await;
+            return reject(CommandRejectReason::InternalFailure);
+        }
+
+        Ok((
+            AttachAccepted {
+                protocol_version,
+                client_id: request.client_id,
+                client_command_id: request.client_command_id,
+            },
+            Box::pin(ServerAttachFrameStream {
+                inner: outbound_rx,
+                client_sync_tx,
+                client_id,
+                client_command_id,
+                cancel_sent: false,
+                closed_reported: false,
+            }),
+        ))
     }
 
     pub async fn stop(&self) {
@@ -457,6 +504,296 @@ fn spawn_server_join_task(
         *inner.state.write().await = ServerRuntimeState::Stopped;
         ServerExitStatus::Stopped
     })
+}
+
+struct ServerAttachFrameStream {
+    inner: mpsc::Receiver<ClientFrame>,
+    client_sync_tx: selvedge_client_sync::ClientSyncSender,
+    client_id: ClientId,
+    client_command_id: ClientCommandId,
+    cancel_sent: bool,
+    closed_reported: bool,
+}
+
+impl futures_core::Stream for ServerAttachFrameStream {
+    type Item = Result<LocalClientFrame, ServerRequestError>;
+
+    fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.closed_reported {
+            return Poll::Ready(None);
+        }
+        match this.inner.poll_recv(context) {
+            Poll::Ready(Some(frame)) => Poll::Ready(Some(Ok(client_frame_to_local(frame)))),
+            Poll::Ready(None) => {
+                this.closed_reported = true;
+                Poll::Ready(Some(Err(ServerRequestError::AttachChannelFailed)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for ServerAttachFrameStream {
+    fn drop(&mut self) {
+        if self.cancel_sent {
+            return;
+        }
+        self.cancel_sent = true;
+        let _ = self
+            .client_sync_tx
+            .try_send(ClientSyncIngress::CancelHydration(CancelHydration {
+                client_id: self.client_id.clone(),
+                client_command_id: self.client_command_id.clone(),
+            }));
+    }
+}
+
+fn local_subscription_to_command(
+    subscription: selvedge_local_protocol::LocalClientSubscription,
+) -> ClientSubscription {
+    ClientSubscription {
+        task_scope: match subscription.task_scope {
+            LocalTaskScope::AllTasks => TaskScope::AllTasks,
+            LocalTaskScope::TaskIds(task_ids) => {
+                TaskScope::TaskIds(task_ids.into_iter().map(TaskId).collect())
+            }
+        },
+        detail_level: match subscription.detail_level {
+            LocalDetailLevel::Summary => DetailLevel::Summary,
+            LocalDetailLevel::Verbose => DetailLevel::Verbose,
+        },
+        include_model_call_status: subscription.include_model_call_status,
+        include_tool_execution_status: subscription.include_tool_execution_status,
+        include_debug_notices: subscription.include_debug_notices,
+    }
+}
+
+fn client_frame_to_local(frame: ClientFrame) -> LocalClientFrame {
+    match frame {
+        ClientFrame::Snapshot(frame) => LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
+            delivery_seq: local_delivery_seq(frame.delivery_seq),
+            client_command_id: LocalClientCommandId(frame.client_command_id.0),
+            snapshot: client_snapshot_to_local(frame.snapshot),
+        }),
+        ClientFrame::Event(frame) => LocalClientFrame::Event(LocalClientEventFrame {
+            delivery_seq: local_delivery_seq(frame.delivery_seq),
+            event: client_event_to_local(frame.event),
+        }),
+        ClientFrame::Notice(frame) => {
+            LocalClientFrame::Notice(selvedge_local_protocol::LocalClientNoticeFrame {
+                delivery_seq: local_delivery_seq(frame.delivery_seq),
+                client_command_id: LocalClientCommandId(frame.client_command_id.0),
+                notice: client_notice_to_local(frame.notice),
+            })
+        }
+    }
+}
+
+fn local_delivery_seq(delivery_seq: DeliverySeq) -> u64 {
+    delivery_seq.0
+}
+
+fn client_snapshot_to_local(snapshot: ClientSnapshot) -> LocalClientSnapshot {
+    LocalClientSnapshot {
+        generated_at: snapshot.generated_at.0,
+        tasks: snapshot.tasks.into_iter().map(task_to_local).collect(),
+        task_parent_edges: snapshot
+            .task_parent_edges
+            .into_iter()
+            .map(parent_edge_to_local)
+            .collect(),
+        history_nodes: snapshot
+            .history_nodes
+            .into_iter()
+            .map(history_node_to_local)
+            .collect(),
+        task_versions: snapshot
+            .task_versions
+            .into_iter()
+            .map(snapshot_task_version_to_local)
+            .collect(),
+    }
+}
+
+fn snapshot_task_version_to_local(version: SnapshotTaskVersion) -> LocalSnapshotTaskVersion {
+    LocalSnapshotTaskVersion {
+        task_id: version.task_id.0,
+        state_version: version.state_version,
+    }
+}
+
+fn task_to_local(task: TaskProjection) -> LocalTaskProjection {
+    LocalTaskProjection {
+        task_id: task.task_id.0,
+        status: match task.status {
+            TaskProjectionStatus::Active => LocalTaskProjectionStatus::Active,
+            TaskProjectionStatus::Archived => LocalTaskProjectionStatus::Archived,
+        },
+        cursor_node_id: task.cursor_node_id.0,
+        model_profile_key: task.model_profile_key.0,
+        reasoning_effort: reasoning_effort_to_local(task.reasoning_effort),
+        state_version: task.state_version,
+        created_at: task.created_at.0,
+        updated_at: task.updated_at.0,
+    }
+}
+
+fn parent_edge_to_local(edge: TaskParentProjection) -> LocalTaskParentProjection {
+    LocalTaskParentProjection {
+        parent_task_id: edge.parent_task_id.0,
+        child_task_id: edge.child_task_id.0,
+    }
+}
+
+fn history_node_to_local(node: HistoryNodeProjection) -> LocalHistoryNodeProjection {
+    LocalHistoryNodeProjection {
+        node_id: node.node_id.0,
+        parent_node_id: node.parent_node_id.map(|node_id| node_id.0),
+        created_at: node.created_at.0,
+        body: history_node_body_to_local(node.body),
+    }
+}
+
+fn history_node_body_to_local(body: HistoryNodeProjectionBody) -> LocalHistoryNodeProjectionBody {
+    match body {
+        HistoryNodeProjectionBody::Message { role, text } => {
+            LocalHistoryNodeProjectionBody::Message {
+                role: message_role_to_local(role),
+                text,
+            }
+        }
+        HistoryNodeProjectionBody::Reasoning { text } => {
+            LocalHistoryNodeProjectionBody::Reasoning { text }
+        }
+        HistoryNodeProjectionBody::FunctionCall {
+            function_call_id,
+            tool_name,
+            arguments,
+        } => LocalHistoryNodeProjectionBody::FunctionCall {
+            function_call_id: function_call_id.0,
+            tool_name: tool_name.0,
+            arguments: arguments.into_iter().map(tool_argument_to_local).collect(),
+        },
+        HistoryNodeProjectionBody::FunctionOutput {
+            function_call_node_id,
+            function_call_id,
+            tool_name,
+            output_text,
+            is_error,
+        } => LocalHistoryNodeProjectionBody::FunctionOutput {
+            function_call_node_id: function_call_node_id.0,
+            function_call_id: function_call_id.0,
+            tool_name: tool_name.0,
+            output_text,
+            is_error,
+        },
+    }
+}
+
+fn client_event_to_local(event: ClientEvent) -> LocalClientEvent {
+    match event {
+        ClientEvent::TaskChanged(event) => LocalClientEvent::TaskChanged(LocalTaskChangedEvent {
+            task: task_to_local(event.task),
+        }),
+        ClientEvent::HistoryAppended(event) => {
+            LocalClientEvent::HistoryAppended(LocalHistoryAppendedEvent {
+                task_id: event.task_id.0,
+                task_state_version: event.task_state_version,
+                appended_nodes: event
+                    .appended_nodes
+                    .into_iter()
+                    .map(history_node_to_local)
+                    .collect(),
+            })
+        }
+        ClientEvent::ModelCallStatus(event) => {
+            LocalClientEvent::ModelCallStatus(LocalModelCallStatusEvent {
+                task_id: event.task_id.0,
+                model_call_id: event.model_call_id.0,
+                phase: model_call_status_phase_to_local(event.phase),
+            })
+        }
+        ClientEvent::ToolExecutionStatus(event) => {
+            LocalClientEvent::ToolExecutionStatus(LocalToolExecutionStatusEvent {
+                task_id: event.task_id.0,
+                tool_execution_run_id: event.tool_execution_run_id.0,
+                function_call_node_id: event.function_call_node_id.0,
+                tool_name: event.tool_name.0,
+                phase: tool_execution_status_phase_to_local(event.phase),
+            })
+        }
+        ClientEvent::DebugNotice(event) => LocalClientEvent::DebugNotice(LocalDebugNoticeEvent {
+            task_id: event.task_id.map(|task_id| task_id.0),
+            message_text: event.message_text,
+        }),
+    }
+}
+
+fn client_notice_to_local(notice: ClientNotice) -> LocalNotice {
+    LocalNotice {
+        level: match notice.level {
+            ClientNoticeLevel::Info => LocalNoticeLevel::Info,
+            ClientNoticeLevel::Warning => LocalNoticeLevel::Warning,
+            ClientNoticeLevel::Error => LocalNoticeLevel::Error,
+        },
+        message_text: notice.message_text,
+    }
+}
+
+fn model_call_status_phase_to_local(phase: ModelCallStatusPhase) -> LocalModelCallStatusPhase {
+    match phase {
+        ModelCallStatusPhase::Requested => LocalModelCallStatusPhase::Requested,
+        ModelCallStatusPhase::Completed => LocalModelCallStatusPhase::Completed,
+        ModelCallStatusPhase::Failed => LocalModelCallStatusPhase::Failed,
+        ModelCallStatusPhase::Discarded => LocalModelCallStatusPhase::Discarded,
+    }
+}
+
+fn tool_execution_status_phase_to_local(
+    phase: ToolExecutionStatusPhase,
+) -> LocalToolExecutionStatusPhase {
+    match phase {
+        ToolExecutionStatusPhase::Requested => LocalToolExecutionStatusPhase::Requested,
+        ToolExecutionStatusPhase::Completed => LocalToolExecutionStatusPhase::Completed,
+        ToolExecutionStatusPhase::Failed => LocalToolExecutionStatusPhase::Failed,
+        ToolExecutionStatusPhase::Discarded => LocalToolExecutionStatusPhase::Discarded,
+    }
+}
+
+fn reasoning_effort_to_local(reasoning_effort: ReasoningEffort) -> LocalReasoningEffort {
+    match reasoning_effort {
+        ReasoningEffort::Minimal => LocalReasoningEffort::Minimal,
+        ReasoningEffort::Low => LocalReasoningEffort::Low,
+        ReasoningEffort::Medium => LocalReasoningEffort::Medium,
+        ReasoningEffort::High => LocalReasoningEffort::High,
+    }
+}
+
+fn message_role_to_local(role: MessageRole) -> LocalMessageRole {
+    match role {
+        MessageRole::System => LocalMessageRole::System,
+        MessageRole::Developer => LocalMessageRole::Developer,
+        MessageRole::User => LocalMessageRole::User,
+        MessageRole::Assistant => LocalMessageRole::Assistant,
+        MessageRole::Tool => LocalMessageRole::Tool,
+    }
+}
+
+fn tool_argument_to_local(argument: ToolCallArgument) -> LocalToolCallArgument {
+    LocalToolCallArgument {
+        name: argument.name.0,
+        value: tool_argument_value_to_local(argument.value),
+    }
+}
+
+fn tool_argument_value_to_local(value: ToolArgumentValue) -> LocalToolArgumentValue {
+    match value {
+        ToolArgumentValue::String(value) => LocalToolArgumentValue::String(value),
+        ToolArgumentValue::Integer(value) => LocalToolArgumentValue::Integer(value),
+        ToolArgumentValue::Number(value) => LocalToolArgumentValue::Number(value),
+        ToolArgumentValue::Boolean(value) => LocalToolArgumentValue::Boolean(value),
+    }
 }
 
 fn start_web(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -151,7 +151,7 @@ pub fn spawn_server(args: ServerStartArgs) -> Result<ServerHandle, ServerStartup
     }
 
     init_config(args.explicit_home.as_ref())?;
-    let home = resolve_home(args.explicit_home.clone())?;
+    let home = resolve_home()?;
     let singleton_lock = acquire_singleton_lock(&home)?;
 
     let startup_result = start_server_after_lock(args, home, singleton_lock);
@@ -237,6 +237,8 @@ impl ServerControl {
     }
 
     async fn submit_command_outcome(&self, request: CommandRequest) -> CommandOutcome {
+        let _request_guard = self.inner.request_gate.lock().await;
+
         if *self.inner.state.read().await != ServerRuntimeState::Ready {
             return CommandOutcome::Rejected(CommandRejectReason::ServerNotReady);
         }
@@ -254,7 +256,7 @@ impl ServerControl {
                 return CommandOutcome::Rejected(CommandRejectReason::UnsupportedCommand);
             }
             Err(ServerRequestError::RouterMailboxClosed) => {
-                self.begin_shutdown().await;
+                self.begin_shutdown_locked().await;
                 return CommandOutcome::Rejected(CommandRejectReason::RouterMailboxClosed);
             }
             Err(ServerRequestError::NotReady) => {
@@ -276,7 +278,7 @@ impl ServerControl {
             .send(RouterIngressMessage::Command(command))
             .is_err()
         {
-            self.begin_shutdown().await;
+            self.begin_shutdown_locked().await;
             return CommandOutcome::Rejected(CommandRejectReason::RouterMailboxClosed);
         }
 
@@ -284,6 +286,11 @@ impl ServerControl {
     }
 
     async fn begin_shutdown(&self) {
+        let _request_guard = self.inner.request_gate.lock().await;
+        self.begin_shutdown_locked().await;
+    }
+
+    async fn begin_shutdown_locked(&self) {
         if self.inner.closing.swap(true, Ordering::SeqCst) {
             return;
         }
@@ -307,6 +314,7 @@ struct ServerContext {
 struct ServerInner {
     state: RwLock<ServerRuntimeState>,
     closing: AtomicBool,
+    request_gate: Mutex<()>,
     stop_notify: Notify,
     lock_path: PathBuf,
     _singleton_lock: File,
@@ -394,6 +402,7 @@ fn start_server_after_lock(
     let inner = Arc::new(ServerInner {
         state: RwLock::new(ServerRuntimeState::Ready),
         closing: AtomicBool::new(false),
+        request_gate: Mutex::new(()),
         stop_notify: Notify::new(),
         lock_path: lock_path_for_home(&home),
         _singleton_lock: singleton_lock,
@@ -527,11 +536,7 @@ fn local_bind_to_web_bind(
     })
 }
 
-fn resolve_home(explicit_home: Option<PathBuf>) -> Result<PathBuf, ServerStartupError> {
-    if let Some(home) = explicit_home {
-        return Ok(home);
-    }
-
+fn resolve_home() -> Result<PathBuf, ServerStartupError> {
     selvedge_config::selvedge_home()
         .map_err(|error| ServerStartupError::ConfigInitFailed(error.to_string()))
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -27,8 +27,8 @@ use selvedge_local_protocol::{
 };
 use selvedge_router::{RouterHandle, RouterStartArgs, SpawnRouterError, ToolExecutionSpawner};
 use selvedge_web::{
-    WebBridge, WebHandle, WebLocalhostBind, WebLocalhostHost, WebStartArgs, WebStartError,
-    spawn_web_surface,
+    ReservedWebStartArgs, WebBindReservation, WebBridge, WebHandle, WebLocalhostBind,
+    WebLocalhostHost, WebStartError, reserve_web_bind, spawn_reserved_web_surface,
 };
 use tokio::sync::{Mutex, Notify, RwLock};
 use tokio::task::JoinHandle;
@@ -149,12 +149,13 @@ pub fn spawn_server(args: ServerStartArgs) -> Result<ServerHandle, ServerStartup
     if let Some(web_binding) = &args.web_binding {
         validate_web_bind_target(&web_binding.bind_target)?;
     }
+    let web_bind = reserve_web_binding(args.web_binding.as_ref())?;
 
     init_config(args.explicit_home.as_ref())?;
     let home = resolve_home()?;
     let singleton_lock = acquire_singleton_lock(&home)?;
 
-    let startup_result = start_server_after_lock(args, home, singleton_lock);
+    let startup_result = start_server_after_lock(args, home, singleton_lock, web_bind);
     if let Err(error) = &startup_result {
         return Err(error.clone());
     }
@@ -337,6 +338,7 @@ fn start_server_after_lock(
     args: ServerStartArgs,
     home: PathBuf,
     singleton_lock: File,
+    web_bind: Option<WebBindReservation>,
 ) -> Result<ServerContext, ServerStartupError> {
     if let Err(error) = init_logging() {
         cleanup_startup_lock(&home);
@@ -391,7 +393,7 @@ fn start_server_after_lock(
         }
     };
 
-    let web = match start_web(args.web_binding, &args.command_mapper) {
+    let web = match start_web(web_bind, &args.command_mapper) {
         Ok(web) => web,
         Err(error) => {
             cleanup_startup_lock(&home);
@@ -452,18 +454,30 @@ fn spawn_server_join_task(
 }
 
 fn start_web(
-    web_binding: Option<WebBindingConfig>,
+    web_bind: Option<WebBindReservation>,
     bridge: &Arc<dyn LocalCommandMapper>,
 ) -> Result<Option<WebHandle>, ServerStartupError> {
+    let Some(bind) = web_bind else {
+        return Ok(None);
+    };
+
+    let bridge = Arc::new(ServerWebBridge {
+        _command_mapper: Arc::clone(bridge),
+    });
+    spawn_reserved_web_surface(ReservedWebStartArgs { bind, bridge })
+        .map(Some)
+        .map_err(map_web_start_error)
+}
+
+fn reserve_web_binding(
+    web_binding: Option<&WebBindingConfig>,
+) -> Result<Option<WebBindReservation>, ServerStartupError> {
     let Some(web_binding) = web_binding else {
         return Ok(None);
     };
 
-    let bind = local_bind_to_web_bind(web_binding.bind_target)?;
-    let bridge = Arc::new(ServerWebBridge {
-        _command_mapper: Arc::clone(bridge),
-    });
-    spawn_web_surface(WebStartArgs { bind, bridge })
+    let bind = local_bind_to_web_bind(web_binding.bind_target.clone())?;
+    reserve_web_bind(bind)
         .map(Some)
         .map_err(map_web_start_error)
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,0 +1,896 @@
+#![doc = include_str!("../README.md")]
+
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use selvedge_api::ApiExecutorConfig;
+use selvedge_client_sync::{
+    ClientSnapshotBuilder, ClientSyncHandle, ClientSyncIngress, ClientSyncStartArgs,
+    SpawnClientSyncError, spawn_client_sync,
+};
+use selvedge_command_model::{
+    BeginClientHydration, ClientCommandId, ClientEvent, ClientFrame, ClientId, ClientNotice,
+    ClientNoticeLevel, ClientSnapshot, ClientSubscription, DetailLevel, RouterCommandEnvelope,
+    RouterIngressMessage, RouterIngressSender, TaskScope,
+};
+use selvedge_core::TaskRuntimeSpawnDeps;
+use selvedge_db::{OpenDbOptions, open_db};
+use selvedge_events::{EventsHandle, EventsStartArgs, SpawnEventsError, spawn_events_task};
+use selvedge_local_protocol::{
+    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
+    CommandRequest, CommandResponse, LocalClientEvent, LocalClientFrame, LocalClientNoticeFrame,
+    LocalClientSnapshot, LocalClientSnapshotFrame, LocalDetailLevel, LocalHistoryNodeProjection,
+    LocalHistoryNodeProjectionBody, LocalMessageRole, LocalModelCallStatusEvent,
+    LocalModelCallStatusPhase, LocalNotice, LocalNoticeLevel, LocalReasoningEffort,
+    LocalSnapshotTaskVersion, LocalTaskParentProjection, LocalTaskProjection,
+    LocalTaskProjectionStatus, LocalTaskScope, LocalToolArgumentValue, LocalToolCallArgument,
+    LocalToolExecutionStatusEvent, LocalToolExecutionStatusPhase, ReadyRequest, ReadyResponse,
+    ReadyState, current_protocol_version, validate_attach_request, validate_command_request,
+    validate_ready_request,
+};
+use selvedge_router::{RouterHandle, RouterStartArgs, SpawnRouterError, ToolExecutionSpawner};
+use selvedge_web::{
+    WebBridge, WebHandle, WebLocalhostBind, WebLocalhostHost, WebStartArgs, WebStartError,
+    spawn_web_surface,
+};
+use tokio::sync::{Mutex, Notify, RwLock, mpsc};
+use tokio::task::JoinHandle;
+
+const SQLITE_FILE_NAME: &str = "selvedge.sqlite";
+const LOCK_FILE_NAME: &str = "server.lock";
+const DEFAULT_EVENTS_INGRESS_CAPACITY: usize = 64;
+const DEFAULT_CLIENT_REGISTRY_CAPACITY: usize = 64;
+const DEFAULT_HYDRATION_BUFFER_CAPACITY: usize = 256;
+const DEFAULT_CLIENT_SYNC_INGRESS_CAPACITY: usize = 64;
+const DEFAULT_ATTACH_FRAME_CAPACITY: usize = 64;
+
+pub struct ServerStartArgs {
+    pub explicit_home: Option<PathBuf>,
+    pub api_config: ApiExecutorConfig,
+    pub tool_executor: Arc<dyn ToolExecutionSpawner>,
+    pub core_spawn_deps: TaskRuntimeSpawnDeps,
+    pub snapshot_builder: Arc<dyn ClientSnapshotBuilder>,
+    pub command_mapper: Arc<dyn LocalCommandMapper>,
+    pub local_binding: LocalBindingConfig,
+    pub web_binding: Option<WebBindingConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalBindingConfig {
+    pub bind_target: LocalhostBindTarget,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebBindingConfig {
+    pub bind_target: LocalhostBindTarget,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LocalhostBindTarget {
+    Ipv4 { port: u16 },
+    Ipv6 { port: u16 },
+}
+
+#[derive(Debug)]
+pub struct ServerHandle {
+    pub control: ServerControl,
+    pub join_handle: JoinHandle<ServerExitStatus>,
+}
+
+pub type ServerFrameStream =
+    Pin<Box<dyn Stream<Item = Result<LocalClientFrame, ServerRequestError>> + Send>>;
+
+#[derive(Clone)]
+pub struct ServerControl {
+    inner: Arc<ServerInner>,
+}
+
+impl fmt::Debug for ServerControl {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ServerControl")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerRuntimeState {
+    Starting,
+    Ready,
+    Closing,
+    Stopped,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerExitStatus {
+    Stopped,
+    StartupFailed(ServerStartupError),
+    RouterStopped,
+    Fatal(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerStartupError {
+    SingletonAlreadyRunning,
+    InvalidBindTarget,
+    ConfigInitFailed(String),
+    LoggingInitFailed(String),
+    DbOpenFailed(String),
+    EventsStartFailed(String),
+    ClientSyncStartFailed(String),
+    RouterStartFailed(String),
+    LocalhostBindFailed(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerRequestError {
+    NotReady,
+    ProtocolValidationFailed,
+    UnsupportedCommand,
+    RouterMailboxClosed,
+    AttachChannelFailed,
+    InternalFailure(String),
+}
+
+pub trait LocalCommandMapper: Send + Sync {
+    fn map_command(
+        &self,
+        request: CommandRequest,
+    ) -> Result<RouterCommandEnvelope, ServerRequestError>;
+}
+
+pub async fn run_server(args: ServerStartArgs) -> ServerExitStatus {
+    match spawn_server(args) {
+        Ok(handle) => handle
+            .join_handle
+            .await
+            .unwrap_or_else(|error| ServerExitStatus::Fatal(error.to_string())),
+        Err(error) => ServerExitStatus::StartupFailed(error),
+    }
+}
+
+pub fn spawn_server(args: ServerStartArgs) -> Result<ServerHandle, ServerStartupError> {
+    validate_bind_target(&args.local_binding.bind_target)?;
+    if let Some(web_binding) = &args.web_binding {
+        validate_bind_target(&web_binding.bind_target)?;
+    }
+
+    let home = resolve_home(args.explicit_home.clone())?;
+    let singleton_lock = acquire_singleton_lock(&home)?;
+
+    let startup_home = home.clone();
+    let startup_result = start_server_after_lock(args, home, singleton_lock);
+    if let Err(error) = &startup_result {
+        let _ = std::fs::remove_file(lock_path_for_home(&startup_home));
+        return Err(error.clone());
+    }
+
+    startup_result.map(ServerContext::into_handle)
+}
+
+impl ServerControl {
+    pub async fn state(&self) -> ServerRuntimeState {
+        self.inner.state.read().await.clone()
+    }
+
+    pub async fn ready(&self, request: ReadyRequest) -> ReadyResponse {
+        let protocol_version = request.protocol_version;
+        let state = if validate_ready_request(&request).is_ok()
+            && *self.inner.state.read().await == ServerRuntimeState::Ready
+        {
+            ReadyState::Ready
+        } else {
+            ReadyState::NotReady
+        };
+
+        ReadyResponse {
+            protocol_version,
+            state,
+        }
+    }
+
+    pub async fn submit_command(&self, request: CommandRequest) -> CommandResponse {
+        let protocol_version = current_protocol_version();
+        let client_command_id = request.client_command_id.clone();
+        let outcome = self.submit_command_outcome(request).await;
+
+        CommandResponse {
+            protocol_version,
+            client_command_id,
+            outcome,
+        }
+    }
+
+    pub async fn attach_client(
+        &self,
+        request: AttachRequest,
+    ) -> Result<(AttachAccepted, ServerFrameStream), AttachRejected> {
+        let protocol_version = current_protocol_version();
+        let client_id = request.client_id.clone();
+        let client_command_id = request.client_command_id.clone();
+
+        let reject = |reason| {
+            Err(AttachRejected {
+                protocol_version,
+                client_command_id: client_command_id.clone(),
+                reason,
+            })
+        };
+
+        if *self.inner.state.read().await != ServerRuntimeState::Ready {
+            return reject(CommandRejectReason::ServerNotReady);
+        }
+
+        if validate_attach_request(&request).is_err() {
+            return reject(CommandRejectReason::MalformedRequest);
+        }
+
+        if self.inner.router_tx.is_closed() {
+            self.begin_shutdown().await;
+            return reject(CommandRejectReason::RouterMailboxClosed);
+        }
+
+        let (outbound, inbound) = mpsc::channel(DEFAULT_ATTACH_FRAME_CAPACITY);
+        let hydration = BeginClientHydration {
+            client_id: ClientId(client_id.0.clone()),
+            client_command_id: ClientCommandId(client_command_id.0.clone()),
+            outbound,
+            subscription: local_subscription_to_command(&request.subscription),
+        };
+
+        let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
+        if client_sync_tx
+            .send(ClientSyncIngress::StartHydration(hydration))
+            .await
+            .is_err()
+        {
+            return reject(CommandRejectReason::InternalFailure);
+        }
+
+        let accepted = AttachAccepted {
+            protocol_version,
+            client_id,
+            client_command_id,
+        };
+        let stream = Box::pin(ServerMpscFrameStream { inbound });
+        Ok((accepted, stream))
+    }
+
+    pub async fn stop(&self) {
+        self.begin_shutdown().await;
+    }
+
+    async fn submit_command_outcome(&self, request: CommandRequest) -> CommandOutcome {
+        if *self.inner.state.read().await != ServerRuntimeState::Ready {
+            return CommandOutcome::Rejected(CommandRejectReason::ServerNotReady);
+        }
+
+        if validate_command_request(&request).is_err() {
+            if request.protocol_version != current_protocol_version() {
+                return CommandOutcome::Rejected(CommandRejectReason::ProtocolVersionMismatch);
+            }
+            return CommandOutcome::Rejected(CommandRejectReason::MalformedRequest);
+        }
+
+        let command = match self.inner.command_mapper.map_command(request) {
+            Ok(command) => command,
+            Err(ServerRequestError::UnsupportedCommand) => {
+                return CommandOutcome::Rejected(CommandRejectReason::UnsupportedCommand);
+            }
+            Err(ServerRequestError::RouterMailboxClosed) => {
+                self.begin_shutdown().await;
+                return CommandOutcome::Rejected(CommandRejectReason::RouterMailboxClosed);
+            }
+            Err(ServerRequestError::NotReady) => {
+                return CommandOutcome::Rejected(CommandRejectReason::ServerNotReady);
+            }
+            Err(ServerRequestError::ProtocolValidationFailed) => {
+                return CommandOutcome::Rejected(CommandRejectReason::MalformedRequest);
+            }
+            Err(
+                ServerRequestError::AttachChannelFailed | ServerRequestError::InternalFailure(_),
+            ) => {
+                return CommandOutcome::Rejected(CommandRejectReason::InternalFailure);
+            }
+        };
+
+        if self
+            .inner
+            .router_tx
+            .send(RouterIngressMessage::Command(command))
+            .is_err()
+        {
+            self.begin_shutdown().await;
+            return CommandOutcome::Rejected(CommandRejectReason::RouterMailboxClosed);
+        }
+
+        CommandOutcome::Accepted
+    }
+
+    async fn begin_shutdown(&self) {
+        if self.inner.closing.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        *self.inner.state.write().await = ServerRuntimeState::Closing;
+        let _ = self.inner.router_tx.send(RouterIngressMessage::StopRouter);
+        let client_sync_tx = self.inner.client_sync_tx.lock().await.clone();
+        let _ = client_sync_tx.send(ClientSyncIngress::Shutdown).await;
+        if let Some(web_control) = self.inner.web_control.lock().await.as_ref() {
+            web_control.stop().await;
+        }
+        self.inner.stop_notify.notify_waiters();
+    }
+}
+
+struct ServerContext {
+    inner: Arc<ServerInner>,
+    join_handle: JoinHandle<ServerExitStatus>,
+}
+
+struct ServerInner {
+    state: RwLock<ServerRuntimeState>,
+    closing: AtomicBool,
+    stop_notify: Notify,
+    lock_path: PathBuf,
+    _singleton_lock: File,
+    router_tx: RouterIngressSender,
+    client_sync_tx: Mutex<selvedge_client_sync::ClientSyncSender>,
+    command_mapper: Arc<dyn LocalCommandMapper>,
+    web_control: Mutex<Option<selvedge_web::WebControl>>,
+}
+
+impl ServerContext {
+    fn into_handle(self) -> ServerHandle {
+        ServerHandle {
+            control: ServerControl { inner: self.inner },
+            join_handle: self.join_handle,
+        }
+    }
+}
+
+fn start_server_after_lock(
+    args: ServerStartArgs,
+    home: PathBuf,
+    singleton_lock: File,
+) -> Result<ServerContext, ServerStartupError> {
+    init_config(args.explicit_home.as_ref())?;
+    init_logging()?;
+
+    let db = open_db(OpenDbOptions {
+        sqlite_path: sqlite_path_for_home(&home).to_string_lossy().to_string(),
+    })
+    .map_err(|error| ServerStartupError::DbOpenFailed(error.to_string()))?;
+
+    let events = spawn_events_task(EventsStartArgs {
+        ingress_capacity: DEFAULT_EVENTS_INGRESS_CAPACITY,
+        client_registry_capacity: DEFAULT_CLIENT_REGISTRY_CAPACITY,
+        hydration_buffer_capacity: DEFAULT_HYDRATION_BUFFER_CAPACITY,
+    })
+    .map_err(map_events_start_error)?;
+
+    let client_sync = spawn_client_sync(ClientSyncStartArgs {
+        events_tx: events.ingress_tx.clone(),
+        snapshot_builder: args.snapshot_builder,
+        ingress_capacity: DEFAULT_CLIENT_SYNC_INGRESS_CAPACITY,
+    })
+    .map_err(map_client_sync_start_error)?;
+
+    let router = selvedge_router::spawn_router(RouterStartArgs {
+        db,
+        events_tx: events.ingress_tx.clone(),
+        api_config: args.api_config,
+        tool_executor: args.tool_executor,
+        core_spawn_deps: args.core_spawn_deps,
+    })
+    .map_err(map_router_start_error)?;
+
+    let web = start_web(args.web_binding, &args.command_mapper)?;
+
+    let inner = Arc::new(ServerInner {
+        state: RwLock::new(ServerRuntimeState::Ready),
+        closing: AtomicBool::new(false),
+        stop_notify: Notify::new(),
+        lock_path: lock_path_for_home(&home),
+        _singleton_lock: singleton_lock,
+        router_tx: router.ingress_tx.clone(),
+        client_sync_tx: Mutex::new(client_sync.ingress_tx.clone()),
+        command_mapper: args.command_mapper,
+        web_control: Mutex::new(web.as_ref().map(|handle| handle.control.clone())),
+    });
+    let join_handle = spawn_server_join_task(inner.clone(), router, events, client_sync, web);
+
+    Ok(ServerContext { inner, join_handle })
+}
+
+fn spawn_server_join_task(
+    inner: Arc<ServerInner>,
+    router: RouterHandle,
+    events: EventsHandle,
+    client_sync: ClientSyncHandle,
+    web: Option<WebHandle>,
+) -> JoinHandle<ServerExitStatus> {
+    tokio::spawn(async move {
+        loop {
+            if inner.closing.load(Ordering::SeqCst) {
+                break;
+            }
+            let notified = inner.stop_notify.notified();
+            if inner.closing.load(Ordering::SeqCst) {
+                break;
+            }
+            notified.await;
+        }
+        let _ = router.join_handle.await;
+        drop(events.ingress_tx);
+        let _ = events.join_handle.await;
+        let _ = client_sync.join_handle.await;
+        if let Some(web) = web {
+            let _ = web.join_handle.await;
+        }
+        let _ = std::fs::remove_file(&inner.lock_path);
+        *inner.state.write().await = ServerRuntimeState::Stopped;
+        ServerExitStatus::Stopped
+    })
+}
+
+fn start_web(
+    web_binding: Option<WebBindingConfig>,
+    bridge: &Arc<dyn LocalCommandMapper>,
+) -> Result<Option<WebHandle>, ServerStartupError> {
+    let Some(web_binding) = web_binding else {
+        return Ok(None);
+    };
+
+    let bind = local_bind_to_web_bind(web_binding.bind_target)?;
+    let bridge = Arc::new(ServerWebBridge {
+        _command_mapper: Arc::clone(bridge),
+    });
+    spawn_web_surface(WebStartArgs { bind, bridge })
+        .map(Some)
+        .map_err(map_web_start_error)
+}
+
+struct ServerWebBridge {
+    _command_mapper: Arc<dyn LocalCommandMapper>,
+}
+
+impl WebBridge for ServerWebBridge {
+    fn ready(&self, _request: ReadyRequest) -> selvedge_web::WebBridgeFuture<ReadyResponse> {
+        Box::pin(async {
+            Ok(ReadyResponse {
+                protocol_version: current_protocol_version(),
+                state: ReadyState::Ready,
+            })
+        })
+    }
+
+    fn submit_command(
+        &self,
+        request: CommandRequest,
+    ) -> selvedge_web::WebBridgeFuture<CommandResponse> {
+        Box::pin(async move {
+            Ok(CommandResponse {
+                protocol_version: current_protocol_version(),
+                client_command_id: request.client_command_id,
+                outcome: CommandOutcome::Rejected(CommandRejectReason::InternalFailure),
+            })
+        })
+    }
+
+    fn attach(&self, _request: AttachRequest) -> selvedge_web::WebAttachFuture {
+        Box::pin(async {
+            Err(selvedge_web::AttachRejectedOrBridgeError::Bridge(
+                selvedge_web::WebBridgeError::InternalFailure(
+                    "server web bridge is owned by the server runtime".to_owned(),
+                ),
+            ))
+        })
+    }
+}
+
+struct ServerMpscFrameStream {
+    inbound: mpsc::Receiver<ClientFrame>,
+}
+
+impl Stream for ServerMpscFrameStream {
+    type Item = Result<LocalClientFrame, ServerRequestError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inbound.poll_recv(cx) {
+            Poll::Ready(Some(frame)) => Poll::Ready(Some(command_frame_to_local(frame))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn command_frame_to_local(frame: ClientFrame) -> Result<LocalClientFrame, ServerRequestError> {
+    match frame {
+        ClientFrame::Snapshot(frame) => Ok(LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
+            delivery_seq: frame.delivery_seq.0,
+            client_command_id: selvedge_local_protocol::LocalClientCommandId(
+                frame.client_command_id.0,
+            ),
+            snapshot: client_snapshot_to_local(frame.snapshot),
+        })),
+        ClientFrame::Event(frame) => Ok(LocalClientFrame::Event(
+            selvedge_local_protocol::LocalClientEventFrame {
+                delivery_seq: frame.delivery_seq.0,
+                event: client_event_to_local(frame.event),
+            },
+        )),
+        ClientFrame::Notice(frame) => Ok(LocalClientFrame::Notice(LocalClientNoticeFrame {
+            delivery_seq: frame.delivery_seq.0,
+            client_command_id: selvedge_local_protocol::LocalClientCommandId(
+                frame.client_command_id.0,
+            ),
+            notice: client_notice_to_local(frame.notice),
+        })),
+    }
+}
+
+fn client_snapshot_to_local(snapshot: ClientSnapshot) -> LocalClientSnapshot {
+    LocalClientSnapshot {
+        generated_at: snapshot.generated_at.0,
+        tasks: snapshot
+            .tasks
+            .into_iter()
+            .map(|task| LocalTaskProjection {
+                task_id: task.task_id.0,
+                status: match task.status {
+                    selvedge_command_model::TaskProjectionStatus::Active => {
+                        LocalTaskProjectionStatus::Active
+                    }
+                    selvedge_command_model::TaskProjectionStatus::Archived => {
+                        LocalTaskProjectionStatus::Archived
+                    }
+                },
+                cursor_node_id: task.cursor_node_id.0,
+                model_profile_key: task.model_profile_key.0,
+                reasoning_effort: reasoning_effort_to_local(task.reasoning_effort),
+                state_version: task.state_version,
+                created_at: task.created_at.0,
+                updated_at: task.updated_at.0,
+            })
+            .collect(),
+        task_parent_edges: snapshot
+            .task_parent_edges
+            .into_iter()
+            .map(|edge| LocalTaskParentProjection {
+                parent_task_id: edge.parent_task_id.0,
+                child_task_id: edge.child_task_id.0,
+            })
+            .collect(),
+        history_nodes: snapshot
+            .history_nodes
+            .into_iter()
+            .map(history_node_to_local)
+            .collect(),
+        task_versions: snapshot
+            .task_versions
+            .into_iter()
+            .map(|version| LocalSnapshotTaskVersion {
+                task_id: version.task_id.0,
+                state_version: version.state_version,
+            })
+            .collect(),
+    }
+}
+
+fn history_node_to_local(
+    node: selvedge_command_model::HistoryNodeProjection,
+) -> LocalHistoryNodeProjection {
+    LocalHistoryNodeProjection {
+        node_id: node.node_id.0,
+        parent_node_id: node.parent_node_id.map(|id| id.0),
+        created_at: node.created_at.0,
+        body: match node.body {
+            selvedge_command_model::HistoryNodeProjectionBody::Message { role, text } => {
+                LocalHistoryNodeProjectionBody::Message {
+                    role: message_role_to_local(role),
+                    text,
+                }
+            }
+            selvedge_command_model::HistoryNodeProjectionBody::Reasoning { text } => {
+                LocalHistoryNodeProjectionBody::Reasoning { text }
+            }
+            selvedge_command_model::HistoryNodeProjectionBody::FunctionCall {
+                function_call_id,
+                tool_name,
+                arguments,
+            } => LocalHistoryNodeProjectionBody::FunctionCall {
+                function_call_id: function_call_id.0,
+                tool_name: tool_name.0,
+                arguments: arguments
+                    .into_iter()
+                    .map(|argument| LocalToolCallArgument {
+                        name: argument.name.0,
+                        value: tool_argument_value_to_local(argument.value),
+                    })
+                    .collect(),
+            },
+            selvedge_command_model::HistoryNodeProjectionBody::FunctionOutput {
+                function_call_node_id,
+                function_call_id,
+                tool_name,
+                output_text,
+                is_error,
+            } => LocalHistoryNodeProjectionBody::FunctionOutput {
+                function_call_node_id: function_call_node_id.0,
+                function_call_id: function_call_id.0,
+                tool_name: tool_name.0,
+                output_text,
+                is_error,
+            },
+        },
+    }
+}
+
+fn client_event_to_local(event: ClientEvent) -> LocalClientEvent {
+    match event {
+        ClientEvent::TaskChanged(event) => {
+            LocalClientEvent::TaskChanged(selvedge_local_protocol::LocalTaskChangedEvent {
+                task: client_snapshot_to_local(ClientSnapshot {
+                    generated_at: selvedge_domain_model::UnixTs(0),
+                    tasks: vec![event.task],
+                    task_parent_edges: Vec::new(),
+                    history_nodes: Vec::new(),
+                    task_versions: Vec::new(),
+                })
+                .tasks
+                .remove(0),
+            })
+        }
+        ClientEvent::HistoryAppended(event) => {
+            LocalClientEvent::HistoryAppended(selvedge_local_protocol::LocalHistoryAppendedEvent {
+                task_id: event.task_id.0,
+                task_state_version: event.task_state_version,
+                appended_nodes: event
+                    .appended_nodes
+                    .into_iter()
+                    .map(history_node_to_local)
+                    .collect(),
+            })
+        }
+        ClientEvent::ModelCallStatus(event) => {
+            LocalClientEvent::ModelCallStatus(LocalModelCallStatusEvent {
+                task_id: event.task_id.0,
+                model_call_id: event.model_call_id.0,
+                phase: model_phase_to_local(event.phase),
+            })
+        }
+        ClientEvent::ToolExecutionStatus(event) => {
+            LocalClientEvent::ToolExecutionStatus(LocalToolExecutionStatusEvent {
+                task_id: event.task_id.0,
+                tool_execution_run_id: event.tool_execution_run_id.0,
+                function_call_node_id: event.function_call_node_id.0,
+                tool_name: event.tool_name.0,
+                phase: tool_phase_to_local(event.phase),
+            })
+        }
+        ClientEvent::DebugNotice(event) => {
+            LocalClientEvent::DebugNotice(selvedge_local_protocol::LocalDebugNoticeEvent {
+                task_id: event.task_id.map(|id| id.0),
+                message_text: event.message_text,
+            })
+        }
+    }
+}
+
+fn local_subscription_to_command(
+    subscription: &selvedge_local_protocol::LocalClientSubscription,
+) -> ClientSubscription {
+    ClientSubscription {
+        task_scope: match &subscription.task_scope {
+            LocalTaskScope::AllTasks => TaskScope::AllTasks,
+            LocalTaskScope::TaskIds(task_ids) => TaskScope::TaskIds(
+                task_ids
+                    .iter()
+                    .map(|task_id| selvedge_command_model::TaskId(task_id.clone()))
+                    .collect(),
+            ),
+        },
+        detail_level: match subscription.detail_level {
+            LocalDetailLevel::Summary => DetailLevel::Summary,
+            LocalDetailLevel::Verbose => DetailLevel::Verbose,
+        },
+        include_model_call_status: subscription.include_model_call_status,
+        include_tool_execution_status: subscription.include_tool_execution_status,
+        include_debug_notices: subscription.include_debug_notices,
+    }
+}
+
+fn client_notice_to_local(notice: ClientNotice) -> LocalNotice {
+    LocalNotice {
+        level: match notice.level {
+            ClientNoticeLevel::Info => LocalNoticeLevel::Info,
+            ClientNoticeLevel::Warning => LocalNoticeLevel::Warning,
+            ClientNoticeLevel::Error => LocalNoticeLevel::Error,
+        },
+        message_text: notice.message_text,
+    }
+}
+
+fn reasoning_effort_to_local(
+    effort: selvedge_domain_model::ReasoningEffort,
+) -> LocalReasoningEffort {
+    match effort {
+        selvedge_domain_model::ReasoningEffort::Minimal => LocalReasoningEffort::Minimal,
+        selvedge_domain_model::ReasoningEffort::Low => LocalReasoningEffort::Low,
+        selvedge_domain_model::ReasoningEffort::Medium => LocalReasoningEffort::Medium,
+        selvedge_domain_model::ReasoningEffort::High => LocalReasoningEffort::High,
+    }
+}
+
+fn message_role_to_local(role: selvedge_domain_model::MessageRole) -> LocalMessageRole {
+    match role {
+        selvedge_domain_model::MessageRole::System => LocalMessageRole::System,
+        selvedge_domain_model::MessageRole::Developer => LocalMessageRole::Developer,
+        selvedge_domain_model::MessageRole::User => LocalMessageRole::User,
+        selvedge_domain_model::MessageRole::Assistant => LocalMessageRole::Assistant,
+        selvedge_domain_model::MessageRole::Tool => LocalMessageRole::Tool,
+    }
+}
+
+fn tool_argument_value_to_local(
+    value: selvedge_domain_model::ToolArgumentValue,
+) -> LocalToolArgumentValue {
+    match value {
+        selvedge_domain_model::ToolArgumentValue::String(value) => {
+            LocalToolArgumentValue::String(value)
+        }
+        selvedge_domain_model::ToolArgumentValue::Integer(value) => {
+            LocalToolArgumentValue::Integer(value)
+        }
+        selvedge_domain_model::ToolArgumentValue::Number(value) => {
+            LocalToolArgumentValue::Number(value)
+        }
+        selvedge_domain_model::ToolArgumentValue::Boolean(value) => {
+            LocalToolArgumentValue::Boolean(value)
+        }
+    }
+}
+
+fn model_phase_to_local(
+    phase: selvedge_command_model::ModelCallStatusPhase,
+) -> LocalModelCallStatusPhase {
+    match phase {
+        selvedge_command_model::ModelCallStatusPhase::Requested => {
+            LocalModelCallStatusPhase::Requested
+        }
+        selvedge_command_model::ModelCallStatusPhase::Completed => {
+            LocalModelCallStatusPhase::Completed
+        }
+        selvedge_command_model::ModelCallStatusPhase::Failed => LocalModelCallStatusPhase::Failed,
+        selvedge_command_model::ModelCallStatusPhase::Discarded => {
+            LocalModelCallStatusPhase::Discarded
+        }
+    }
+}
+
+fn tool_phase_to_local(
+    phase: selvedge_command_model::ToolExecutionStatusPhase,
+) -> LocalToolExecutionStatusPhase {
+    match phase {
+        selvedge_command_model::ToolExecutionStatusPhase::Requested => {
+            LocalToolExecutionStatusPhase::Requested
+        }
+        selvedge_command_model::ToolExecutionStatusPhase::Completed => {
+            LocalToolExecutionStatusPhase::Completed
+        }
+        selvedge_command_model::ToolExecutionStatusPhase::Failed => {
+            LocalToolExecutionStatusPhase::Failed
+        }
+        selvedge_command_model::ToolExecutionStatusPhase::Discarded => {
+            LocalToolExecutionStatusPhase::Discarded
+        }
+    }
+}
+
+fn validate_bind_target(bind_target: &LocalhostBindTarget) -> Result<(), ServerStartupError> {
+    match bind_target {
+        LocalhostBindTarget::Ipv4 { .. } | LocalhostBindTarget::Ipv6 { .. } => Ok(()),
+    }
+}
+
+fn local_bind_to_web_bind(
+    bind_target: LocalhostBindTarget,
+) -> Result<WebLocalhostBind, ServerStartupError> {
+    Ok(match bind_target {
+        LocalhostBindTarget::Ipv4 { port } => WebLocalhostBind {
+            host: WebLocalhostHost::Ipv4Loopback,
+            port,
+        },
+        LocalhostBindTarget::Ipv6 { port } => WebLocalhostBind {
+            host: WebLocalhostHost::Ipv6Loopback,
+            port,
+        },
+    })
+}
+
+fn resolve_home(explicit_home: Option<PathBuf>) -> Result<PathBuf, ServerStartupError> {
+    if let Some(home) = explicit_home {
+        return Ok(home);
+    }
+
+    selvedge_config::selvedge_home()
+        .map_err(|error| ServerStartupError::ConfigInitFailed(error.to_string()))
+}
+
+fn init_config(explicit_home: Option<&PathBuf>) -> Result<(), ServerStartupError> {
+    let result = if let Some(home) = explicit_home {
+        selvedge_config::init_with_home(home)
+    } else {
+        selvedge_config::init()
+    };
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if error.to_string().contains("already") => Ok(()),
+        Err(error) => Err(ServerStartupError::ConfigInitFailed(error.to_string())),
+    }
+}
+
+fn init_logging() -> Result<(), ServerStartupError> {
+    match selvedge_logging::init() {
+        Ok(()) => Ok(()),
+        Err(error) if error.to_string().contains("already") => Ok(()),
+        Err(error) => Err(ServerStartupError::LoggingInitFailed(error.to_string())),
+    }
+}
+
+fn acquire_singleton_lock(home: &Path) -> Result<File, ServerStartupError> {
+    std::fs::create_dir_all(home).map_err(|error| {
+        ServerStartupError::ConfigInitFailed(format!("failed to create home directory: {error}"))
+    })?;
+
+    match OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(lock_path_for_home(home))
+    {
+        Ok(file) => Ok(file),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            Err(ServerStartupError::SingletonAlreadyRunning)
+        }
+        Err(error) => Err(ServerStartupError::ConfigInitFailed(error.to_string())),
+    }
+}
+
+fn sqlite_path_for_home(home: &Path) -> PathBuf {
+    home.join(SQLITE_FILE_NAME)
+}
+
+fn lock_path_for_home(home: &Path) -> PathBuf {
+    home.join(LOCK_FILE_NAME)
+}
+
+fn map_events_start_error(error: SpawnEventsError) -> ServerStartupError {
+    ServerStartupError::EventsStartFailed(format!("{error:?}"))
+}
+
+fn map_client_sync_start_error(error: SpawnClientSyncError) -> ServerStartupError {
+    ServerStartupError::ClientSyncStartFailed(format!("{error:?}"))
+}
+
+fn map_router_start_error(error: SpawnRouterError) -> ServerStartupError {
+    ServerStartupError::RouterStartFailed(format!("{error:?}"))
+}
+
+fn map_web_start_error(error: WebStartError) -> ServerStartupError {
+    match error {
+        WebStartError::InvalidBindTarget => ServerStartupError::InvalidBindTarget,
+        WebStartError::BindFailed(message) => ServerStartupError::LocalhostBindFailed(message),
+        WebStartError::TokioSpawnFailed => {
+            ServerStartupError::LocalhostBindFailed("tokio spawn failed".to_owned())
+        }
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -330,37 +330,66 @@ fn start_server_after_lock(
     home: PathBuf,
     singleton_lock: File,
 ) -> Result<ServerContext, ServerStartupError> {
-    init_logging()?;
+    if let Err(error) = init_logging() {
+        cleanup_startup_lock(&home);
+        return Err(error);
+    }
 
-    let db = open_db(OpenDbOptions {
+    let db = match open_db(OpenDbOptions {
         sqlite_path: sqlite_path_for_home(&home).to_string_lossy().to_string(),
-    })
-    .map_err(|error| ServerStartupError::DbOpenFailed(error.to_string()))?;
+    }) {
+        Ok(db) => db,
+        Err(error) => {
+            cleanup_startup_lock(&home);
+            return Err(ServerStartupError::DbOpenFailed(error.to_string()));
+        }
+    };
 
-    let events = spawn_events_task(EventsStartArgs {
+    let events = match spawn_events_task(EventsStartArgs {
         ingress_capacity: DEFAULT_EVENTS_INGRESS_CAPACITY,
         client_registry_capacity: DEFAULT_CLIENT_REGISTRY_CAPACITY,
         hydration_buffer_capacity: DEFAULT_HYDRATION_BUFFER_CAPACITY,
-    })
-    .map_err(map_events_start_error)?;
+    }) {
+        Ok(events) => events,
+        Err(error) => {
+            cleanup_startup_lock(&home);
+            return Err(map_events_start_error(error));
+        }
+    };
 
-    let client_sync = spawn_client_sync(ClientSyncStartArgs {
+    let client_sync = match spawn_client_sync(ClientSyncStartArgs {
         events_tx: events.ingress_tx.clone(),
         snapshot_builder: args.snapshot_builder,
         ingress_capacity: DEFAULT_CLIENT_SYNC_INGRESS_CAPACITY,
-    })
-    .map_err(map_client_sync_start_error)?;
+    }) {
+        Ok(client_sync) => client_sync,
+        Err(error) => {
+            cleanup_startup_lock(&home);
+            return Err(map_client_sync_start_error(error));
+        }
+    };
 
-    let router = selvedge_router::spawn_router(RouterStartArgs {
+    let router = match selvedge_router::spawn_router(RouterStartArgs {
         db,
         events_tx: events.ingress_tx.clone(),
         api_config: args.api_config,
         tool_executor: args.tool_executor,
         core_spawn_deps: args.core_spawn_deps,
-    })
-    .map_err(map_router_start_error)?;
+    }) {
+        Ok(router) => router,
+        Err(error) => {
+            cleanup_startup_lock(&home);
+            return Err(map_router_start_error(error));
+        }
+    };
 
-    let web = start_web(args.web_binding, &args.command_mapper)?;
+    let web = match start_web(args.web_binding, &args.command_mapper) {
+        Ok(web) => web,
+        Err(error) => {
+            cleanup_startup_lock(&home);
+            return Err(error);
+        }
+    };
 
     let inner = Arc::new(ServerInner {
         state: RwLock::new(ServerRuntimeState::Ready),
@@ -376,6 +405,10 @@ fn start_server_after_lock(
     let join_handle = spawn_server_join_task(inner.clone(), router, events, client_sync, web);
 
     Ok(ServerContext { inner, join_handle })
+}
+
+fn cleanup_startup_lock(home: &Path) {
+    let _ = std::fs::remove_file(lock_path_for_home(home));
 }
 
 fn spawn_server_join_task(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -763,11 +763,26 @@ impl futures_core::Stream for ServerAttachFrameStream {
         match this.inner.poll_recv(context) {
             Poll::Ready(Some(frame)) => Poll::Ready(Some(Ok(client_frame_to_local(frame)))),
             Poll::Ready(None) => {
-                clear_active_attach(
-                    &this.active_attaches,
-                    &this.client_id,
-                    &this.client_command_id,
-                );
+                let client_id = this.client_id.clone();
+                let client_command_id = this.client_command_id.clone();
+                if let Some(client_sync_tx) = this.client_sync_tx.upgrade() {
+                    send_cancel_hydration(
+                        &client_sync_tx,
+                        client_id.clone(),
+                        client_command_id.clone(),
+                    );
+                }
+                if let Some(events_tx) = this.events_tx.upgrade() {
+                    send_detach_client_and_clear_active(
+                        &events_tx,
+                        client_id,
+                        client_command_id,
+                        DetachReason::ClientDisconnected,
+                        Arc::clone(&this.active_attaches),
+                    );
+                } else {
+                    clear_active_attach(&this.active_attaches, &client_id, &client_command_id);
+                }
                 this.closed_reported = true;
                 Poll::Ready(Some(Err(ServerRequestError::AttachChannelFailed)))
             }
@@ -1692,7 +1707,7 @@ mod tests {
     async fn closed_frame_channel_clears_active_attach_before_stream_drop() {
         let router_tx = accepting_router_sender();
         let (client_sync_tx, mut client_sync_rx) = mpsc::channel(4);
-        let (events_tx, _events_rx) = mpsc::channel(4);
+        let (events_tx, mut events_rx) = mpsc::channel(4);
         let control = test_control(router_tx, client_sync_tx, events_tx);
 
         let (_accepted, mut stream) = control
@@ -1711,6 +1726,35 @@ mod tests {
             .expect("stream terminal item")
             .expect_err("closed frame channel reports error");
         assert_eq!(error, ServerRequestError::AttachChannelFailed);
+        match timeout(Duration::from_millis(100), client_sync_rx.recv())
+            .await
+            .expect("channel close cancel arrives")
+            .expect("channel close cancel")
+        {
+            ClientSyncIngress::CancelHydration(cancel) => {
+                assert_eq!(cancel.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    cancel.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+            }
+            _ => panic!("unexpected client-sync ingress"),
+        }
+        match timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("channel close detach arrives")
+            .expect("channel close detach")
+        {
+            EventIngress::Control(EventControlMessage::DetachClient(detach)) => {
+                assert_eq!(detach.client_id, ClientId("client-1".to_owned()));
+                assert_eq!(
+                    detach.client_command_id,
+                    ClientCommandId("attach-1".to_owned())
+                );
+                assert_eq!(detach.reason, DetachReason::ClientDisconnected);
+            }
+            _ => panic!("unexpected events ingress"),
+        }
 
         let (_accepted, _retry_stream) = control
             .attach_client(test_attach_request())

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -147,17 +147,15 @@ pub async fn run_server(args: ServerStartArgs) -> ServerExitStatus {
 pub fn spawn_server(args: ServerStartArgs) -> Result<ServerHandle, ServerStartupError> {
     validate_bind_target(&args.local_binding.bind_target)?;
     if let Some(web_binding) = &args.web_binding {
-        validate_bind_target(&web_binding.bind_target)?;
+        validate_web_bind_target(&web_binding.bind_target)?;
     }
 
     init_config(args.explicit_home.as_ref())?;
     let home = resolve_home(args.explicit_home.clone())?;
     let singleton_lock = acquire_singleton_lock(&home)?;
 
-    let startup_home = home.clone();
     let startup_result = start_server_after_lock(args, home, singleton_lock);
     if let Err(error) = &startup_result {
-        let _ = std::fs::remove_file(lock_path_for_home(&startup_home));
         return Err(error.clone());
     }
 
@@ -468,6 +466,15 @@ impl WebBridge for ServerWebBridge {
 
 fn validate_bind_target(bind_target: &LocalhostBindTarget) -> Result<(), ServerStartupError> {
     match bind_target {
+        LocalhostBindTarget::Ipv4 { .. } | LocalhostBindTarget::Ipv6 { .. } => Ok(()),
+    }
+}
+
+fn validate_web_bind_target(bind_target: &LocalhostBindTarget) -> Result<(), ServerStartupError> {
+    match bind_target {
+        LocalhostBindTarget::Ipv4 { port } | LocalhostBindTarget::Ipv6 { port } if *port == 0 => {
+            Err(ServerStartupError::InvalidBindTarget)
+        }
         LocalhostBindTarget::Ipv4 { .. } | LocalhostBindTarget::Ipv6 { .. } => Ok(()),
     }
 }

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -160,6 +160,32 @@ async fn invalid_web_bind_target_is_rejected_before_durable_startup_side_effects
 }
 
 #[tokio::test]
+async fn occupied_web_bind_target_is_rejected_before_runtime_tasks_start() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let sqlite_path = home.join("selvedge.sqlite");
+    let lock_path = home.join("server.lock");
+    let _ = std::fs::remove_file(&lock_path);
+    let _ = std::fs::remove_file(&sqlite_path);
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind occupied port");
+    let port = listener.local_addr().expect("occupied addr").port();
+
+    let mut args = test_args(home.to_path_buf(), Arc::new(RecordingMapper::new()));
+    args.web_binding = Some(WebBindingConfig {
+        bind_target: LocalhostBindTarget::Ipv4 { port },
+    });
+
+    let failed = spawn_server(args);
+
+    assert!(matches!(
+        failed,
+        Err(ServerStartupError::LocalhostBindFailed(_))
+    ));
+    assert!(!sqlite_path.exists());
+    assert!(!lock_path.exists());
+}
+
+#[tokio::test]
 async fn command_submit_validates_protocol_and_maps_to_router_mailbox() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -1,0 +1,314 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use selvedge_api::ApiExecutorConfig;
+use selvedge_client_sync::{
+    ClientSnapshotBuildFuture, ClientSnapshotBuildRequest, ClientSnapshotBuilder,
+};
+use selvedge_command_model::{
+    ClientSnapshot, RouterCommand, RouterCommandEnvelope, RouterIngressWeakSender,
+    ToolExecutionRequest,
+};
+use selvedge_core::{TaskRuntimeConfig, TaskRuntimeSpawnDeps};
+use selvedge_domain_model::{ModelProfileKey, UnixTs};
+use selvedge_local_protocol::{
+    AttachRequest, CommandOutcome, CommandRejectReason, CommandRequest, LocalClientCommandId,
+    LocalClientId, LocalClientSubscription, LocalDetailLevel, LocalTaskScope, ProtocolVersion,
+    ReadyRequest, ReadyState, current_protocol_version,
+};
+use selvedge_router::{ToolExecutionSpawnError, ToolExecutionSpawner};
+use selvedge_server::{
+    LocalBindingConfig, LocalCommandMapper, LocalhostBindTarget, ServerRequestError,
+    ServerRuntimeState, ServerStartArgs, ServerStartupError, spawn_server,
+};
+use tempfile::TempDir;
+use tokio::task::JoinHandle;
+
+#[tokio::test]
+async fn spawn_server_initializes_ready_control_and_creates_durable_paths() {
+    let home = TempDir::new().expect("temp home");
+    let mapper = Arc::new(RecordingMapper::new());
+
+    let handle =
+        spawn_server(test_args(home.path().to_path_buf(), mapper.clone())).expect("spawn server");
+
+    assert_eq!(handle.control.state().await, ServerRuntimeState::Ready);
+    assert_eq!(
+        handle
+            .control
+            .ready(ReadyRequest {
+                protocol_version: current_protocol_version()
+            })
+            .await
+            .state,
+        ReadyState::Ready
+    );
+    assert!(home.path().join("selvedge.sqlite").exists());
+    assert!(home.path().join("server.lock").exists());
+
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+    assert_eq!(handle.control.state().await, ServerRuntimeState::Stopped);
+    assert!(!home.path().join("server.lock").exists());
+}
+
+#[tokio::test]
+async fn singleton_lock_rejects_second_server_for_same_home() {
+    let home = TempDir::new().expect("temp home");
+    let first = spawn_server(test_args(
+        home.path().to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("spawn first server");
+
+    let second = spawn_server(test_args(
+        home.path().to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ));
+
+    assert!(matches!(
+        second,
+        Err(ServerStartupError::SingletonAlreadyRunning)
+    ));
+
+    first.control.stop().await;
+    first.join_handle.await.expect("join first server");
+}
+
+#[tokio::test]
+async fn command_submit_validates_protocol_and_maps_to_router_mailbox() {
+    let home = TempDir::new().expect("temp home");
+    let mapper = Arc::new(RecordingMapper::new());
+    let handle =
+        spawn_server(test_args(home.path().to_path_buf(), mapper.clone())).expect("spawn server");
+
+    let invalid = handle
+        .control
+        .submit_command(CommandRequest {
+            protocol_version: ProtocolVersion(2),
+            ..valid_command("bad-version")
+        })
+        .await;
+    assert_eq!(
+        invalid.outcome,
+        CommandOutcome::Rejected(CommandRejectReason::ProtocolVersionMismatch)
+    );
+
+    let accepted = handle
+        .control
+        .submit_command(valid_command("command-1"))
+        .await;
+    assert_eq!(accepted.outcome, CommandOutcome::Accepted);
+    assert_eq!(mapper.seen_commands(), vec!["send-user-input".to_owned()]);
+
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
+async fn command_mapper_can_reject_unsupported_local_command() {
+    let home = TempDir::new().expect("temp home");
+    let handle = spawn_server(test_args(
+        home.path().to_path_buf(),
+        Arc::new(RejectingMapper),
+    ))
+    .expect("spawn server");
+
+    let rejected = handle
+        .control
+        .submit_command(valid_command("command-1"))
+        .await;
+
+    assert_eq!(
+        rejected.outcome,
+        CommandOutcome::Rejected(CommandRejectReason::UnsupportedCommand)
+    );
+
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
+async fn attach_client_accepts_valid_subscription_and_rejects_malformed_request() {
+    let home = TempDir::new().expect("temp home");
+    let handle = spawn_server(test_args(
+        home.path().to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("spawn server");
+
+    let accepted = handle
+        .control
+        .attach_client(valid_attach("attach-1"))
+        .await
+        .expect("valid attach request");
+
+    assert_eq!(accepted.0.client_command_id.0, "attach-1");
+
+    let rejected = match handle
+        .control
+        .attach_client(AttachRequest {
+            protocol_version: current_protocol_version(),
+            client_id: LocalClientId::new("client-1").expect("valid client id"),
+            client_command_id: LocalClientCommandId::new("attach-2").expect("valid command id"),
+            subscription: LocalClientSubscription {
+                task_scope: LocalTaskScope::TaskIds(vec![" ".to_owned()]),
+                detail_level: LocalDetailLevel::Summary,
+                include_model_call_status: false,
+                include_tool_execution_status: false,
+                include_debug_notices: false,
+            },
+        })
+        .await
+    {
+        Ok(_) => panic!("malformed attach request should be rejected"),
+        Err(rejected) => rejected,
+    };
+
+    assert_eq!(rejected.reason, CommandRejectReason::MalformedRequest);
+
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
+async fn stopped_server_rejects_new_command_submissions() {
+    let home = TempDir::new().expect("temp home");
+    let handle = spawn_server(test_args(
+        home.path().to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("spawn server");
+
+    handle.control.stop().await;
+
+    let response = handle
+        .control
+        .submit_command(valid_command("command-1"))
+        .await;
+    assert_eq!(
+        response.outcome,
+        CommandOutcome::Rejected(CommandRejectReason::ServerNotReady)
+    );
+
+    handle.join_handle.await.expect("join server");
+}
+
+struct RejectingMapper;
+
+impl LocalCommandMapper for RejectingMapper {
+    fn map_command(
+        &self,
+        _request: CommandRequest,
+    ) -> Result<RouterCommandEnvelope, ServerRequestError> {
+        Err(ServerRequestError::UnsupportedCommand)
+    }
+}
+
+struct RecordingMapper {
+    seen: Mutex<Vec<String>>,
+}
+
+impl RecordingMapper {
+    fn new() -> Self {
+        Self {
+            seen: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn seen_commands(&self) -> Vec<String> {
+        self.seen.lock().expect("mapper lock").clone()
+    }
+}
+
+impl LocalCommandMapper for RecordingMapper {
+    fn map_command(
+        &self,
+        request: CommandRequest,
+    ) -> Result<RouterCommandEnvelope, ServerRequestError> {
+        self.seen
+            .lock()
+            .expect("mapper lock")
+            .push(request.command_name);
+        Ok(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureMissingTaskRuntimes,
+        })
+    }
+}
+
+struct EmptySnapshotBuilder;
+
+impl ClientSnapshotBuilder for EmptySnapshotBuilder {
+    fn build_snapshot(&self, _request: ClientSnapshotBuildRequest) -> ClientSnapshotBuildFuture {
+        Box::pin(async {
+            Ok(ClientSnapshot {
+                generated_at: UnixTs(1),
+                tasks: Vec::new(),
+                task_parent_edges: Vec::new(),
+                history_nodes: Vec::new(),
+                task_versions: Vec::new(),
+            })
+        })
+    }
+}
+
+struct NoopToolExecutor;
+
+impl ToolExecutionSpawner for NoopToolExecutor {
+    fn spawn_tool_execution(
+        &self,
+        _request: ToolExecutionRequest,
+        _router_tx: RouterIngressWeakSender,
+    ) -> Result<JoinHandle<()>, ToolExecutionSpawnError> {
+        Err(ToolExecutionSpawnError::ToolExecutorUnavailable)
+    }
+}
+
+fn test_args(home: std::path::PathBuf, mapper: Arc<dyn LocalCommandMapper>) -> ServerStartArgs {
+    ServerStartArgs {
+        explicit_home: Some(home),
+        api_config: ApiExecutorConfig {
+            request_timeout: Duration::from_secs(1),
+            max_response_bytes: None,
+        },
+        tool_executor: Arc::new(NoopToolExecutor),
+        core_spawn_deps: TaskRuntimeSpawnDeps::new(TaskRuntimeConfig {
+            mailbox_capacity: 4,
+            model_profiles: HashMap::<ModelProfileKey, _>::new(),
+        }),
+        snapshot_builder: Arc::new(EmptySnapshotBuilder),
+        command_mapper: mapper,
+        local_binding: LocalBindingConfig {
+            bind_target: LocalhostBindTarget::Ipv4 { port: 0 },
+        },
+        web_binding: None,
+    }
+}
+
+fn valid_command(command_id: &str) -> CommandRequest {
+    CommandRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_command_id: LocalClientCommandId::new(command_id).expect("valid command id"),
+        command_name: "send-user-input".to_owned(),
+        payload: serde_json::json!({"message": "hello"}),
+    }
+}
+
+fn valid_attach(command_id: &str) -> AttachRequest {
+    AttachRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_command_id: LocalClientCommandId::new(command_id).expect("valid command id"),
+        subscription: LocalClientSubscription {
+            task_scope: LocalTaskScope::AllTasks,
+            detail_level: LocalDetailLevel::Summary,
+            include_model_call_status: false,
+            include_tool_execution_status: false,
+            include_debug_notices: false,
+        },
+    }
+}

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -82,6 +82,22 @@ async fn singleton_lock_rejects_second_server_for_same_home() {
 }
 
 #[tokio::test]
+async fn stale_lock_file_does_not_block_server_restart() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    std::fs::write(home.join("server.lock"), "stale").expect("write stale lock");
+
+    let handle = spawn_server(test_args(
+        home.to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("spawn server with stale lock file");
+
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
 async fn command_submit_validates_protocol_and_maps_to_router_mailbox() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -20,7 +20,7 @@ use selvedge_local_protocol::{
 use selvedge_router::{ToolExecutionSpawnError, ToolExecutionSpawner};
 use selvedge_server::{
     LocalBindingConfig, LocalCommandMapper, LocalhostBindTarget, ServerRequestError,
-    ServerRuntimeState, ServerStartArgs, ServerStartupError, spawn_server,
+    ServerRuntimeState, ServerStartArgs, ServerStartupError, WebBindingConfig, spawn_server,
 };
 use tempfile::TempDir;
 use tokio::sync::Mutex as AsyncMutex;
@@ -106,6 +106,56 @@ async fn stale_lock_file_does_not_block_server_restart() {
 
     handle.control.stop().await;
     handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
+async fn startup_failure_after_lock_leaves_recoverable_lock_file() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let sqlite_path = home.join("selvedge.sqlite");
+    let lock_path = home.join("server.lock");
+    let _ = std::fs::remove_file(&lock_path);
+    let _ = std::fs::remove_file(&sqlite_path);
+    let _ = std::fs::remove_dir_all(&sqlite_path);
+    std::fs::create_dir(&sqlite_path).expect("create sqlite path directory");
+
+    let failed = spawn_server(test_args(
+        home.to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ));
+
+    assert!(matches!(failed, Err(ServerStartupError::DbOpenFailed(_))));
+    assert!(lock_path.exists());
+
+    std::fs::remove_dir(&sqlite_path).expect("remove sqlite path directory");
+    let restarted = spawn_server(test_args(
+        home.to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("stale lock file should remain recoverable");
+    restarted.control.stop().await;
+    restarted.join_handle.await.expect("join restarted server");
+}
+
+#[tokio::test]
+async fn invalid_web_bind_target_is_rejected_before_durable_startup_side_effects() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let sqlite_path = home.join("selvedge.sqlite");
+    let lock_path = home.join("server.lock");
+    let _ = std::fs::remove_file(&lock_path);
+    let _ = std::fs::remove_file(&sqlite_path);
+
+    let mut args = test_args(home.to_path_buf(), Arc::new(RecordingMapper::new()));
+    args.web_binding = Some(WebBindingConfig {
+        bind_target: LocalhostBindTarget::Ipv4 { port: 0 },
+    });
+
+    let failed = spawn_server(args);
+
+    assert!(matches!(failed, Err(ServerStartupError::InvalidBindTarget)));
+    assert!(!sqlite_path.exists());
+    assert!(!lock_path.exists());
 }
 
 #[tokio::test]

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -94,6 +94,32 @@ async fn singleton_lock_rejects_second_server_for_same_home() {
 }
 
 #[tokio::test]
+async fn singleton_lock_rejects_second_web_enabled_server_before_port_bind() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let port = unused_tcp_v4_port();
+    let mut first_args = test_args(home.to_path_buf(), Arc::new(RecordingMapper::new()));
+    first_args.web_binding = Some(WebBindingConfig {
+        bind_target: LocalhostBindTarget::Ipv4 { port },
+    });
+    let first = spawn_server(first_args).expect("spawn first server");
+
+    let mut second_args = test_args(home.to_path_buf(), Arc::new(RecordingMapper::new()));
+    second_args.web_binding = Some(WebBindingConfig {
+        bind_target: LocalhostBindTarget::Ipv4 { port },
+    });
+    let second = spawn_server(second_args);
+
+    assert!(matches!(
+        second,
+        Err(ServerStartupError::SingletonAlreadyRunning)
+    ));
+
+    first.control.stop().await;
+    first.join_handle.await.expect("join first server");
+}
+
+#[tokio::test]
 async fn stale_lock_file_does_not_block_server_restart() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();
@@ -525,6 +551,13 @@ fn test_args(home: std::path::PathBuf, mapper: Arc<dyn LocalCommandMapper>) -> S
         },
         web_binding: None,
     }
+}
+
+fn unused_tcp_v4_port() -> u16 {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind unused port");
+    let port = listener.local_addr().expect("unused addr").port();
+    drop(listener);
+    port
 }
 
 fn valid_command(command_id: &str) -> CommandRequest {

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -109,7 +109,7 @@ async fn stale_lock_file_does_not_block_server_restart() {
 }
 
 #[tokio::test]
-async fn startup_failure_after_lock_leaves_recoverable_lock_file() {
+async fn startup_failure_after_lock_removes_recoverable_lock_file() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();
     let sqlite_path = home.join("selvedge.sqlite");
@@ -125,7 +125,7 @@ async fn startup_failure_after_lock_leaves_recoverable_lock_file() {
     ));
 
     assert!(matches!(failed, Err(ServerStartupError::DbOpenFailed(_))));
-    assert!(lock_path.exists());
+    assert!(!lock_path.exists());
 
     std::fs::remove_dir(&sqlite_path).expect("remove sqlite path directory");
     let restarted = spawn_server(test_args(

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex, mpsc as std_mpsc};
 use std::time::Duration;
 
+use futures_util::StreamExt;
 use selvedge_api::ApiExecutorConfig;
 use selvedge_client_sync::{
     ClientSnapshotBuildFuture, ClientSnapshotBuildRequest, ClientSnapshotBuilder,
@@ -14,8 +15,8 @@ use selvedge_core::{TaskRuntimeConfig, TaskRuntimeSpawnDeps};
 use selvedge_domain_model::{ModelProfileKey, UnixTs};
 use selvedge_local_protocol::{
     AttachRequest, CommandOutcome, CommandRejectReason, CommandRequest, LocalClientCommandId,
-    LocalClientId, LocalClientSubscription, LocalDetailLevel, LocalTaskScope, ProtocolVersion,
-    ReadyRequest, ReadyState, current_protocol_version,
+    LocalClientFrame, LocalClientId, LocalClientSubscription, LocalDetailLevel, LocalTaskScope,
+    ProtocolVersion, ReadyRequest, ReadyState, current_protocol_version,
 };
 use selvedge_router::{ToolExecutionSpawnError, ToolExecutionSpawner};
 use selvedge_server::{
@@ -305,7 +306,7 @@ async fn command_mapper_can_reject_unsupported_local_command() {
 }
 
 #[tokio::test]
-async fn attach_client_defers_accepted_stream_until_client_sync_hydration_exists() {
+async fn attach_client_accepts_and_streams_initial_snapshot() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();
     let handle = spawn_server(test_args(
@@ -314,11 +315,21 @@ async fn attach_client_defers_accepted_stream_until_client_sync_hydration_exists
     ))
     .expect("spawn server");
 
-    let deferred = match handle.control.attach_client(valid_attach("attach-1")).await {
-        Ok(_) => panic!("server stage should defer accepted attach streams"),
-        Err(rejected) => rejected,
-    };
-    assert_eq!(deferred.reason, CommandRejectReason::ServerNotReady);
+    let (accepted, mut frames) = handle
+        .control
+        .attach_client(valid_attach("attach-1"))
+        .await
+        .expect("attach accepted");
+    assert_eq!(
+        accepted.client_command_id,
+        LocalClientCommandId::new("attach-1").expect("valid command id")
+    );
+    let frame = timeout(Duration::from_secs(1), frames.next())
+        .await
+        .expect("snapshot timeout")
+        .expect("snapshot frame")
+        .expect("snapshot frame ok");
+    assert!(matches!(frame, LocalClientFrame::Snapshot(_)));
 
     let rejected = match handle
         .control

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -168,6 +168,22 @@ async fn attach_client_accepts_valid_subscription_and_rejects_malformed_request(
 
     assert_eq!(rejected.reason, CommandRejectReason::MalformedRequest);
 
+    let version_mismatch = match handle
+        .control
+        .attach_client(AttachRequest {
+            protocol_version: ProtocolVersion(2),
+            ..valid_attach("attach-3")
+        })
+        .await
+    {
+        Ok(_) => panic!("version-mismatched attach request should be rejected"),
+        Err(rejected) => rejected,
+    };
+    assert_eq!(
+        version_mismatch.reason,
+        CommandRejectReason::ProtocolVersionMismatch
+    );
+
     handle.control.stop().await;
     handle.join_handle.await.expect("join server");
 }

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -374,6 +374,39 @@ async fn attach_client_accepts_and_streams_initial_snapshot() {
 }
 
 #[tokio::test]
+async fn dropped_attach_stream_detaches_events_session() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let handle = spawn_server(test_args(
+        home.to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("spawn server");
+
+    for index in 0..70 {
+        let (_accepted, mut frames) = handle
+            .control
+            .attach_client(valid_attach_for(
+                &format!("client-{index}"),
+                &format!("attach-{index}"),
+            ))
+            .await
+            .expect("attach accepted");
+        let frame = timeout(Duration::from_secs(1), frames.next())
+            .await
+            .expect("snapshot timeout")
+            .expect("snapshot frame")
+            .expect("snapshot frame ok");
+        assert!(matches!(frame, LocalClientFrame::Snapshot(_)));
+        drop(frames);
+        tokio::task::yield_now().await;
+    }
+
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
 async fn stopped_server_rejects_new_command_submissions() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();
@@ -582,9 +615,13 @@ fn valid_command(command_id: &str) -> CommandRequest {
 }
 
 fn valid_attach(command_id: &str) -> AttachRequest {
+    valid_attach_for("client-1", command_id)
+}
+
+fn valid_attach_for(client_id: &str, command_id: &str) -> AttachRequest {
     AttachRequest {
         protocol_version: current_protocol_version(),
-        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_id: LocalClientId::new(client_id).expect("valid client id"),
         client_command_id: LocalClientCommandId::new(command_id).expect("valid command id"),
         subscription: LocalClientSubscription {
             task_scope: LocalTaskScope::AllTasks,

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -160,7 +160,7 @@ async fn command_mapper_can_reject_unsupported_local_command() {
 }
 
 #[tokio::test]
-async fn attach_client_accepts_valid_subscription_and_rejects_malformed_request() {
+async fn attach_client_defers_accepted_stream_until_client_sync_hydration_exists() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();
     let handle = spawn_server(test_args(
@@ -169,13 +169,11 @@ async fn attach_client_accepts_valid_subscription_and_rejects_malformed_request(
     ))
     .expect("spawn server");
 
-    let accepted = handle
-        .control
-        .attach_client(valid_attach("attach-1"))
-        .await
-        .expect("valid attach request");
-
-    assert_eq!(accepted.0.client_command_id.0, "attach-1");
+    let deferred = match handle.control.attach_client(valid_attach("attach-1")).await {
+        Ok(_) => panic!("server stage should defer accepted attach streams"),
+        Err(rejected) => rejected,
+    };
+    assert_eq!(deferred.reason, CommandRejectReason::ServerNotReady);
 
     let rejected = match handle
         .control

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -54,7 +54,7 @@ async fn spawn_server_initializes_ready_control_and_creates_durable_paths() {
     let mismatched_ready = handle
         .control
         .ready(ReadyRequest {
-            protocol_version: ProtocolVersion(2),
+            protocol_version: ProtocolVersion(3),
         })
         .await;
     assert_eq!(
@@ -223,7 +223,7 @@ async fn command_submit_validates_protocol_and_maps_to_router_mailbox() {
     let invalid = handle
         .control
         .submit_command(CommandRequest {
-            protocol_version: ProtocolVersion(2),
+            protocol_version: ProtocolVersion(3),
             ..valid_command("bad-version")
         })
         .await;
@@ -357,7 +357,7 @@ async fn attach_client_accepts_and_streams_initial_snapshot() {
     let version_mismatch = match handle
         .control
         .attach_client(AttachRequest {
-            protocol_version: ProtocolVersion(2),
+            protocol_version: ProtocolVersion(3),
             ..valid_attach("attach-3")
         })
         .await

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -14,9 +14,10 @@ use selvedge_command_model::{
 use selvedge_core::{TaskRuntimeConfig, TaskRuntimeSpawnDeps};
 use selvedge_domain_model::{ModelProfileKey, UnixTs};
 use selvedge_local_protocol::{
-    AttachRequest, CommandOutcome, CommandRejectReason, CommandRequest, LocalClientCommandId,
-    LocalClientFrame, LocalClientId, LocalClientSubscription, LocalDetailLevel, LocalTaskScope,
-    ProtocolVersion, ReadyRequest, ReadyState, current_protocol_version,
+    AttachRejectReason, AttachRequest, CommandOutcome, CommandRejectReason, CommandRequest,
+    LocalClientCommandId, LocalClientFrame, LocalClientId, LocalClientSubscription,
+    LocalDetailLevel, LocalTaskScope, ProtocolVersion, ReadyRequest, ReadyState,
+    current_protocol_version,
 };
 use selvedge_router::{ToolExecutionSpawnError, ToolExecutionSpawner};
 use selvedge_server::{
@@ -351,7 +352,7 @@ async fn attach_client_accepts_and_streams_initial_snapshot() {
         Err(rejected) => rejected,
     };
 
-    assert_eq!(rejected.reason, CommandRejectReason::MalformedRequest);
+    assert_eq!(rejected.reason, AttachRejectReason::MalformedRequest);
 
     let version_mismatch = match handle
         .control
@@ -366,7 +367,7 @@ async fn attach_client_accepts_and_streams_initial_snapshot() {
     };
     assert_eq!(
         version_mismatch.reason,
-        CommandRejectReason::ProtocolVersionMismatch
+        AttachRejectReason::ProtocolVersionMismatch
     );
 
     handle.control.stop().await;

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, mpsc as std_mpsc};
 use std::time::Duration;
 
 use selvedge_api::ApiExecutorConfig;
@@ -25,6 +25,7 @@ use selvedge_server::{
 use tempfile::TempDir;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
+use tokio::time::timeout;
 
 static SERVER_TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
 static SERVER_TEST_HOME: LazyLock<TempDir> = LazyLock::new(|| TempDir::new().expect("temp home"));
@@ -189,6 +190,48 @@ async fn command_submit_validates_protocol_and_maps_to_router_mailbox() {
 }
 
 #[tokio::test]
+async fn stop_waits_for_in_flight_command_acceptance_decision() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let (entered_tx, entered_rx) = std_mpsc::channel();
+    let (release_tx, release_rx) = std_mpsc::channel();
+    let handle = spawn_server(test_args(
+        home.to_path_buf(),
+        Arc::new(BlockingMapper {
+            entered_tx,
+            release_rx: Mutex::new(release_rx),
+        }),
+    ))
+    .expect("spawn server");
+
+    let runtime_handle = tokio::runtime::Handle::current();
+    let submit_control = handle.control.clone();
+    let submit_thread = std::thread::spawn(move || {
+        runtime_handle.block_on(async move {
+            submit_control
+                .submit_command(valid_command("command-1"))
+                .await
+        })
+    });
+    entered_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("mapper should enter command acceptance");
+
+    let stop_control = handle.control.clone();
+    let mut stop_task = tokio::spawn(async move { stop_control.stop().await });
+    let stop_waited = timeout(Duration::from_millis(50), &mut stop_task)
+        .await
+        .is_err();
+
+    release_tx.send(()).expect("release mapper");
+    assert!(stop_waited);
+    let response = submit_thread.join().expect("join submit thread");
+    assert_eq!(response.outcome, CommandOutcome::Accepted);
+    stop_task.await.expect("join stop task");
+    handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
 async fn command_mapper_can_reject_unsupported_local_command() {
     let _guard = SERVER_TEST_LOCK.lock().await;
     let home = SERVER_TEST_HOME.path();
@@ -315,6 +358,32 @@ async fn initialized_config_rejects_mismatched_explicit_home() {
     ));
 }
 
+#[tokio::test]
+async fn relative_explicit_home_cleans_lock_after_working_directory_changes() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let parent = home.parent().expect("temp home parent").to_path_buf();
+    let home_name = home.file_name().expect("temp home name").to_os_string();
+    let original_cwd = std::env::current_dir().expect("current dir");
+    let _ = std::fs::remove_file(home.join("server.lock"));
+
+    std::env::set_current_dir(&parent).expect("enter home parent");
+    let handle = spawn_server(test_args(
+        std::path::PathBuf::from(home_name),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("spawn server with relative home");
+    assert!(home.join("server.lock").exists());
+
+    let other_cwd = TempDir::new().expect("other cwd");
+    std::env::set_current_dir(other_cwd.path()).expect("change cwd");
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+    std::env::set_current_dir(original_cwd).expect("restore cwd");
+
+    assert!(!home.join("server.lock").exists());
+}
+
 struct RejectingMapper;
 
 impl LocalCommandMapper for RejectingMapper {
@@ -351,6 +420,30 @@ impl LocalCommandMapper for RecordingMapper {
             .lock()
             .expect("mapper lock")
             .push(request.command_name);
+        Ok(RouterCommandEnvelope {
+            client_id: None,
+            client_command_id: None,
+            command: RouterCommand::EnsureMissingTaskRuntimes,
+        })
+    }
+}
+
+struct BlockingMapper {
+    entered_tx: std_mpsc::Sender<()>,
+    release_rx: Mutex<std_mpsc::Receiver<()>>,
+}
+
+impl LocalCommandMapper for BlockingMapper {
+    fn map_command(
+        &self,
+        _request: CommandRequest,
+    ) -> Result<RouterCommandEnvelope, ServerRequestError> {
+        self.entered_tx.send(()).expect("send mapper entry");
+        self.release_rx
+            .lock()
+            .expect("release lock")
+            .recv_timeout(Duration::from_secs(1))
+            .expect("mapper release");
         Ok(RouterCommandEnvelope {
             client_id: None,
             client_command_id: None,

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use selvedge_api::ApiExecutorConfig;
@@ -23,15 +23,19 @@ use selvedge_server::{
     ServerRuntimeState, ServerStartArgs, ServerStartupError, spawn_server,
 };
 use tempfile::TempDir;
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
+
+static SERVER_TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
+static SERVER_TEST_HOME: LazyLock<TempDir> = LazyLock::new(|| TempDir::new().expect("temp home"));
 
 #[tokio::test]
 async fn spawn_server_initializes_ready_control_and_creates_durable_paths() {
-    let home = TempDir::new().expect("temp home");
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
     let mapper = Arc::new(RecordingMapper::new());
 
-    let handle =
-        spawn_server(test_args(home.path().to_path_buf(), mapper.clone())).expect("spawn server");
+    let handle = spawn_server(test_args(home.to_path_buf(), mapper.clone())).expect("spawn server");
 
     assert_eq!(handle.control.state().await, ServerRuntimeState::Ready);
     assert_eq!(
@@ -44,26 +48,27 @@ async fn spawn_server_initializes_ready_control_and_creates_durable_paths() {
             .state,
         ReadyState::Ready
     );
-    assert!(home.path().join("selvedge.sqlite").exists());
-    assert!(home.path().join("server.lock").exists());
+    assert!(home.join("selvedge.sqlite").exists());
+    assert!(home.join("server.lock").exists());
 
     handle.control.stop().await;
     handle.join_handle.await.expect("join server");
     assert_eq!(handle.control.state().await, ServerRuntimeState::Stopped);
-    assert!(!home.path().join("server.lock").exists());
+    assert!(!home.join("server.lock").exists());
 }
 
 #[tokio::test]
 async fn singleton_lock_rejects_second_server_for_same_home() {
-    let home = TempDir::new().expect("temp home");
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
     let first = spawn_server(test_args(
-        home.path().to_path_buf(),
+        home.to_path_buf(),
         Arc::new(RecordingMapper::new()),
     ))
     .expect("spawn first server");
 
     let second = spawn_server(test_args(
-        home.path().to_path_buf(),
+        home.to_path_buf(),
         Arc::new(RecordingMapper::new()),
     ));
 
@@ -78,10 +83,10 @@ async fn singleton_lock_rejects_second_server_for_same_home() {
 
 #[tokio::test]
 async fn command_submit_validates_protocol_and_maps_to_router_mailbox() {
-    let home = TempDir::new().expect("temp home");
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
     let mapper = Arc::new(RecordingMapper::new());
-    let handle =
-        spawn_server(test_args(home.path().to_path_buf(), mapper.clone())).expect("spawn server");
+    let handle = spawn_server(test_args(home.to_path_buf(), mapper.clone())).expect("spawn server");
 
     let invalid = handle
         .control
@@ -108,12 +113,10 @@ async fn command_submit_validates_protocol_and_maps_to_router_mailbox() {
 
 #[tokio::test]
 async fn command_mapper_can_reject_unsupported_local_command() {
-    let home = TempDir::new().expect("temp home");
-    let handle = spawn_server(test_args(
-        home.path().to_path_buf(),
-        Arc::new(RejectingMapper),
-    ))
-    .expect("spawn server");
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let handle = spawn_server(test_args(home.to_path_buf(), Arc::new(RejectingMapper)))
+        .expect("spawn server");
 
     let rejected = handle
         .control
@@ -131,9 +134,10 @@ async fn command_mapper_can_reject_unsupported_local_command() {
 
 #[tokio::test]
 async fn attach_client_accepts_valid_subscription_and_rejects_malformed_request() {
-    let home = TempDir::new().expect("temp home");
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
     let handle = spawn_server(test_args(
-        home.path().to_path_buf(),
+        home.to_path_buf(),
         Arc::new(RecordingMapper::new()),
     ))
     .expect("spawn server");
@@ -190,9 +194,10 @@ async fn attach_client_accepts_valid_subscription_and_rejects_malformed_request(
 
 #[tokio::test]
 async fn stopped_server_rejects_new_command_submissions() {
-    let home = TempDir::new().expect("temp home");
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
     let handle = spawn_server(test_args(
-        home.path().to_path_buf(),
+        home.to_path_buf(),
         Arc::new(RecordingMapper::new()),
     ))
     .expect("spawn server");
@@ -209,6 +214,30 @@ async fn stopped_server_rejects_new_command_submissions() {
     );
 
     handle.join_handle.await.expect("join server");
+}
+
+#[tokio::test]
+async fn initialized_config_rejects_mismatched_explicit_home() {
+    let _guard = SERVER_TEST_LOCK.lock().await;
+    let home = SERVER_TEST_HOME.path();
+    let handle = spawn_server(test_args(
+        home.to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ))
+    .expect("spawn server");
+    handle.control.stop().await;
+    handle.join_handle.await.expect("join server");
+
+    let other_home = TempDir::new().expect("other temp home");
+    let result = spawn_server(test_args(
+        other_home.path().to_path_buf(),
+        Arc::new(RecordingMapper::new()),
+    ));
+
+    assert!(matches!(
+        result,
+        Err(ServerStartupError::ConfigInitFailed(_))
+    ));
 }
 
 struct RejectingMapper;

--- a/crates/server/tests/server_contract.rs
+++ b/crates/server/tests/server_contract.rs
@@ -48,6 +48,17 @@ async fn spawn_server_initializes_ready_control_and_creates_durable_paths() {
             .state,
         ReadyState::Ready
     );
+    let mismatched_ready = handle
+        .control
+        .ready(ReadyRequest {
+            protocol_version: ProtocolVersion(2),
+        })
+        .await;
+    assert_eq!(
+        mismatched_ready.protocol_version,
+        current_protocol_version()
+    );
+    assert_eq!(mismatched_ready.state, ReadyState::NotReady);
     assert!(home.join("selvedge.sqlite").exists());
     assert!(home.join("server.lock").exists());
 

--- a/crates/systemd/Cargo.toml
+++ b/crates/systemd/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "selvedge-systemd"
+edition = "2024"
+publish = false
+
+[dependencies]
+tokio = { version = "1.42.0", features = ["rt", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/systemd/README.md
+++ b/crates/systemd/README.md
@@ -1,0 +1,9 @@
+# systemd
+
+This crate owns the root-CLI systemd boundary for the Selvedge server unit.
+
+Use it to validate the configured `selvedge-server` unit name, query unit status, request unit start, and wait for systemd to report `Active` or `Failed`.
+
+`wait_service_active` polls until the configured timeout. If the caller drops the returned future, polling stops and no `SystemdError` is returned.
+
+This crate does not install, write, or modify unit files. It does not treat systemd `Active` as server readiness, stop the server, check localhost endpoints, send business commands, or access router/events/client-sync mailboxes.

--- a/crates/systemd/src/lib.rs
+++ b/crates/systemd/src/lib.rs
@@ -82,7 +82,9 @@ impl<B: SystemdBackend> SystemdClient<B> {
 
     pub async fn wait_service_active(&self) -> Result<ServiceStatus, SystemdError> {
         validate_config(&self.config)?;
-        let deadline = Instant::now() + self.config.operation_timeout;
+        let deadline = Instant::now()
+            .checked_add(self.config.operation_timeout)
+            .ok_or(SystemdError::Timeout)?;
         loop {
             let now = Instant::now();
             let remaining = deadline.saturating_duration_since(now);

--- a/crates/systemd/src/lib.rs
+++ b/crates/systemd/src/lib.rs
@@ -62,10 +62,12 @@ impl<B: SystemdBackend> SystemdClient<B> {
     }
 
     pub async fn query_service_status(&self) -> Result<ServiceStatus, SystemdError> {
+        validate_config(&self.config)?;
         self.backend.query_status(&self.config.unit_name).await
     }
 
     pub async fn start_service(&self) -> Result<StartServiceOutcome, SystemdError> {
+        validate_config(&self.config)?;
         match self.query_service_status().await? {
             ServiceStatus::Active => Ok(StartServiceOutcome::AlreadyRunning),
             ServiceStatus::Activating => Ok(StartServiceOutcome::AlreadyStarting),
@@ -79,9 +81,21 @@ impl<B: SystemdBackend> SystemdClient<B> {
     }
 
     pub async fn wait_service_active(&self) -> Result<ServiceStatus, SystemdError> {
+        validate_config(&self.config)?;
         let deadline = Instant::now() + self.config.operation_timeout;
         loop {
-            match self.query_service_status().await? {
+            let now = Instant::now();
+            let remaining = deadline.saturating_duration_since(now);
+            if remaining.is_zero() {
+                return Err(SystemdError::Timeout);
+            }
+
+            let status =
+                tokio::time::timeout(remaining, self.backend.query_status(&self.config.unit_name))
+                    .await
+                    .map_err(|_| SystemdError::Timeout)??;
+
+            match status {
                 ServiceStatus::Active => return Ok(ServiceStatus::Active),
                 status @ ServiceStatus::Failed { .. } => return Ok(status),
                 ServiceStatus::NotInstalled => return Err(SystemdError::UnitNotFound),

--- a/crates/systemd/src/lib.rs
+++ b/crates/systemd/src/lib.rs
@@ -1,0 +1,118 @@
+#![doc = include_str!("../README.md")]
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SystemdConfig {
+    pub unit_name: String,
+    pub operation_timeout: Duration,
+    pub poll_interval: Duration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServiceStatus {
+    NotInstalled,
+    Inactive,
+    Activating,
+    Active,
+    Failed { message: String },
+    Unknown { raw_state: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StartServiceOutcome {
+    StartRequested,
+    AlreadyRunning,
+    AlreadyStarting,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SystemdError {
+    InvalidUnitName,
+    Unavailable(String),
+    UnitNotFound,
+    StartRejected(String),
+    Timeout,
+    BackendFailure(String),
+}
+
+pub trait SystemdBackend: Send + Sync + 'static {
+    fn query_status(
+        &self,
+        unit_name: &str,
+    ) -> impl Future<Output = Result<ServiceStatus, SystemdError>> + Send;
+
+    fn start_unit(
+        &self,
+        unit_name: &str,
+    ) -> impl Future<Output = Result<StartServiceOutcome, SystemdError>> + Send;
+}
+
+pub struct SystemdClient<B: SystemdBackend> {
+    pub config: SystemdConfig,
+    pub backend: B,
+}
+
+impl<B: SystemdBackend> SystemdClient<B> {
+    pub fn new(config: SystemdConfig, backend: B) -> Result<Self, SystemdError> {
+        validate_config(&config)?;
+
+        Ok(Self { config, backend })
+    }
+
+    pub async fn query_service_status(&self) -> Result<ServiceStatus, SystemdError> {
+        self.backend.query_status(&self.config.unit_name).await
+    }
+
+    pub async fn start_service(&self) -> Result<StartServiceOutcome, SystemdError> {
+        match self.query_service_status().await? {
+            ServiceStatus::Active => Ok(StartServiceOutcome::AlreadyRunning),
+            ServiceStatus::Activating => Ok(StartServiceOutcome::AlreadyStarting),
+            ServiceStatus::NotInstalled => Err(SystemdError::UnitNotFound),
+            ServiceStatus::Inactive
+            | ServiceStatus::Failed { .. }
+            | ServiceStatus::Unknown { .. } => {
+                self.backend.start_unit(&self.config.unit_name).await
+            }
+        }
+    }
+
+    pub async fn wait_service_active(&self) -> Result<ServiceStatus, SystemdError> {
+        let deadline = Instant::now() + self.config.operation_timeout;
+        loop {
+            match self.query_service_status().await? {
+                ServiceStatus::Active => return Ok(ServiceStatus::Active),
+                status @ ServiceStatus::Failed { .. } => return Ok(status),
+                ServiceStatus::NotInstalled => return Err(SystemdError::UnitNotFound),
+                ServiceStatus::Inactive
+                | ServiceStatus::Activating
+                | ServiceStatus::Unknown { .. } => {}
+            }
+
+            if Instant::now() >= deadline {
+                return Err(SystemdError::Timeout);
+            }
+
+            let now = Instant::now();
+            let remaining = deadline.saturating_duration_since(now);
+            let sleep_for = remaining.min(self.config.poll_interval);
+            if sleep_for.is_zero() {
+                return Err(SystemdError::Timeout);
+            }
+            tokio::time::sleep(sleep_for).await;
+        }
+    }
+}
+
+fn validate_config(config: &SystemdConfig) -> Result<(), SystemdError> {
+    if config.unit_name.trim().is_empty() {
+        return Err(SystemdError::InvalidUnitName);
+    }
+
+    if config.operation_timeout.is_zero() || config.poll_interval.is_zero() {
+        return Err(SystemdError::InvalidUnitName);
+    }
+
+    Ok(())
+}

--- a/crates/systemd/tests/systemd_contract.rs
+++ b/crates/systemd/tests/systemd_contract.rs
@@ -175,6 +175,19 @@ async fn wait_service_active_times_out_when_status_query_stalls() {
 }
 
 #[tokio::test]
+async fn wait_service_active_returns_error_for_oversized_timeout() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(vec![Ok(ServiceStatus::Active)]);
+    let client = SystemdClient::new(wait_config(Duration::MAX), backend.clone()).expect("client");
+
+    assert_eq!(
+        client.wait_service_active().await,
+        Err(SystemdError::Timeout)
+    );
+    assert_eq!(backend.query_calls(), 0);
+}
+
+#[tokio::test]
 async fn dropping_wait_future_stops_polling_without_cancelled_error() {
     let _guard = TEST_LOCK.lock().await;
     let backend = FakeSystemdBackend::repeat(ServiceStatus::Activating);

--- a/crates/systemd/tests/systemd_contract.rs
+++ b/crates/systemd/tests/systemd_contract.rs
@@ -1,0 +1,312 @@
+use std::collections::VecDeque;
+use std::fs;
+use std::future;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use selvedge_systemd::{
+    ServiceStatus, StartServiceOutcome, SystemdBackend, SystemdClient, SystemdConfig, SystemdError,
+};
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::time::timeout;
+
+static TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
+
+#[tokio::test]
+async fn query_maps_backend_statuses_without_ready_semantics() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(vec![
+        Ok(ServiceStatus::Active),
+        Ok(ServiceStatus::Inactive),
+        Ok(ServiceStatus::Activating),
+        Ok(ServiceStatus::Failed {
+            message: "exit code 1".to_owned(),
+        }),
+        Ok(ServiceStatus::NotInstalled),
+        Ok(ServiceStatus::Unknown {
+            raw_state: "maintenance".to_owned(),
+        }),
+    ]);
+    let client = SystemdClient::new(valid_config(), backend.clone()).expect("client");
+
+    assert_eq!(
+        client.query_service_status().await,
+        Ok(ServiceStatus::Active)
+    );
+    assert_eq!(
+        client.query_service_status().await,
+        Ok(ServiceStatus::Inactive)
+    );
+    assert_eq!(
+        client.query_service_status().await,
+        Ok(ServiceStatus::Activating)
+    );
+    assert_eq!(
+        client.query_service_status().await,
+        Ok(ServiceStatus::Failed {
+            message: "exit code 1".to_owned()
+        })
+    );
+    assert_eq!(
+        client.query_service_status().await,
+        Ok(ServiceStatus::NotInstalled)
+    );
+    assert_eq!(
+        client.query_service_status().await,
+        Ok(ServiceStatus::Unknown {
+            raw_state: "maintenance".to_owned()
+        })
+    );
+    assert_eq!(backend.query_calls(), 6);
+}
+
+#[tokio::test]
+async fn start_service_uses_status_preflight_and_avoids_duplicate_start_requests() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(vec![
+        Ok(ServiceStatus::Inactive),
+        Ok(ServiceStatus::Active),
+        Ok(ServiceStatus::Activating),
+        Ok(ServiceStatus::NotInstalled),
+    ]);
+    backend.push_start(Ok(StartServiceOutcome::StartRequested));
+    let client = SystemdClient::new(valid_config(), backend.clone()).expect("client");
+
+    assert_eq!(
+        client.start_service().await,
+        Ok(StartServiceOutcome::StartRequested)
+    );
+    assert_eq!(
+        client.start_service().await,
+        Ok(StartServiceOutcome::AlreadyRunning)
+    );
+    assert_eq!(
+        client.start_service().await,
+        Ok(StartServiceOutcome::AlreadyStarting)
+    );
+    assert_eq!(
+        client.start_service().await,
+        Err(SystemdError::UnitNotFound)
+    );
+    assert_eq!(backend.start_calls(), 1);
+}
+
+#[tokio::test]
+async fn start_service_returns_backend_rejection() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(vec![Ok(ServiceStatus::Inactive)]);
+    backend.push_start(Err(SystemdError::StartRejected("masked".to_owned())));
+    let client = SystemdClient::new(valid_config(), backend).expect("client");
+
+    assert_eq!(
+        client.start_service().await,
+        Err(SystemdError::StartRejected("masked".to_owned()))
+    );
+}
+
+#[tokio::test]
+async fn unavailable_backend_errors_are_preserved() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(vec![Err(SystemdError::Unavailable(
+        "dbus unavailable".to_owned(),
+    ))]);
+    let client = SystemdClient::new(valid_config(), backend).expect("client");
+
+    assert_eq!(
+        client.query_service_status().await,
+        Err(SystemdError::Unavailable("dbus unavailable".to_owned()))
+    );
+}
+
+#[tokio::test]
+async fn wait_service_active_returns_active_or_failed_status() {
+    let _guard = TEST_LOCK.lock().await;
+    let active_backend = FakeSystemdBackend::new(vec![
+        Ok(ServiceStatus::Activating),
+        Ok(ServiceStatus::Active),
+    ]);
+    let active_client =
+        SystemdClient::new(wait_config(Duration::from_millis(50)), active_backend).expect("client");
+    assert_eq!(
+        active_client.wait_service_active().await,
+        Ok(ServiceStatus::Active)
+    );
+
+    let failed_backend = FakeSystemdBackend::new(vec![
+        Ok(ServiceStatus::Activating),
+        Ok(ServiceStatus::Failed {
+            message: "unit crashed".to_owned(),
+        }),
+    ]);
+    let failed_client =
+        SystemdClient::new(wait_config(Duration::from_millis(50)), failed_backend).expect("client");
+    assert_eq!(
+        failed_client.wait_service_active().await,
+        Ok(ServiceStatus::Failed {
+            message: "unit crashed".to_owned()
+        })
+    );
+}
+
+#[tokio::test]
+async fn wait_service_active_times_out() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::repeat(ServiceStatus::Activating);
+    let client =
+        SystemdClient::new(wait_config(Duration::from_millis(10)), backend).expect("client");
+
+    assert_eq!(
+        client.wait_service_active().await,
+        Err(SystemdError::Timeout)
+    );
+}
+
+#[tokio::test]
+async fn dropping_wait_future_stops_polling_without_cancelled_error() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::repeat(ServiceStatus::Activating);
+    let client = SystemdClient::new(wait_config(Duration::from_millis(100)), backend.clone())
+        .expect("client");
+
+    let mut wait = Box::pin(client.wait_service_active());
+    assert!(
+        timeout(Duration::from_millis(15), wait.as_mut())
+            .await
+            .is_err()
+    );
+    let calls_before_drop = backend.query_calls();
+    drop(wait);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    assert_eq!(backend.query_calls(), calls_before_drop);
+}
+
+#[tokio::test]
+async fn invalid_unit_name_is_rejected_before_backend_calls() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(vec![Ok(ServiceStatus::Active)]);
+
+    let result = SystemdClient::new(
+        SystemdConfig {
+            unit_name: " ".to_owned(),
+            ..valid_config()
+        },
+        backend.clone(),
+    );
+
+    assert!(matches!(result, Err(SystemdError::InvalidUnitName)));
+    assert_eq!(backend.query_calls(), 0);
+}
+
+#[test]
+fn tui_and_web_do_not_depend_on_systemd_crate() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let tui_manifest = format!("{root}/../tui/Cargo.toml");
+    if let Ok(manifest) = fs::read_to_string(tui_manifest) {
+        assert!(!manifest.contains("selvedge-systemd"));
+    }
+    let web_manifest =
+        fs::read_to_string(format!("{root}/../web/Cargo.toml")).expect("web manifest");
+    assert!(!web_manifest.contains("selvedge-systemd"));
+}
+
+#[derive(Clone)]
+struct FakeSystemdBackend {
+    state: Arc<Mutex<FakeSystemdState>>,
+}
+
+struct FakeSystemdState {
+    query_calls: usize,
+    start_calls: usize,
+    query_results: VecDeque<Result<ServiceStatus, SystemdError>>,
+    start_results: VecDeque<Result<StartServiceOutcome, SystemdError>>,
+    repeat_status: Option<ServiceStatus>,
+}
+
+impl FakeSystemdBackend {
+    fn new(query_results: Vec<Result<ServiceStatus, SystemdError>>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FakeSystemdState {
+                query_calls: 0,
+                start_calls: 0,
+                query_results: query_results.into(),
+                start_results: VecDeque::new(),
+                repeat_status: None,
+            })),
+        }
+    }
+
+    fn repeat(status: ServiceStatus) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FakeSystemdState {
+                query_calls: 0,
+                start_calls: 0,
+                query_results: VecDeque::new(),
+                start_results: VecDeque::new(),
+                repeat_status: Some(status),
+            })),
+        }
+    }
+
+    fn push_start(&self, result: Result<StartServiceOutcome, SystemdError>) {
+        self.state
+            .lock()
+            .expect("fake systemd lock")
+            .start_results
+            .push_back(result);
+    }
+
+    fn query_calls(&self) -> usize {
+        self.state.lock().expect("fake systemd lock").query_calls
+    }
+
+    fn start_calls(&self) -> usize {
+        self.state.lock().expect("fake systemd lock").start_calls
+    }
+}
+
+impl SystemdBackend for FakeSystemdBackend {
+    async fn query_status(&self, _unit_name: &str) -> Result<ServiceStatus, SystemdError> {
+        let next = {
+            let mut state = self.state.lock().expect("fake systemd lock");
+            state.query_calls += 1;
+            state.query_results.pop_front().or_else(|| {
+                state
+                    .repeat_status
+                    .as_ref()
+                    .map(|status| Ok(status.clone()))
+            })
+        };
+
+        if let Some(result) = next {
+            return result;
+        }
+
+        future::pending().await
+    }
+
+    async fn start_unit(&self, _unit_name: &str) -> Result<StartServiceOutcome, SystemdError> {
+        let mut state = self.state.lock().expect("fake systemd lock");
+        state.start_calls += 1;
+        state
+            .start_results
+            .pop_front()
+            .unwrap_or(Ok(StartServiceOutcome::StartRequested))
+    }
+}
+
+fn valid_config() -> SystemdConfig {
+    SystemdConfig {
+        unit_name: "selvedge-server.service".to_owned(),
+        operation_timeout: Duration::from_millis(50),
+        poll_interval: Duration::from_millis(1),
+    }
+}
+
+fn wait_config(timeout: Duration) -> SystemdConfig {
+    SystemdConfig {
+        operation_timeout: timeout,
+        poll_interval: Duration::from_millis(1),
+        ..valid_config()
+    }
+}

--- a/crates/systemd/tests/systemd_contract.rs
+++ b/crates/systemd/tests/systemd_contract.rs
@@ -162,6 +162,19 @@ async fn wait_service_active_times_out() {
 }
 
 #[tokio::test]
+async fn wait_service_active_times_out_when_status_query_stalls() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(Vec::new());
+    let client =
+        SystemdClient::new(wait_config(Duration::from_millis(10)), backend).expect("client");
+
+    assert_eq!(
+        client.wait_service_active().await,
+        Err(SystemdError::Timeout)
+    );
+}
+
+#[tokio::test]
 async fn dropping_wait_future_stops_polling_without_cancelled_error() {
     let _guard = TEST_LOCK.lock().await;
     let backend = FakeSystemdBackend::repeat(ServiceStatus::Activating);
@@ -195,6 +208,28 @@ async fn invalid_unit_name_is_rejected_before_backend_calls() {
     );
 
     assert!(matches!(result, Err(SystemdError::InvalidUnitName)));
+    assert_eq!(backend.query_calls(), 0);
+}
+
+#[tokio::test]
+async fn public_operations_revalidate_mutated_config_before_backend_calls() {
+    let _guard = TEST_LOCK.lock().await;
+    let backend = FakeSystemdBackend::new(vec![Ok(ServiceStatus::Active)]);
+    let mut client = SystemdClient::new(valid_config(), backend.clone()).expect("client");
+    client.config.unit_name = " ".to_owned();
+
+    assert_eq!(
+        client.query_service_status().await,
+        Err(SystemdError::InvalidUnitName)
+    );
+    assert_eq!(
+        client.start_service().await,
+        Err(SystemdError::InvalidUnitName)
+    );
+    assert_eq!(
+        client.wait_service_active().await,
+        Err(SystemdError::InvalidUnitName)
+    );
     assert_eq!(backend.query_calls(), 0);
 }
 

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "selvedge-tui"
+edition = "2024"
+publish = false
+
+[dependencies]
+futures-util = "0.3.31"
+selvedge-local-client = { path = "../local-client" }
+selvedge-local-protocol = { path = "../local-protocol" }
+
+[dev-dependencies]
+serde_json = "1.0.135"
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 futures-util = "0.3.31"
 selvedge-local-client = { path = "../local-client" }
 selvedge-local-protocol = { path = "../local-protocol" }
+tokio = { version = "1.42.0", features = ["time"] }
 
 [dev-dependencies]
 serde_json = "1.0.135"

--- a/crates/tui/README.md
+++ b/crates/tui/README.md
@@ -1,0 +1,7 @@
+# tui
+
+This crate owns the TUI startup boundary for attaching to an existing Selvedge local server.
+
+Use it to connect through `selvedge-local-client`, probe readiness, open an attach stream, wait for the first snapshot, submit an optional initial command, and return a typed exit status.
+
+The current entry point is generic over `LocalTransport` because the repository has not yet implemented the real localhost transport below `selvedge-local-client`.

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1,0 +1,154 @@
+#![doc = include_str!("../README.md")]
+
+use futures_util::StreamExt;
+use selvedge_local_client::{
+    AttachRejectedOrClientError, LocalClientConfig, LocalClientError, LocalTransport, connect,
+};
+use selvedge_local_protocol::{
+    AttachRequest, CommandOutcome, CommandRequest, LocalClientCommandId, LocalClientFrame,
+    LocalClientId, LocalClientSubscription, ReadyRequest, ReadyState, current_protocol_version,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TuiStartArgs {
+    pub client_config: LocalClientConfig,
+    pub client_id: String,
+    pub attach_command_id: String,
+    pub subscription: LocalClientSubscription,
+    pub initial_command: Option<CommandRequest>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TuiRuntimeState {
+    Starting,
+    ConnectingServer,
+    Attaching,
+    WaitingSnapshot,
+    Interactive,
+    Disconnecting,
+    Exited,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TuiExitStatus {
+    Exited,
+    ServerUnavailable,
+    ServerNotReady,
+    AttachRejected(String),
+    Disconnected,
+    TerminalFailed(String),
+    LocalClientFailed(LocalClientError),
+    InvalidArgs(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TuiInputAction {
+    SubmitCommand(CommandRequest),
+    Exit,
+    Noop,
+}
+
+pub trait TuiCommandMapper: Send + Sync + 'static {
+    fn map_input(&self, input_text: &str) -> Result<TuiInputAction, String>;
+}
+
+pub async fn run_tui<T, M>(args: TuiStartArgs, mapper: M) -> TuiExitStatus
+where
+    T: LocalTransport,
+    M: TuiCommandMapper,
+{
+    // NOTE(package-order): `selvedge-local-client` currently exposes only the
+    // `LocalTransport` abstraction. After the real localhost transport lands in
+    // that dependency package, this entry point must be repaired to select and
+    // call that concrete transport directly instead of requiring `T`.
+    let _mapper = mapper;
+
+    let client_id = match LocalClientId::new(args.client_id) {
+        Ok(client_id) => client_id,
+        Err(error) => return TuiExitStatus::InvalidArgs(format!("{error:?}")),
+    };
+    let attach_command_id = match LocalClientCommandId::new(args.attach_command_id) {
+        Ok(client_command_id) => client_command_id,
+        Err(error) => return TuiExitStatus::InvalidArgs(format!("{error:?}")),
+    };
+
+    let client = match connect::<T>(args.client_config).await {
+        Ok(client) => client,
+        Err(LocalClientError::ConnectFailed(_)) => return TuiExitStatus::ServerUnavailable,
+        Err(error) => return TuiExitStatus::LocalClientFailed(error),
+    };
+
+    let ready = client
+        .ready(ReadyRequest {
+            protocol_version: current_protocol_version(),
+        })
+        .await;
+    let ready = match ready {
+        Ok(ready) => ready,
+        Err(error) => {
+            return close_after_error(&client, TuiExitStatus::LocalClientFailed(error)).await;
+        }
+    };
+    if ready.state == ReadyState::NotReady {
+        return close_after_error(&client, TuiExitStatus::ServerNotReady).await;
+    }
+
+    let attach = client
+        .attach(AttachRequest {
+            protocol_version: current_protocol_version(),
+            client_id,
+            client_command_id: attach_command_id,
+            subscription: args.subscription,
+        })
+        .await;
+    let (_accepted, mut frames) = match attach {
+        Ok(attach) => attach,
+        Err(AttachRejectedOrClientError::Rejected(rejected)) => {
+            return close_after_error(
+                &client,
+                TuiExitStatus::AttachRejected(format!("{:?}", rejected.reason)),
+            )
+            .await;
+        }
+        Err(AttachRejectedOrClientError::Client(error)) => {
+            return close_after_error(&client, TuiExitStatus::LocalClientFailed(error)).await;
+        }
+    };
+
+    loop {
+        match frames.next().await {
+            Some(Ok(LocalClientFrame::Snapshot(_))) => break,
+            Some(Ok(LocalClientFrame::Notice(_))) | Some(Ok(LocalClientFrame::Event(_))) => {}
+            Some(Err(_)) | None => {
+                drop(frames);
+                return close_after_error(&client, TuiExitStatus::Disconnected).await;
+            }
+        }
+    }
+
+    if let Some(command) = args.initial_command {
+        let response = match client.submit_command(command).await {
+            Ok(response) => response,
+            Err(error) => {
+                drop(frames);
+                return close_after_error(&client, TuiExitStatus::LocalClientFailed(error)).await;
+            }
+        };
+        match response.outcome {
+            CommandOutcome::Accepted | CommandOutcome::Rejected(_) => {}
+        }
+    }
+
+    drop(frames);
+    let _ = client.close().await;
+    TuiExitStatus::Exited
+}
+
+async fn close_after_error<T: LocalTransport>(
+    client: &selvedge_local_client::LocalClient<T>,
+    status: TuiExitStatus,
+) -> TuiExitStatus {
+    let _ = client.close().await;
+    status
+}

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -36,6 +36,7 @@ pub enum TuiExitStatus {
     ServerUnavailable,
     ServerNotReady,
     AttachRejected(String),
+    CommandRejected(String),
     Disconnected,
     TerminalFailed(String),
     LocalClientFailed(LocalClientError),
@@ -136,7 +137,15 @@ where
             }
         };
         match response.outcome {
-            CommandOutcome::Accepted | CommandOutcome::Rejected(_) => {}
+            CommandOutcome::Accepted => {}
+            CommandOutcome::Rejected(reason) => {
+                drop(frames);
+                return close_after_error(
+                    &client,
+                    TuiExitStatus::CommandRejected(format!("{reason:?}")),
+                )
+                .await;
+            }
         }
     }
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -38,6 +38,7 @@ pub enum TuiExitStatus {
     AttachRejected(String),
     CommandRejected(String),
     Disconnected,
+    SnapshotTimeout,
     TerminalFailed(String),
     LocalClientFailed(LocalClientError),
     InvalidArgs(String),
@@ -74,6 +75,7 @@ where
         Err(error) => return TuiExitStatus::InvalidArgs(format!("{error:?}")),
     };
 
+    let snapshot_timeout = args.client_config.request_timeout;
     let client = match connect::<T>(args.client_config).await {
         Ok(client) => client,
         Err(LocalClientError::ConnectFailed(_)) => return TuiExitStatus::ServerUnavailable,
@@ -117,14 +119,15 @@ where
         }
     };
 
-    loop {
-        match frames.next().await {
-            Some(Ok(LocalClientFrame::Snapshot(_))) => break,
-            Some(Ok(LocalClientFrame::Notice(_))) | Some(Ok(LocalClientFrame::Event(_))) => {}
-            Some(Err(_)) | None => {
-                drop(frames);
-                return close_after_error(&client, TuiExitStatus::Disconnected).await;
-            }
+    match tokio::time::timeout(snapshot_timeout, wait_for_initial_snapshot(&mut frames)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(status)) => {
+            drop(frames);
+            return close_after_error(&client, status).await;
+        }
+        Err(_) => {
+            drop(frames);
+            return close_after_error(&client, TuiExitStatus::SnapshotTimeout).await;
         }
     }
 
@@ -152,6 +155,18 @@ where
     drop(frames);
     let _ = client.close().await;
     TuiExitStatus::Exited
+}
+
+async fn wait_for_initial_snapshot(
+    frames: &mut selvedge_local_client::LocalFrameStream,
+) -> Result<(), TuiExitStatus> {
+    loop {
+        match frames.next().await {
+            Some(Ok(LocalClientFrame::Snapshot(_))) => return Ok(()),
+            Some(Ok(LocalClientFrame::Notice(_))) | Some(Ok(LocalClientFrame::Event(_))) => {}
+            Some(Err(_)) | None => return Err(TuiExitStatus::Disconnected),
+        }
+    }
 }
 
 async fn close_after_error<T: LocalTransport>(

--- a/crates/tui/tests/tui_contract.rs
+++ b/crates/tui/tests/tui_contract.rs
@@ -1,0 +1,298 @@
+use std::collections::VecDeque;
+use std::future;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use futures_util::stream;
+use selvedge_local_client::{
+    AttachRejectedOrClientError, LocalClientConfig, LocalClientError, LocalEndpoint,
+    LocalFrameStream, LocalTransport,
+};
+use selvedge_local_protocol::{
+    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
+    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientFrame, LocalClientId,
+    LocalClientSnapshot, LocalClientSnapshotFrame, LocalClientSubscription, LocalDetailLevel,
+    LocalTaskScope, ReadyRequest, ReadyResponse, ReadyState, current_protocol_version,
+};
+use selvedge_tui::{TuiExitStatus, TuiInputAction, TuiStartArgs, run_tui};
+use tokio::sync::Mutex as AsyncMutex;
+
+static TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
+static CONNECT_PLAN: LazyLock<Mutex<Option<Result<FakeTransportStateHandle, LocalClientError>>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+type FakeTransportStateHandle = Arc<Mutex<FakeTransportState>>;
+
+#[tokio::test]
+async fn connect_failure_returns_server_unavailable() {
+    let _guard = TEST_LOCK.lock().await;
+    install_connect_plan(Err(LocalClientError::ConnectFailed("refused".to_owned())));
+
+    let status = run_tui::<FakeTransport, _>(valid_args(None), NoopMapper).await;
+
+    assert_eq!(status, TuiExitStatus::ServerUnavailable);
+}
+
+#[tokio::test]
+async fn not_ready_returns_server_not_ready() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .ready_responses
+        .push_back(ReadyResponse {
+            protocol_version: current_protocol_version(),
+            state: ReadyState::NotReady,
+        });
+    install_connect_plan(Ok(state.clone()));
+
+    let status = run_tui::<FakeTransport, _>(valid_args(None), NoopMapper).await;
+
+    assert_eq!(status, TuiExitStatus::ServerNotReady);
+    assert_eq!(state.lock().expect("fake state").close_calls, 1);
+}
+
+#[tokio::test]
+async fn attach_rejection_returns_attach_rejected() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = ready_state();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Rejected(AttachRejected {
+            protocol_version: current_protocol_version(),
+            client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+            reason: CommandRejectReason::ServerNotReady,
+        }));
+    install_connect_plan(Ok(state.clone()));
+
+    let status = run_tui::<FakeTransport, _>(valid_args(None), NoopMapper).await;
+
+    assert_eq!(
+        status,
+        TuiExitStatus::AttachRejected("ServerNotReady".to_owned())
+    );
+    assert_eq!(state.lock().expect("fake state").close_calls, 1);
+}
+
+#[tokio::test]
+async fn waits_for_snapshot_then_submits_initial_command_and_exits() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = ready_state();
+    {
+        let mut state_guard = state.lock().expect("fake state");
+        state_guard
+            .attach_responses
+            .push_back(AttachAction::Accepted(vec![Ok(
+                LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
+                    delivery_seq: 1,
+                    client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+                    snapshot: empty_snapshot(),
+                }),
+            )]));
+        state_guard.command_responses.push_back(CommandResponse {
+            protocol_version: current_protocol_version(),
+            client_command_id: LocalClientCommandId::new("command-1").expect("command id"),
+            outcome: CommandOutcome::Rejected(CommandRejectReason::UnsupportedCommand),
+        });
+    }
+    install_connect_plan(Ok(state.clone()));
+
+    let status =
+        run_tui::<FakeTransport, _>(valid_args(Some(valid_command("command-1"))), NoopMapper).await;
+
+    assert_eq!(status, TuiExitStatus::Exited);
+    let state = state.lock().expect("fake state");
+    assert_eq!(state.attach_calls, 1);
+    assert_eq!(state.command_calls, 1);
+    assert_eq!(state.close_calls, 1);
+}
+
+#[tokio::test]
+async fn stream_closed_before_snapshot_returns_disconnected() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = ready_state();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Accepted(Vec::new()));
+    install_connect_plan(Ok(state.clone()));
+
+    let status = run_tui::<FakeTransport, _>(valid_args(None), NoopMapper).await;
+
+    assert_eq!(status, TuiExitStatus::Disconnected);
+    assert_eq!(state.lock().expect("fake state").close_calls, 1);
+}
+
+struct NoopMapper;
+
+impl selvedge_tui::TuiCommandMapper for NoopMapper {
+    fn map_input(&self, _input_text: &str) -> Result<TuiInputAction, String> {
+        Ok(TuiInputAction::Noop)
+    }
+}
+
+#[derive(Clone)]
+struct FakeTransport {
+    state: FakeTransportStateHandle,
+}
+
+#[derive(Default)]
+struct FakeTransportState {
+    ready_responses: VecDeque<ReadyResponse>,
+    attach_responses: VecDeque<AttachAction>,
+    command_responses: VecDeque<CommandResponse>,
+    ready_calls: usize,
+    attach_calls: usize,
+    command_calls: usize,
+    close_calls: usize,
+}
+
+enum AttachAction {
+    Accepted(Vec<Result<LocalClientFrame, LocalClientError>>),
+    Rejected(AttachRejected),
+}
+
+impl FakeTransportState {
+    fn new_handle() -> FakeTransportStateHandle {
+        Arc::new(Mutex::new(Self::default()))
+    }
+}
+
+impl LocalTransport for FakeTransport {
+    async fn connect(config: LocalClientConfig) -> Result<Self, LocalClientError>
+    where
+        Self: Sized,
+    {
+        let _ = config;
+        match CONNECT_PLAN.lock().expect("connect plan").take() {
+            Some(Ok(state)) => Ok(Self { state }),
+            Some(Err(error)) => Err(error),
+            None => Err(LocalClientError::ConnectFailed(
+                "missing connect plan".to_owned(),
+            )),
+        }
+    }
+
+    async fn ready(&self, request: ReadyRequest) -> Result<ReadyResponse, LocalClientError> {
+        let _ = request;
+        let mut state = self.state.lock().expect("fake state");
+        state.ready_calls += 1;
+        Ok(state.ready_responses.pop_front().unwrap_or(ReadyResponse {
+            protocol_version: current_protocol_version(),
+            state: ReadyState::Ready,
+        }))
+    }
+
+    async fn submit_command(
+        &self,
+        request: CommandRequest,
+    ) -> Result<CommandResponse, LocalClientError> {
+        let mut state = self.state.lock().expect("fake state");
+        state.command_calls += 1;
+        Ok(state
+            .command_responses
+            .pop_front()
+            .unwrap_or(CommandResponse {
+                protocol_version: current_protocol_version(),
+                client_command_id: request.client_command_id,
+                outcome: CommandOutcome::Accepted,
+            }))
+    }
+
+    async fn attach(
+        &self,
+        request: AttachRequest,
+    ) -> Result<(AttachAccepted, LocalFrameStream), AttachRejectedOrClientError> {
+        let mut state = self.state.lock().expect("fake state");
+        state.attach_calls += 1;
+        match state.attach_responses.pop_front() {
+            Some(AttachAction::Accepted(frames)) => Ok((
+                AttachAccepted {
+                    protocol_version: current_protocol_version(),
+                    client_id: request.client_id,
+                    client_command_id: request.client_command_id,
+                },
+                Box::pin(stream::iter(frames)),
+            )),
+            Some(AttachAction::Rejected(rejected)) => {
+                Err(AttachRejectedOrClientError::Rejected(rejected))
+            }
+            None => Ok((
+                AttachAccepted {
+                    protocol_version: current_protocol_version(),
+                    client_id: request.client_id,
+                    client_command_id: request.client_command_id,
+                },
+                Box::pin(stream::iter(Vec::new())),
+            )),
+        }
+    }
+
+    fn close(&self) -> impl Future<Output = ()> + Send {
+        let state = self.state.clone();
+        {
+            state.lock().expect("fake state").close_calls += 1;
+        };
+        future::ready(())
+    }
+}
+
+fn install_connect_plan(plan: Result<FakeTransportStateHandle, LocalClientError>) {
+    *CONNECT_PLAN.lock().expect("connect plan") = Some(plan);
+}
+
+fn ready_state() -> FakeTransportStateHandle {
+    let state = FakeTransportState::new_handle();
+    state
+        .lock()
+        .expect("fake state")
+        .ready_responses
+        .push_back(ReadyResponse {
+            protocol_version: current_protocol_version(),
+            state: ReadyState::Ready,
+        });
+    state
+}
+
+fn valid_args(initial_command: Option<CommandRequest>) -> TuiStartArgs {
+    TuiStartArgs {
+        client_config: LocalClientConfig {
+            endpoint: LocalEndpoint::TcpIpv4 { port: 17691 },
+            request_timeout: Duration::from_secs(1),
+        },
+        client_id: "client-1".to_owned(),
+        attach_command_id: "attach-1".to_owned(),
+        subscription: LocalClientSubscription {
+            task_scope: LocalTaskScope::AllTasks,
+            detail_level: LocalDetailLevel::Summary,
+            include_model_call_status: false,
+            include_tool_execution_status: false,
+            include_debug_notices: false,
+        },
+        initial_command,
+    }
+}
+
+fn valid_command(command_id: &str) -> CommandRequest {
+    CommandRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("client id"),
+        client_command_id: LocalClientCommandId::new(command_id).expect("command id"),
+        command_name: "noop".to_owned(),
+        payload: serde_json::json!({}),
+    }
+}
+
+fn empty_snapshot() -> LocalClientSnapshot {
+    LocalClientSnapshot {
+        generated_at: 1,
+        tasks: Vec::new(),
+        task_parent_edges: Vec::new(),
+        history_nodes: Vec::new(),
+        task_versions: Vec::new(),
+    }
+}

--- a/crates/tui/tests/tui_contract.rs
+++ b/crates/tui/tests/tui_contract.rs
@@ -9,10 +9,11 @@ use selvedge_local_client::{
     LocalFrameStream, LocalTransport,
 };
 use selvedge_local_protocol::{
-    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
-    CommandRequest, CommandResponse, LocalClientCommandId, LocalClientFrame, LocalClientId,
-    LocalClientSnapshot, LocalClientSnapshotFrame, LocalClientSubscription, LocalDetailLevel,
-    LocalTaskScope, ReadyRequest, ReadyResponse, ReadyState, current_protocol_version,
+    AttachAccepted, AttachRejectReason, AttachRejected, AttachRequest, CommandOutcome,
+    CommandRejectReason, CommandRequest, CommandResponse, LocalClientCommandId, LocalClientFrame,
+    LocalClientId, LocalClientSnapshot, LocalClientSnapshotFrame, LocalClientSubscription,
+    LocalDetailLevel, LocalTaskScope, ReadyRequest, ReadyResponse, ReadyState,
+    current_protocol_version,
 };
 use selvedge_tui::{TuiExitStatus, TuiInputAction, TuiStartArgs, run_tui};
 use tokio::sync::Mutex as AsyncMutex;
@@ -64,7 +65,7 @@ async fn attach_rejection_returns_attach_rejected() {
         .push_back(AttachAction::Rejected(AttachRejected {
             protocol_version: current_protocol_version(),
             client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
-            reason: CommandRejectReason::ServerNotReady,
+            reason: AttachRejectReason::ServerNotReady,
         }));
     install_connect_plan(Ok(state.clone()));
 

--- a/crates/tui/tests/tui_contract.rs
+++ b/crates/tui/tests/tui_contract.rs
@@ -78,7 +78,7 @@ async fn attach_rejection_returns_attach_rejected() {
 }
 
 #[tokio::test]
-async fn waits_for_snapshot_then_submits_initial_command_and_exits() {
+async fn waits_for_snapshot_then_submits_initial_command_and_reports_rejection() {
     let _guard = TEST_LOCK.lock().await;
     let state = ready_state();
     {
@@ -103,9 +103,44 @@ async fn waits_for_snapshot_then_submits_initial_command_and_exits() {
     let status =
         run_tui::<FakeTransport, _>(valid_args(Some(valid_command("command-1"))), NoopMapper).await;
 
-    assert_eq!(status, TuiExitStatus::Exited);
+    assert_eq!(
+        status,
+        TuiExitStatus::CommandRejected("UnsupportedCommand".to_owned())
+    );
     let state = state.lock().expect("fake state");
     assert_eq!(state.attach_calls, 1);
+    assert_eq!(state.command_calls, 1);
+    assert_eq!(state.close_calls, 1);
+}
+
+#[tokio::test]
+async fn accepted_initial_command_exits_successfully() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = ready_state();
+    {
+        let mut state_guard = state.lock().expect("fake state");
+        state_guard
+            .attach_responses
+            .push_back(AttachAction::Accepted(vec![Ok(
+                LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
+                    delivery_seq: 1,
+                    client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+                    snapshot: empty_snapshot(),
+                }),
+            )]));
+        state_guard.command_responses.push_back(CommandResponse {
+            protocol_version: current_protocol_version(),
+            client_command_id: LocalClientCommandId::new("command-1").expect("command id"),
+            outcome: CommandOutcome::Accepted,
+        });
+    }
+    install_connect_plan(Ok(state.clone()));
+
+    let status =
+        run_tui::<FakeTransport, _>(valid_args(Some(valid_command("command-1"))), NoopMapper).await;
+
+    assert_eq!(status, TuiExitStatus::Exited);
+    let state = state.lock().expect("fake state");
     assert_eq!(state.command_calls, 1);
     assert_eq!(state.close_calls, 1);
 }

--- a/crates/tui/tests/tui_contract.rs
+++ b/crates/tui/tests/tui_contract.rs
@@ -162,6 +162,25 @@ async fn stream_closed_before_snapshot_returns_disconnected() {
     assert_eq!(state.lock().expect("fake state").close_calls, 1);
 }
 
+#[tokio::test]
+async fn snapshot_wait_timeout_returns_snapshot_timeout() {
+    let _guard = TEST_LOCK.lock().await;
+    let state = ready_state();
+    state
+        .lock()
+        .expect("fake state")
+        .attach_responses
+        .push_back(AttachAction::Pending);
+    install_connect_plan(Ok(state.clone()));
+
+    let mut args = valid_args(None);
+    args.client_config.request_timeout = Duration::from_millis(5);
+    let status = run_tui::<FakeTransport, _>(args, NoopMapper).await;
+
+    assert_eq!(status, TuiExitStatus::SnapshotTimeout);
+    assert_eq!(state.lock().expect("fake state").close_calls, 1);
+}
+
 struct NoopMapper;
 
 impl selvedge_tui::TuiCommandMapper for NoopMapper {
@@ -189,6 +208,7 @@ struct FakeTransportState {
 enum AttachAction {
     Accepted(Vec<Result<LocalClientFrame, LocalClientError>>),
     Rejected(AttachRejected),
+    Pending,
 }
 
 impl FakeTransportState {
@@ -256,6 +276,14 @@ impl LocalTransport for FakeTransport {
             Some(AttachAction::Rejected(rejected)) => {
                 Err(AttachRejectedOrClientError::Rejected(rejected))
             }
+            Some(AttachAction::Pending) => Ok((
+                AttachAccepted {
+                    protocol_version: current_protocol_version(),
+                    client_id: request.client_id,
+                    client_command_id: request.client_command_id,
+                },
+                Box::pin(stream::pending()),
+            )),
             None => Ok((
                 AttachAccepted {
                     protocol_version: current_protocol_version(),

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "selvedge-web"
+edition = "2024"
+publish = false
+
+[dependencies]
+futures-core = "0.3.31"
+selvedge-local-protocol = { path = "../local-protocol" }
+tokio = { version = "1.42.0", features = ["rt", "sync"] }
+
+[dev-dependencies]
+serde_json = "1.0.145"
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 futures-core = "0.3.31"
 selvedge-local-protocol = { path = "../local-protocol" }
 tokio = { version = "1.42.0", features = ["rt", "sync"] }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 
 [dev-dependencies]
 futures-util = "0.3.31"

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -9,8 +9,9 @@ selvedge-local-protocol = { path = "../local-protocol" }
 tokio = { version = "1.42.0", features = ["rt", "sync"] }
 
 [dev-dependencies]
+futures-util = "0.3.31"
 serde_json = "1.0.145"
-tokio = { version = "1.42.0", features = ["macros", "rt", "sync"] }
+tokio = { version = "1.42.0", features = ["macros", "rt", "sync", "time"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/web/README.md
+++ b/crates/web/README.md
@@ -1,0 +1,7 @@
+# web
+
+This crate defines the browser-facing web surface boundary used by `selvedge-server`.
+
+Use it to pass web bind settings, bridge requests, bridge futures, attach frame streams, runtime state, start errors, bridge errors, and the web control handle across package boundaries.
+
+This crate currently provides the stable public interface and lifecycle handle needed by `selvedge-server`. HTTP route handling, page serving, attach stream forwarding, browser session shutdown, and localhost listener ownership are implemented when the full web package is advanced in the package sequence.

--- a/crates/web/README.md
+++ b/crates/web/README.md
@@ -4,4 +4,8 @@ This crate defines the browser-facing web surface boundary used by `selvedge-ser
 
 Use it to pass web bind settings, bridge requests, bridge futures, attach frame streams, runtime state, start errors, bridge errors, and the web control handle across package boundaries.
 
-This crate currently provides the stable public interface and lifecycle handle needed by `selvedge-server`. HTTP route handling, page serving, attach stream forwarding, browser session shutdown, and localhost listener ownership are implemented when the full web package is advanced in the package sequence.
+`spawn_web_surface` binds the configured loopback address and keeps that listener owned by the web task. `WebControl` exposes the request handling core used by the browser-facing routes: `page` returns the static shell, `submit_command` validates and forwards command requests, and `attach` validates and wraps bridge frame streams.
+
+`WebBridge` is implemented by `selvedge-server`. The web package forwards through that bridge and never touches router, events, database, or systemd state.
+
+Stopping the web control moves the runtime to closing, stops accepting new control operations, closes wrapped attach streams, releases the listener, and resolves the join handle with `WebExitStatus::Stopped`.

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -14,9 +14,15 @@ use selvedge_local_protocol::{
 };
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
+use tokio_stream::wrappers::WatchStream;
 
 pub struct WebStartArgs {
     pub bind: WebLocalhostBind,
+    pub bridge: Arc<dyn WebBridge>,
+}
+
+pub struct ReservedWebStartArgs {
+    pub bind: WebBindReservation,
     pub bridge: Arc<dyn WebBridge>,
 }
 
@@ -30,6 +36,11 @@ pub struct WebLocalhostBind {
 pub enum WebLocalhostHost {
     Ipv4Loopback,
     Ipv6Loopback,
+}
+
+pub struct WebBindReservation {
+    bind: WebLocalhostBind,
+    listener: TcpListener,
 }
 
 pub struct WebHandle {
@@ -108,13 +119,29 @@ pub enum AttachRejectedOrBridgeError {
 }
 
 pub fn spawn_web_surface(args: WebStartArgs) -> Result<WebHandle, WebStartError> {
-    if args.bind.port == 0 {
+    let bind = reserve_web_bind(args.bind)?;
+    spawn_reserved_web_surface(ReservedWebStartArgs {
+        bind,
+        bridge: args.bridge,
+    })
+}
+
+pub fn reserve_web_bind(bind: WebLocalhostBind) -> Result<WebBindReservation, WebStartError> {
+    if bind.port == 0 {
+        return Err(WebStartError::InvalidBindTarget);
+    }
+    let listener = bind_localhost(&bind)?;
+    Ok(WebBindReservation { bind, listener })
+}
+
+pub fn spawn_reserved_web_surface(args: ReservedWebStartArgs) -> Result<WebHandle, WebStartError> {
+    if args.bind.bind.port == 0 {
         return Err(WebStartError::InvalidBindTarget);
     }
 
     let handle =
         tokio::runtime::Handle::try_current().map_err(|_| WebStartError::TokioSpawnFailed)?;
-    let listener = bind_localhost(&args.bind)?;
+    let listener = args.bind.listener;
     let (state_tx, mut state_rx) = watch::channel(WebRuntimeState::Listening);
     let control = WebControl {
         inner: Arc::new(WebControlInner {
@@ -240,7 +267,7 @@ impl WebControl {
     fn wrap_frame_stream(&self, inner: WebFrameStream) -> WebFrameStream {
         Box::pin(WebBrowserFrameStream {
             inner,
-            state_rx: self.inner.state_tx.subscribe(),
+            state_stream: WatchStream::new(self.inner.state_tx.subscribe()),
             closed_after_error: false,
         })
     }
@@ -248,7 +275,7 @@ impl WebControl {
 
 struct WebBrowserFrameStream {
     inner: WebFrameStream,
-    state_rx: watch::Receiver<WebRuntimeState>,
+    state_stream: WatchStream<WebRuntimeState>,
     closed_after_error: bool,
 }
 
@@ -257,13 +284,19 @@ impl Stream for WebBrowserFrameStream {
 
     fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-        if this.closed_after_error
-            || matches!(
-                *this.state_rx.borrow(),
-                WebRuntimeState::Closing | WebRuntimeState::Stopped | WebRuntimeState::Failed
-            )
-        {
+        if this.closed_after_error {
             return Poll::Ready(None);
+        }
+
+        loop {
+            match Pin::new(&mut this.state_stream).poll_next(context) {
+                Poll::Ready(Some(
+                    WebRuntimeState::Closing | WebRuntimeState::Stopped | WebRuntimeState::Failed,
+                )) => return Poll::Ready(None),
+                Poll::Ready(Some(_)) => {}
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => break,
+            }
         }
 
         match this.inner.as_mut().poll_next(context) {
@@ -272,29 +305,7 @@ impl Stream for WebBrowserFrameStream {
                 Poll::Ready(Some(Err(error)))
             }
             Poll::Ready(item) => Poll::Ready(item),
-            Poll::Pending => {
-                let state_changed = {
-                    let changed = this.state_rx.changed();
-                    tokio::pin!(changed);
-                    Future::poll(changed.as_mut(), context)
-                };
-                match state_changed {
-                    Poll::Ready(Ok(())) => {
-                        if matches!(
-                            *this.state_rx.borrow(),
-                            WebRuntimeState::Closing
-                                | WebRuntimeState::Stopped
-                                | WebRuntimeState::Failed
-                        ) {
-                            Poll::Ready(None)
-                        } else {
-                            Poll::Pending
-                        }
-                    }
-                    Poll::Ready(Err(_)) => Poll::Ready(None),
-                    Poll::Pending => Poll::Pending,
-                }
-            }
+            Poll::Pending => Poll::Pending,
         }
     }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,13 +1,16 @@
 #![doc = include_str!("../README.md")]
 
 use std::future::Future;
+use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use futures_core::Stream;
 use selvedge_local_protocol::{
-    AttachAccepted, AttachRejected, AttachRequest, CommandRequest, CommandResponse,
-    LocalClientFrame, ReadyRequest, ReadyResponse,
+    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
+    CommandRequest, CommandResponse, LocalClientFrame, ReadyRequest, ReadyResponse,
+    current_protocol_version, validate_attach_request, validate_command_request,
 };
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -41,6 +44,13 @@ pub struct WebControl {
 
 struct WebControlInner {
     state_tx: watch::Sender<WebRuntimeState>,
+    bridge: Arc<dyn WebBridge>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebPageResponse {
+    pub content_type: String,
+    pub body: String,
 }
 
 pub type WebFrameStream =
@@ -102,13 +112,19 @@ pub fn spawn_web_surface(args: WebStartArgs) -> Result<WebHandle, WebStartError>
         return Err(WebStartError::InvalidBindTarget);
     }
 
-    let _bridge = args.bridge;
+    let handle =
+        tokio::runtime::Handle::try_current().map_err(|_| WebStartError::TokioSpawnFailed)?;
+    let listener = bind_localhost(&args.bind)?;
     let (state_tx, mut state_rx) = watch::channel(WebRuntimeState::Listening);
     let control = WebControl {
-        inner: Arc::new(WebControlInner { state_tx }),
+        inner: Arc::new(WebControlInner {
+            state_tx,
+            bridge: args.bridge,
+        }),
     };
     let task_control = control.clone();
-    let join_handle = tokio::spawn(async move {
+    let join_handle = handle.spawn(async move {
+        let _listener = listener;
         while state_rx.changed().await.is_ok() {
             if *state_rx.borrow() == WebRuntimeState::Closing {
                 break;
@@ -129,7 +145,156 @@ impl WebControl {
         self.inner.state_tx.borrow().clone()
     }
 
+    pub async fn page(&self) -> Result<WebPageResponse, WebBridgeError> {
+        self.ensure_listening()?;
+        Ok(WebPageResponse {
+            content_type: "text/html; charset=utf-8".to_owned(),
+            body: "<!doctype html><html><head><title>Selvedge</title></head><body><main id=\"selvedge-root\">Selvedge</main></body></html>".to_owned(),
+        })
+    }
+
+    pub async fn submit_command(
+        &self,
+        request: CommandRequest,
+    ) -> Result<CommandResponse, WebBridgeError> {
+        self.ensure_listening()?;
+        let client_command_id = request.client_command_id.clone();
+        if validate_command_request(&request).is_err() {
+            let reason = if request.protocol_version != current_protocol_version() {
+                CommandRejectReason::ProtocolVersionMismatch
+            } else {
+                CommandRejectReason::MalformedRequest
+            };
+            return Ok(rejected_command_response(client_command_id, reason));
+        }
+
+        match self.inner.bridge.submit_command(request).await {
+            Ok(response) => Ok(response),
+            Err(WebBridgeError::ServerNotReady) => Ok(rejected_command_response(
+                client_command_id,
+                CommandRejectReason::ServerNotReady,
+            )),
+            Err(WebBridgeError::ProtocolValidationFailed) => Ok(rejected_command_response(
+                client_command_id,
+                CommandRejectReason::MalformedRequest,
+            )),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn attach(
+        &self,
+        request: AttachRequest,
+    ) -> Result<(AttachAccepted, WebFrameStream), AttachRejectedOrBridgeError> {
+        self.ensure_listening()
+            .map_err(AttachRejectedOrBridgeError::Bridge)?;
+        let protocol_version = current_protocol_version();
+        let client_command_id = request.client_command_id.clone();
+        if validate_attach_request(&request).is_err() {
+            let reason = if request.protocol_version != current_protocol_version() {
+                CommandRejectReason::ProtocolVersionMismatch
+            } else {
+                CommandRejectReason::MalformedRequest
+            };
+            return Err(AttachRejectedOrBridgeError::Rejected(AttachRejected {
+                protocol_version,
+                client_command_id,
+                reason,
+            }));
+        }
+
+        match self.inner.bridge.attach(request).await {
+            Ok((accepted, stream)) => Ok((accepted, self.wrap_frame_stream(stream))),
+            Err(AttachRejectedOrBridgeError::Bridge(WebBridgeError::ServerNotReady)) => {
+                Err(AttachRejectedOrBridgeError::Rejected(AttachRejected {
+                    protocol_version,
+                    client_command_id,
+                    reason: CommandRejectReason::ServerNotReady,
+                }))
+            }
+            Err(AttachRejectedOrBridgeError::Bridge(WebBridgeError::ProtocolValidationFailed)) => {
+                Err(AttachRejectedOrBridgeError::Rejected(AttachRejected {
+                    protocol_version,
+                    client_command_id,
+                    reason: CommandRejectReason::MalformedRequest,
+                }))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     pub async fn stop(&self) {
         let _ = self.inner.state_tx.send(WebRuntimeState::Closing);
     }
+
+    fn ensure_listening(&self) -> Result<(), WebBridgeError> {
+        if *self.inner.state_tx.borrow() == WebRuntimeState::Listening {
+            Ok(())
+        } else {
+            Err(WebBridgeError::InternalFailure(
+                "web surface is closing".to_owned(),
+            ))
+        }
+    }
+
+    fn wrap_frame_stream(&self, inner: WebFrameStream) -> WebFrameStream {
+        Box::pin(WebBrowserFrameStream {
+            inner,
+            state_rx: self.inner.state_tx.subscribe(),
+            closed_after_error: false,
+        })
+    }
+}
+
+struct WebBrowserFrameStream {
+    inner: WebFrameStream,
+    state_rx: watch::Receiver<WebRuntimeState>,
+    closed_after_error: bool,
+}
+
+impl Stream for WebBrowserFrameStream {
+    type Item = Result<LocalClientFrame, WebBridgeError>;
+
+    fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.closed_after_error
+            || matches!(
+                *this.state_rx.borrow(),
+                WebRuntimeState::Closing | WebRuntimeState::Stopped | WebRuntimeState::Failed
+            )
+        {
+            return Poll::Ready(None);
+        }
+
+        match this.inner.as_mut().poll_next(context) {
+            Poll::Ready(Some(Err(error))) => {
+                this.closed_after_error = true;
+                Poll::Ready(Some(Err(error)))
+            }
+            other => other,
+        }
+    }
+}
+
+fn rejected_command_response(
+    client_command_id: selvedge_local_protocol::LocalClientCommandId,
+    reason: CommandRejectReason,
+) -> CommandResponse {
+    CommandResponse {
+        protocol_version: current_protocol_version(),
+        client_command_id,
+        outcome: CommandOutcome::Rejected(reason),
+    }
+}
+
+fn bind_localhost(bind: &WebLocalhostBind) -> Result<TcpListener, WebStartError> {
+    let listener = match bind.host {
+        WebLocalhostHost::Ipv4Loopback => TcpListener::bind((Ipv4Addr::LOCALHOST, bind.port)),
+        WebLocalhostHost::Ipv6Loopback => TcpListener::bind((Ipv6Addr::LOCALHOST, bind.port)),
+    }
+    .map_err(|error| WebStartError::BindFailed(error.to_string()))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| WebStartError::BindFailed(error.to_string()))?;
+    Ok(listener)
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -271,7 +271,30 @@ impl Stream for WebBrowserFrameStream {
                 this.closed_after_error = true;
                 Poll::Ready(Some(Err(error)))
             }
-            other => other,
+            Poll::Ready(item) => Poll::Ready(item),
+            Poll::Pending => {
+                let state_changed = {
+                    let changed = this.state_rx.changed();
+                    tokio::pin!(changed);
+                    Future::poll(changed.as_mut(), context)
+                };
+                match state_changed {
+                    Poll::Ready(Ok(())) => {
+                        if matches!(
+                            *this.state_rx.borrow(),
+                            WebRuntimeState::Closing
+                                | WebRuntimeState::Stopped
+                                | WebRuntimeState::Failed
+                        ) {
+                            Poll::Ready(None)
+                        } else {
+                            Poll::Pending
+                        }
+                    }
+                    Poll::Ready(Err(_)) => Poll::Ready(None),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -8,9 +8,9 @@ use std::task::{Context, Poll};
 
 use futures_core::Stream;
 use selvedge_local_protocol::{
-    AttachAccepted, AttachRejected, AttachRequest, CommandOutcome, CommandRejectReason,
-    CommandRequest, CommandResponse, LocalClientFrame, ReadyRequest, ReadyResponse,
-    current_protocol_version, validate_attach_request, validate_command_request,
+    AttachAccepted, AttachRejectReason, AttachRejected, AttachRequest, CommandOutcome,
+    CommandRejectReason, CommandRequest, CommandResponse, LocalClientFrame, ReadyRequest,
+    ReadyResponse, current_protocol_version, validate_attach_request, validate_command_request,
 };
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -219,9 +219,9 @@ impl WebControl {
         let client_command_id = request.client_command_id.clone();
         if validate_attach_request(&request).is_err() {
             let reason = if request.protocol_version != current_protocol_version() {
-                CommandRejectReason::ProtocolVersionMismatch
+                AttachRejectReason::ProtocolVersionMismatch
             } else {
-                CommandRejectReason::MalformedRequest
+                AttachRejectReason::MalformedRequest
             };
             return Err(AttachRejectedOrBridgeError::Rejected(AttachRejected {
                 protocol_version,
@@ -236,14 +236,14 @@ impl WebControl {
                 Err(AttachRejectedOrBridgeError::Rejected(AttachRejected {
                     protocol_version,
                     client_command_id,
-                    reason: CommandRejectReason::ServerNotReady,
+                    reason: AttachRejectReason::ServerNotReady,
                 }))
             }
             Err(AttachRejectedOrBridgeError::Bridge(WebBridgeError::ProtocolValidationFailed)) => {
                 Err(AttachRejectedOrBridgeError::Rejected(AttachRejected {
                     protocol_version,
                     client_command_id,
-                    reason: CommandRejectReason::MalformedRequest,
+                    reason: AttachRejectReason::MalformedRequest,
                 }))
             }
             Err(error) => Err(error),

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -3,14 +3,13 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, Ordering};
 
 use futures_core::Stream;
 use selvedge_local_protocol::{
     AttachAccepted, AttachRejected, AttachRequest, CommandRequest, CommandResponse,
     LocalClientFrame, ReadyRequest, ReadyResponse,
 };
-use tokio::sync::Notify;
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 pub struct WebStartArgs {
@@ -41,8 +40,7 @@ pub struct WebControl {
 }
 
 struct WebControlInner {
-    state: AtomicU8,
-    stop_notify: Notify,
+    state_tx: watch::Sender<WebRuntimeState>,
 }
 
 pub type WebFrameStream =
@@ -105,26 +103,18 @@ pub fn spawn_web_surface(args: WebStartArgs) -> Result<WebHandle, WebStartError>
     }
 
     let _bridge = args.bridge;
+    let (state_tx, mut state_rx) = watch::channel(WebRuntimeState::Listening);
     let control = WebControl {
-        inner: Arc::new(WebControlInner {
-            state: AtomicU8::new(web_state_code(WebRuntimeState::Listening)),
-            stop_notify: Notify::new(),
-        }),
+        inner: Arc::new(WebControlInner { state_tx }),
     };
     let task_control = control.clone();
     let join_handle = tokio::spawn(async move {
-        loop {
-            if task_control.inner.state.load(Ordering::SeqCst)
-                == web_state_code(WebRuntimeState::Closing)
-            {
+        while state_rx.changed().await.is_ok() {
+            if *state_rx.borrow() == WebRuntimeState::Closing {
                 break;
             }
-            task_control.inner.stop_notify.notified().await;
         }
-        task_control
-            .inner
-            .state
-            .store(web_state_code(WebRuntimeState::Stopped), Ordering::SeqCst);
+        let _ = task_control.inner.state_tx.send(WebRuntimeState::Stopped);
         WebExitStatus::Stopped
     });
 
@@ -136,33 +126,10 @@ pub fn spawn_web_surface(args: WebStartArgs) -> Result<WebHandle, WebStartError>
 
 impl WebControl {
     pub async fn state(&self) -> WebRuntimeState {
-        web_state_from_code(self.inner.state.load(Ordering::SeqCst))
+        self.inner.state_tx.borrow().clone()
     }
 
     pub async fn stop(&self) {
-        self.inner
-            .state
-            .store(web_state_code(WebRuntimeState::Closing), Ordering::SeqCst);
-        self.inner.stop_notify.notify_waiters();
-    }
-}
-
-fn web_state_code(state: WebRuntimeState) -> u8 {
-    match state {
-        WebRuntimeState::Binding => 0,
-        WebRuntimeState::Listening => 1,
-        WebRuntimeState::Closing => 2,
-        WebRuntimeState::Stopped => 3,
-        WebRuntimeState::Failed => 4,
-    }
-}
-
-fn web_state_from_code(code: u8) -> WebRuntimeState {
-    match code {
-        0 => WebRuntimeState::Binding,
-        1 => WebRuntimeState::Listening,
-        2 => WebRuntimeState::Closing,
-        3 => WebRuntimeState::Stopped,
-        _ => WebRuntimeState::Failed,
+        let _ = self.inner.state_tx.send(WebRuntimeState::Closing);
     }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,0 +1,168 @@
+#![doc = include_str!("../README.md")]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use futures_core::Stream;
+use selvedge_local_protocol::{
+    AttachAccepted, AttachRejected, AttachRequest, CommandRequest, CommandResponse,
+    LocalClientFrame, ReadyRequest, ReadyResponse,
+};
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+pub struct WebStartArgs {
+    pub bind: WebLocalhostBind,
+    pub bridge: Arc<dyn WebBridge>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebLocalhostBind {
+    pub host: WebLocalhostHost,
+    pub port: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebLocalhostHost {
+    Ipv4Loopback,
+    Ipv6Loopback,
+}
+
+pub struct WebHandle {
+    pub control: WebControl,
+    pub join_handle: JoinHandle<WebExitStatus>,
+}
+
+#[derive(Clone)]
+pub struct WebControl {
+    inner: Arc<WebControlInner>,
+}
+
+struct WebControlInner {
+    state: AtomicU8,
+    stop_notify: Notify,
+}
+
+pub type WebFrameStream =
+    Pin<Box<dyn Stream<Item = Result<LocalClientFrame, WebBridgeError>> + Send>>;
+pub type WebBridgeFuture<T> = Pin<Box<dyn Future<Output = Result<T, WebBridgeError>> + Send>>;
+pub type WebAttachFuture = Pin<
+    Box<
+        dyn Future<Output = Result<(AttachAccepted, WebFrameStream), AttachRejectedOrBridgeError>>
+            + Send,
+    >,
+>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebRuntimeState {
+    Binding,
+    Listening,
+    Closing,
+    Stopped,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebExitStatus {
+    Stopped,
+    Fatal(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebStartError {
+    InvalidBindTarget,
+    BindFailed(String),
+    TokioSpawnFailed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebBridgeError {
+    ServerNotReady,
+    ProtocolValidationFailed,
+    CommandRejected(String),
+    AttachRejected(String),
+    StreamClosed,
+    InternalFailure(String),
+}
+
+pub trait WebBridge: Send + Sync + 'static {
+    fn ready(&self, request: ReadyRequest) -> WebBridgeFuture<ReadyResponse>;
+    fn submit_command(&self, request: CommandRequest) -> WebBridgeFuture<CommandResponse>;
+    fn attach(&self, request: AttachRequest) -> WebAttachFuture;
+}
+
+#[derive(Debug)]
+pub enum AttachRejectedOrBridgeError {
+    Rejected(AttachRejected),
+    Bridge(WebBridgeError),
+}
+
+pub fn spawn_web_surface(args: WebStartArgs) -> Result<WebHandle, WebStartError> {
+    if args.bind.port == 0 {
+        return Err(WebStartError::InvalidBindTarget);
+    }
+
+    let _bridge = args.bridge;
+    let control = WebControl {
+        inner: Arc::new(WebControlInner {
+            state: AtomicU8::new(web_state_code(WebRuntimeState::Listening)),
+            stop_notify: Notify::new(),
+        }),
+    };
+    let task_control = control.clone();
+    let join_handle = tokio::spawn(async move {
+        loop {
+            if task_control.inner.state.load(Ordering::SeqCst)
+                == web_state_code(WebRuntimeState::Closing)
+            {
+                break;
+            }
+            task_control.inner.stop_notify.notified().await;
+        }
+        task_control
+            .inner
+            .state
+            .store(web_state_code(WebRuntimeState::Stopped), Ordering::SeqCst);
+        WebExitStatus::Stopped
+    });
+
+    Ok(WebHandle {
+        control,
+        join_handle,
+    })
+}
+
+impl WebControl {
+    pub async fn state(&self) -> WebRuntimeState {
+        web_state_from_code(self.inner.state.load(Ordering::SeqCst))
+    }
+
+    pub async fn stop(&self) {
+        self.inner
+            .state
+            .store(web_state_code(WebRuntimeState::Closing), Ordering::SeqCst);
+        self.inner.stop_notify.notify_waiters();
+    }
+}
+
+fn web_state_code(state: WebRuntimeState) -> u8 {
+    match state {
+        WebRuntimeState::Binding => 0,
+        WebRuntimeState::Listening => 1,
+        WebRuntimeState::Closing => 2,
+        WebRuntimeState::Stopped => 3,
+        WebRuntimeState::Failed => 4,
+    }
+}
+
+fn web_state_from_code(code: u8) -> WebRuntimeState {
+    match code {
+        0 => WebRuntimeState::Binding,
+        1 => WebRuntimeState::Listening,
+        2 => WebRuntimeState::Closing,
+        3 => WebRuntimeState::Stopped,
+        _ => WebRuntimeState::Failed,
+    }
+}

--- a/crates/web/tests/web_contract.rs
+++ b/crates/web/tests/web_contract.rs
@@ -1,21 +1,28 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use futures_util::StreamExt;
+use futures_util::stream;
 use selvedge_local_protocol::{
-    AttachRequest, CommandOutcome, CommandRequest, CommandResponse, LocalClientCommandId,
-    LocalClientId, LocalClientSubscription, LocalDetailLevel, LocalTaskScope, ReadyRequest,
-    ReadyResponse, ReadyState, current_protocol_version,
+    AttachAccepted, AttachRequest, CommandOutcome, CommandRejectReason, CommandRequest,
+    CommandResponse, LocalClientCommandId, LocalClientEvent, LocalClientEventFrame,
+    LocalClientFrame, LocalClientId, LocalClientSnapshot, LocalClientSnapshotFrame,
+    LocalClientSubscription, LocalDetailLevel, LocalTaskScope, ReadyRequest, ReadyResponse,
+    ReadyState, current_protocol_version,
 };
 use selvedge_web::{
-    AttachRejectedOrBridgeError, WebAttachFuture, WebBridge, WebBridgeFuture, WebExitStatus,
-    WebLocalhostBind, WebLocalhostHost, WebRuntimeState, WebStartArgs, WebStartError,
-    spawn_web_surface,
+    AttachRejectedOrBridgeError, WebAttachFuture, WebBridge, WebBridgeError, WebBridgeFuture,
+    WebExitStatus, WebFrameStream, WebLocalhostBind, WebLocalhostHost, WebRuntimeState,
+    WebStartArgs, WebStartError, spawn_web_surface,
 };
+use tokio::time::{Duration, timeout};
 
 #[tokio::test]
 async fn spawn_web_surface_exposes_control_handle_and_stop_status() {
+    let bridge = Arc::new(RecordingBridge::default());
     let handle = spawn_web_surface(WebStartArgs {
-        bind: loopback_bind(),
-        bridge: Arc::new(StaticBridge),
+        bind: unused_loopback_bind(),
+        bridge,
     })
     .expect("valid web start args");
 
@@ -42,6 +49,22 @@ fn spawn_web_surface_rejects_zero_port() {
     assert!(matches!(result, Err(WebStartError::InvalidBindTarget)));
 }
 
+#[tokio::test]
+async fn spawn_web_surface_reports_bind_failure() {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind held port");
+    let port = listener.local_addr().expect("held addr").port();
+
+    let result = spawn_web_surface(WebStartArgs {
+        bind: WebLocalhostBind {
+            host: WebLocalhostHost::Ipv4Loopback,
+            port,
+        },
+        bridge: Arc::new(StaticBridge),
+    });
+
+    assert!(matches!(result, Err(WebStartError::BindFailed(_))));
+}
+
 #[test]
 fn web_bridge_trait_exposes_ready_command_and_attach_futures() {
     let bridge = StaticBridge;
@@ -52,6 +75,180 @@ fn web_bridge_trait_exposes_ready_command_and_attach_futures() {
     let attach: WebAttachFuture = bridge.attach(valid_attach_request());
 
     drop((ready, command, attach));
+}
+
+#[tokio::test]
+async fn page_request_returns_static_page_without_bridge_call() {
+    let bridge = Arc::new(RecordingBridge::default());
+    let handle = spawn_web_surface(WebStartArgs {
+        bind: unused_loopback_bind(),
+        bridge: bridge.clone(),
+    })
+    .expect("valid web start args");
+
+    let page = handle.control.page().await.expect("page response");
+
+    assert_eq!(page.content_type, "text/html; charset=utf-8");
+    assert!(page.body.contains("Selvedge"));
+    assert_eq!(bridge.page_observable_call_count(), 0);
+    handle.control.stop().await;
+    assert_eq!(
+        handle.join_handle.await.expect("join web task"),
+        WebExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn invalid_command_request_returns_rejection_without_bridge_call() {
+    let bridge = Arc::new(RecordingBridge::default());
+    let handle = spawn_web_surface(WebStartArgs {
+        bind: unused_loopback_bind(),
+        bridge: bridge.clone(),
+    })
+    .expect("valid web start args");
+
+    let response = handle
+        .control
+        .submit_command(CommandRequest {
+            command_name: " ".to_owned(),
+            ..valid_command_request()
+        })
+        .await
+        .expect("command response");
+
+    assert_eq!(
+        response.outcome,
+        CommandOutcome::Rejected(CommandRejectReason::MalformedRequest)
+    );
+    assert_eq!(bridge.command_call_count(), 0);
+    handle.control.stop().await;
+    assert_eq!(
+        handle.join_handle.await.expect("join web task"),
+        WebExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn command_request_returns_bridge_response() {
+    let bridge = Arc::new(RecordingBridge::default());
+    bridge.push_command_response(Ok(CommandResponse {
+        protocol_version: current_protocol_version(),
+        client_command_id: LocalClientCommandId::new("command-1").expect("command id"),
+        outcome: CommandOutcome::Rejected(CommandRejectReason::UnsupportedCommand),
+    }));
+    let handle = spawn_web_surface(WebStartArgs {
+        bind: unused_loopback_bind(),
+        bridge: bridge.clone(),
+    })
+    .expect("valid web start args");
+
+    let response = handle
+        .control
+        .submit_command(valid_command_request())
+        .await
+        .expect("command response");
+
+    assert_eq!(
+        response.outcome,
+        CommandOutcome::Rejected(CommandRejectReason::UnsupportedCommand)
+    );
+    assert_eq!(bridge.command_call_count(), 1);
+    handle.control.stop().await;
+    assert_eq!(
+        handle.join_handle.await.expect("join web task"),
+        WebExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn attach_request_forwards_bridge_frames_in_order() {
+    let bridge = Arc::new(RecordingBridge::default());
+    bridge.push_attach_response(Ok((
+        AttachAccepted {
+            protocol_version: current_protocol_version(),
+            client_id: LocalClientId::new("client-1").expect("client id"),
+            client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+        },
+        Box::pin(stream::iter(vec![
+            Ok(LocalClientFrame::Snapshot(LocalClientSnapshotFrame {
+                delivery_seq: 1,
+                client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+                snapshot: empty_snapshot(),
+            })),
+            Ok(LocalClientFrame::Event(LocalClientEventFrame {
+                delivery_seq: 2,
+                event: LocalClientEvent::DebugNotice(
+                    selvedge_local_protocol::LocalDebugNoticeEvent {
+                        task_id: None,
+                        message_text: "ready".to_owned(),
+                    },
+                ),
+            })),
+        ])),
+    )));
+    let handle = spawn_web_surface(WebStartArgs {
+        bind: unused_loopback_bind(),
+        bridge: bridge.clone(),
+    })
+    .expect("valid web start args");
+
+    let (_accepted, mut frames) = handle
+        .control
+        .attach(valid_attach_request())
+        .await
+        .expect("attach accepted");
+
+    assert!(matches!(
+        frames.next().await,
+        Some(Ok(LocalClientFrame::Snapshot(_)))
+    ));
+    assert!(matches!(
+        frames.next().await,
+        Some(Ok(LocalClientFrame::Event(_)))
+    ));
+    assert!(frames.next().await.is_none());
+    assert_eq!(bridge.attach_call_count(), 1);
+    handle.control.stop().await;
+    assert_eq!(
+        handle.join_handle.await.expect("join web task"),
+        WebExitStatus::Stopped
+    );
+}
+
+#[tokio::test]
+async fn stop_closes_active_attach_stream() {
+    let bridge = Arc::new(RecordingBridge::default());
+    bridge.push_attach_response(Ok((
+        AttachAccepted {
+            protocol_version: current_protocol_version(),
+            client_id: LocalClientId::new("client-1").expect("client id"),
+            client_command_id: LocalClientCommandId::new("attach-1").expect("command id"),
+        },
+        Box::pin(stream::pending()),
+    )));
+    let handle = spawn_web_surface(WebStartArgs {
+        bind: unused_loopback_bind(),
+        bridge,
+    })
+    .expect("valid web start args");
+    let (_accepted, mut frames) = handle
+        .control
+        .attach(valid_attach_request())
+        .await
+        .expect("attach accepted");
+
+    handle.control.stop().await;
+
+    assert!(
+        timeout(Duration::from_secs(1), frames.next())
+            .await
+            .expect("stream close timeout")
+            .is_none()
+    );
+    assert_eq!(
+        handle.join_handle.await.expect("join web task"),
+        WebExitStatus::Stopped
+    );
 }
 
 struct StaticBridge;
@@ -85,10 +282,107 @@ impl WebBridge for StaticBridge {
     }
 }
 
-fn loopback_bind() -> WebLocalhostBind {
+#[derive(Default)]
+struct RecordingBridge {
+    command_responses: std::sync::Mutex<Vec<Result<CommandResponse, WebBridgeError>>>,
+    attach_responses: std::sync::Mutex<
+        Vec<Result<(AttachAccepted, WebFrameStream), AttachRejectedOrBridgeError>>,
+    >,
+    command_calls: AtomicUsize,
+    attach_calls: AtomicUsize,
+}
+
+impl RecordingBridge {
+    fn push_command_response(&self, response: Result<CommandResponse, WebBridgeError>) {
+        self.command_responses
+            .lock()
+            .expect("command responses")
+            .push(response);
+    }
+
+    fn push_attach_response(
+        &self,
+        response: Result<(AttachAccepted, WebFrameStream), AttachRejectedOrBridgeError>,
+    ) {
+        self.attach_responses
+            .lock()
+            .expect("attach responses")
+            .push(response);
+    }
+
+    fn page_observable_call_count(&self) -> usize {
+        self.command_call_count() + self.attach_call_count()
+    }
+
+    fn command_call_count(&self) -> usize {
+        self.command_calls.load(Ordering::SeqCst)
+    }
+
+    fn attach_call_count(&self) -> usize {
+        self.attach_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl WebBridge for RecordingBridge {
+    fn ready(&self, _request: ReadyRequest) -> WebBridgeFuture<ReadyResponse> {
+        Box::pin(async {
+            Ok(ReadyResponse {
+                protocol_version: current_protocol_version(),
+                state: ReadyState::Ready,
+            })
+        })
+    }
+
+    fn submit_command(&self, request: CommandRequest) -> WebBridgeFuture<CommandResponse> {
+        self.command_calls.fetch_add(1, Ordering::SeqCst);
+        let response = self
+            .command_responses
+            .lock()
+            .expect("command responses")
+            .pop();
+        Box::pin(async move {
+            match response {
+                Some(response) => response,
+                None => Ok(CommandResponse {
+                    protocol_version: current_protocol_version(),
+                    client_command_id: request.client_command_id,
+                    outcome: CommandOutcome::Accepted,
+                }),
+            }
+        })
+    }
+
+    fn attach(&self, request: AttachRequest) -> WebAttachFuture {
+        self.attach_calls.fetch_add(1, Ordering::SeqCst);
+        let response = self
+            .attach_responses
+            .lock()
+            .expect("attach responses")
+            .pop();
+        Box::pin(async move {
+            match response {
+                Some(response) => response,
+                None => Ok((
+                    AttachAccepted {
+                        protocol_version: current_protocol_version(),
+                        client_id: request.client_id,
+                        client_command_id: request.client_command_id,
+                    },
+                    Box::pin(stream::empty()) as WebFrameStream,
+                )),
+            }
+        })
+    }
+}
+
+fn unused_loopback_bind() -> WebLocalhostBind {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind unused port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+
     WebLocalhostBind {
         host: WebLocalhostHost::Ipv4Loopback,
-        port: 4173,
+        port,
     }
 }
 
@@ -99,6 +393,16 @@ fn valid_command_request() -> CommandRequest {
         client_command_id: LocalClientCommandId::new("command-1").expect("valid command id"),
         command_name: "send-user-input".to_owned(),
         payload: serde_json::json!({ "message": "hello" }),
+    }
+}
+
+fn empty_snapshot() -> LocalClientSnapshot {
+    LocalClientSnapshot {
+        generated_at: 1,
+        tasks: Vec::new(),
+        task_parent_edges: Vec::new(),
+        history_nodes: Vec::new(),
+        task_versions: Vec::new(),
     }
 }
 

--- a/crates/web/tests/web_contract.rs
+++ b/crates/web/tests/web_contract.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use selvedge_local_protocol::{
+    AttachRequest, CommandOutcome, CommandRequest, CommandResponse, LocalClientCommandId,
+    LocalClientId, LocalClientSubscription, LocalDetailLevel, LocalTaskScope, ReadyRequest,
+    ReadyResponse, ReadyState, current_protocol_version,
+};
+use selvedge_web::{
+    AttachRejectedOrBridgeError, WebAttachFuture, WebBridge, WebBridgeFuture, WebExitStatus,
+    WebLocalhostBind, WebLocalhostHost, WebRuntimeState, WebStartArgs, WebStartError,
+    spawn_web_surface,
+};
+
+#[tokio::test]
+async fn spawn_web_surface_exposes_control_handle_and_stop_status() {
+    let handle = spawn_web_surface(WebStartArgs {
+        bind: loopback_bind(),
+        bridge: Arc::new(StaticBridge),
+    })
+    .expect("valid web start args");
+
+    assert_eq!(handle.control.state().await, WebRuntimeState::Listening);
+
+    handle.control.stop().await;
+
+    assert_eq!(
+        handle.join_handle.await.expect("join web task"),
+        WebExitStatus::Stopped
+    );
+}
+
+#[test]
+fn spawn_web_surface_rejects_zero_port() {
+    let result = spawn_web_surface(WebStartArgs {
+        bind: WebLocalhostBind {
+            host: WebLocalhostHost::Ipv4Loopback,
+            port: 0,
+        },
+        bridge: Arc::new(StaticBridge),
+    });
+
+    assert!(matches!(result, Err(WebStartError::InvalidBindTarget)));
+}
+
+#[test]
+fn web_bridge_trait_exposes_ready_command_and_attach_futures() {
+    let bridge = StaticBridge;
+    let ready: WebBridgeFuture<ReadyResponse> = bridge.ready(ReadyRequest {
+        protocol_version: current_protocol_version(),
+    });
+    let command: WebBridgeFuture<CommandResponse> = bridge.submit_command(valid_command_request());
+    let attach: WebAttachFuture = bridge.attach(valid_attach_request());
+
+    drop((ready, command, attach));
+}
+
+struct StaticBridge;
+
+impl WebBridge for StaticBridge {
+    fn ready(&self, _request: ReadyRequest) -> WebBridgeFuture<ReadyResponse> {
+        Box::pin(async {
+            Ok(ReadyResponse {
+                protocol_version: current_protocol_version(),
+                state: ReadyState::Ready,
+            })
+        })
+    }
+
+    fn submit_command(&self, request: CommandRequest) -> WebBridgeFuture<CommandResponse> {
+        Box::pin(async move {
+            Ok(CommandResponse {
+                protocol_version: current_protocol_version(),
+                client_command_id: request.client_command_id,
+                outcome: CommandOutcome::Accepted,
+            })
+        })
+    }
+
+    fn attach(&self, _request: AttachRequest) -> WebAttachFuture {
+        Box::pin(async {
+            Err(AttachRejectedOrBridgeError::Bridge(
+                selvedge_web::WebBridgeError::ServerNotReady,
+            ))
+        })
+    }
+}
+
+fn loopback_bind() -> WebLocalhostBind {
+    WebLocalhostBind {
+        host: WebLocalhostHost::Ipv4Loopback,
+        port: 4173,
+    }
+}
+
+fn valid_command_request() -> CommandRequest {
+    CommandRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_command_id: LocalClientCommandId::new("command-1").expect("valid command id"),
+        command_name: "send-user-input".to_owned(),
+        payload: serde_json::json!({ "message": "hello" }),
+    }
+}
+
+fn valid_attach_request() -> AttachRequest {
+    AttachRequest {
+        protocol_version: current_protocol_version(),
+        client_id: LocalClientId::new("client-1").expect("valid client id"),
+        client_command_id: LocalClientCommandId::new("attach-1").expect("valid command id"),
+        subscription: LocalClientSubscription {
+            task_scope: LocalTaskScope::AllTasks,
+            detail_level: LocalDetailLevel::Summary,
+            include_model_call_status: false,
+            include_tool_execution_status: false,
+            include_debug_notices: false,
+        },
+    }
+}

--- a/crates/web/tests/web_contract.rs
+++ b/crates/web/tests/web_contract.rs
@@ -237,14 +237,16 @@ async fn stop_closes_active_attach_stream() {
         .await
         .expect("attach accepted");
 
-    handle.control.stop().await;
-
-    assert!(
+    let next_frame = tokio::spawn(async move {
         timeout(Duration::from_secs(1), frames.next())
             .await
             .expect("stream close timeout")
-            .is_none()
-    );
+    });
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    handle.control.stop().await;
+
+    assert!(next_frame.await.expect("join next frame").is_none());
     assert_eq!(
         handle.join_handle.await.expect("join web task"),
         WebExitStatus::Stopped


### PR DESCRIPTION
## What changed

This PR integrates the local Selvedge runtime stack from `integration` into `main`.

Major pieces included:

- Adds the localhost protocol model used by server, local client, TUI, and web surfaces.
- Adds the process-local server lifecycle, singleton locking, config/logging/db startup, localhost bind validation, command routing, attach admission, and web surface startup.
- Adds client synchronization for attach hydration snapshots, replacement, cancellation, stale result filtering, and delivery failure cleanup.
- Adds the local transport client state machine and attach stream lifecycle handling.
- Adds systemd unit control support.
- Adds TUI startup/attach/command flow contracts.
- Adds web bridge request handling and attach stream bridging.
- Extends router, events, command-model, and protocol contracts to support attach admission, client registry reservations, reject reasons, detach reasons, and attach cleanup semantics.
- Updates repo scaffolding and module docs for the new crates.

## Why

The project now has the local control plane needed for a single process-local server, localhost clients, UI surfaces, attach streams, and hydrated client-facing state. The final attach admission work hardens the acceptance boundary so accepted attach streams have router/events/client-sync/server state established, and rejected or cancelled attaches do not leave stale reservations behind.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `codex-review-final integration`

## Branch state

- Head branch: `integration`
- Base branch: `main`
- `integration` has been rebased onto current `origin/main`.
